### PR TITLE
[ADD] add a new module to allow planner changing the supply method on procurement order level

### DIFF
--- a/procurement_supply_method/README.rst
+++ b/procurement_supply_method/README.rst
@@ -1,33 +1,3 @@
-# -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2010-2015 Elico Corp (<http://www.elico-corp.com>)
-#    Alex Duan <alex.duan@elico-corp.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
-{
-    'name': 'Procurement Improvement - supply method',
-    'version': '1.0',
-    'author': 'Elico Corp, Odoo Community Association (OCA)',
-    'website': 'www.openerp.net.cn',
-    'category': 'Generic Modules/Production',
-    'depends': ['procurement', 'sale', 'mrp', 'purchase'],
-    'description': """
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
     :alt: License
 
@@ -98,11 +68,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization
     whose mission is to support the collaborative development of Odoo features
         and promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
-    """,
-    'data': [
-        'procurement_supply_method_views.xml',
-    ],
-    'installable': True,
-}
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
+To contribute to this module, please visit http://odoo-community.org. 

--- a/procurement_supply_method/__init__.py
+++ b/procurement_supply_method/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2010-2015 Elico Corp (<http://www.elico-corp.com>)
+#    Alex Duan <alex.duan@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import procurement

--- a/procurement_supply_method/__openerp__.py
+++ b/procurement_supply_method/__openerp__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2010-2015 Elico Corp (<http://www.elico-corp.com>)
+#    Alex Duan <alex.duan@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Procurement Improvement - supply method',
+    'version': '1.0',
+    'author': 'Elico Corp',
+    'website': 'www.openerp.net.cn',
+    'category': 'Generic Modules/Production',
+    'depends': ['procurement', 'sale', 'mrp', 'purchase'],
+    'description': """
+This module aims to add more flexibility on procurement management.
+    - Allowing planner changing the supply method on the procurement order level by
+        adding a new field supply_method for planner to confirm.
+    - Allowing planner changing the procurement method and supply method
+        before the procurement order is running.
+======
+Note:
+======
+This module redefine the field: procure_method which is defined in moudle: procurement
+    """,
+    'data': [
+        'procurement_supply_method_views.xml',
+    ],
+    'installable': True,
+}
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/procurement_supply_method/__openerp__.py
+++ b/procurement_supply_method/__openerp__.py
@@ -23,20 +23,83 @@
 {
     'name': 'Procurement Improvement - supply method',
     'version': '1.0',
-    'author': 'Elico Corp',
+    'author': 'Elico Corp, Odoo Community Association (OCA)',
     'website': 'www.openerp.net.cn',
     'category': 'Generic Modules/Production',
     'depends': ['procurement', 'sale', 'mrp', 'purchase'],
     'description': """
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+Module Description
+==================
+Procurement Improvement - supply method
+
 This module aims to add more flexibility on procurement management.
-    - Allowing planner changing the supply method on the procurement order level by
-        adding a new field supply_method for planner to confirm.
-    - Allowing planner changing the procurement method and supply method
+  * Allowing planner changing the supply method on the procurement order level by
+        adding a new field supply_method for planner to modify.
+
+  * Allowing planner changing the procurement method and supply method
         before the procurement order is running.
-======
-Note:
-======
-This module redefine the field: procure_method which is defined in moudle: procurement
+
+Business case:
+    One company might purchase from one company or produce in another company
+        for the same product, the planner can change the supply method
+        on the procurement order level instead of having two products with different
+        supply methods.
+
+Please note that this module re-define the field: procure_method
+    which is defined in module: procurement.
+
+Installation
+============
+
+To install this module, you need to:
+
+ * have basic modules installed (sale, mrp, procurement, purchase)
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+ * No specific configuration needed.
+
+Usage
+=====
+
+
+For further information, please visit:
+
+ * https://www.odoo.com/forum/help-1
+
+Known issues / Roadmap
+======================
+
+
+Credits
+=======
+
+
+Contributors
+------------
+
+* Alex Duan <alex.duan@elico-corp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization
+    whose mission is to support the collaborative development of Odoo features
+        and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
     """,
     'data': [
         'procurement_supply_method_views.xml',

--- a/procurement_supply_method/mrp.py
+++ b/procurement_supply_method/mrp.py
@@ -28,6 +28,7 @@ class MrpProduction(orm.Model):
     def _hook_create_post_procurement(
             self, cr, uid, production, procurement_id, context=None):
         '''write back the supply_method to the procurement order'''
+
         if procurement_id:
             procurement_obj = self.pool.get('procurement.order')
             procurement_order = procurement_obj.browse(
@@ -35,6 +36,7 @@ class MrpProduction(orm.Model):
             product_id = procurement_order.product_id
             if not procurement_order.supply_method:
                 supply_method = product_id.supply_method
-                procurement_order.write({'supply_method': supply_method}, context=context)
+                procurement_order.write(
+                    {'supply_method': supply_method}, context=context)
         return super(MrpProduction, self)._hook_create_post_procurement(
             cr, uid, production, procurement_id, context=context)

--- a/procurement_supply_method/mrp.py
+++ b/procurement_supply_method/mrp.py
@@ -19,6 +19,22 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import procurement
-from . import mrp
-from . import sale
+from openerp.osv import orm
+
+
+class MrpProduction(orm.Model):
+    _inherit = 'mrp.production'
+
+    def _hook_create_post_procurement(
+            self, cr, uid, production, procurement_id, context=None):
+        '''write back the supply_method to the procurement order'''
+        if procurement_id:
+            procurement_obj = self.pool.get('procurement.order')
+            procurement_order = procurement_obj.browse(
+                cr, uid, procurement_id, context=context)
+            product_id = procurement_order.product_id
+            if not procurement_order.supply_method:
+                supply_method = product_id.supply_method
+                procurement_order.write({'supply_method': supply_method}, context=context)
+        return super(MrpProduction, self)._hook_create_post_procurement(
+            cr, uid, production, procurement_id, context=context)

--- a/procurement_supply_method/procurement.py
+++ b/procurement_supply_method/procurement.py
@@ -22,8 +22,6 @@
 
 from osv import osv, fields
 
-from tools.translate import _
-
 
 class ProcurementOrder(osv.osv):
     """
@@ -32,33 +30,40 @@ class ProcurementOrder(osv.osv):
     _inherit = "procurement.order"
     _columns = {
         'supply_method': fields.selection(
-            [('produce', _('Produce')), ('buy', _('Buy'))],
+            [('produce', 'Produce'), ('buy', 'Buy')],
             'Supply method',
             states={'draft': [('readonly', False)],
-                    'confirmed': [('readonly', False)], 'exception': [('readonly', False)]},
+                    'confirmed': [('readonly', False)],
+                    'exception': [('readonly', False)]},
             readonly=True),
 
-        # make this field editable when in state draft, confirmed and exception.
+        # make this field editable when in state draft,confirmed and exception.
         'procure_method': fields.selection(
-            [('make_to_stock', _('Make to Stock')), ('make_to_order', _('Make to Order'))],
-            _('Procurement Method'),
+            [('make_to_stock', 'Make to Stock'),
+             ('make_to_order', 'Make to Order')],
+            'Procurement Method',
             states={'draft': [('readonly', False)],
-                    'confirmed': [('readonly', False)], 'exception': [('readonly', False)]},
+                    'confirmed': [('readonly', False)],
+                    'exception': [('readonly', False)]},
             readonly=True, required=True,
-            help="If you encode manually a Procurement, you probably want to use"
-            " a make to order method."),
+            help="If you encode manually a Procurement,"
+            " you probably want to use a make to order method."),
 
     }
 
     def init(self, cr):
-        '''initializes the supply_method field for existing data when this module is first installed.
+        '''initializes the supply_method field for existing data
+        when this module is first installed.
 
-        NOTE: this method will be executed when this module is installed or upgraded.'''
+        NOTE: this method will be executed
+            when this module is installed or upgraded.'''
 
-        cr.execute('update procurement_order set supply_method = pt.supply_method '
+        cr.execute('update procurement_order '
+                   'set supply_method = pt.supply_method '
                    'from product_product pp, product_template pt '
                    'where procurement_order.supply_method is null '
-                   'and procurement_order.product_id = pp.id and pp.product_tmpl_id = pt.id')
+                   'and procurement_order.product_id = pp.id '
+                   'and pp.product_tmpl_id = pt.id')
 
     def check_produce(self, cr, uid, ids, context=None):
         """ Checks product supply method.
@@ -72,9 +77,11 @@ class ProcurementOrder(osv.osv):
                 if supply_method != 'produce':
                     return False
                 elif supply_method == 'service':
-                    res = self.check_produce_service(cr, uid, procurement, context)
+                    res = self.check_produce_service(
+                        cr, uid, procurement, context)
                 else:
-                    res = self.check_produce_product(cr, uid, procurement, context)
+                    res = self.check_produce_product(
+                        cr, uid, procurement, context)
                 if not res:
                     return False
                 return True

--- a/procurement_supply_method/procurement.py
+++ b/procurement_supply_method/procurement.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2010-2015 Elico Corp (<http://www.elico-corp.com>)
+#    Alex Duan <alex.duan@elico-corp.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from osv import osv, fields
+
+from tools.translate import _
+
+
+class ProcurementOrder(osv.osv):
+    """
+    Procurement Orders
+    """
+    _inherit = "procurement.order"
+    _columns = {
+        'supply_method': fields.selection(
+            [('produce', _('Produce')), ('buy', _('Buy'))],
+            'Supply method',
+            states={'draft': [('readonly', False)],
+                    'confirmed': [('readonly', False)], 'exception': [('readonly', False)]},
+            readonly=True),
+
+        # make this field editable when in state draft, confirmed and exception.
+        'procure_method': fields.selection(
+            [('make_to_stock', _('Make to Stock')), ('make_to_order', _('Make to Order'))],
+            _('Procurement Method'),
+            states={'draft': [('readonly', False)],
+                    'confirmed': [('readonly', False)], 'exception': [('readonly', False)]},
+            readonly=True, required=True,
+            help="If you encode manually a Procurement, you probably want to use"
+            " a make to order method."),
+
+    }
+
+    def init(self, cr):
+        '''initializes the supply_method field for existing data when this module is first installed.
+
+        NOTE: this method will be executed when this module is installed or upgraded.'''
+
+        cr.execute('update procurement_order set supply_method = pt.supply_method '
+                   'from product_product pp, product_template pt '
+                   'where procurement_order.supply_method is null '
+                   'and procurement_order.product_id = pp.id and pp.product_tmpl_id = pt.id')
+
+    def check_produce(self, cr, uid, ids, context=None):
+        """ Checks product supply method.
+
+        Checking the supply_method on the procurement order first.
+        @return: True or Product Id.
+        """
+        for procurement in self.browse(cr, uid, ids, context=context):
+            supply_method = procurement.supply_method
+            if supply_method:
+                if supply_method != 'produce':
+                    return False
+                elif supply_method == 'service':
+                    res = self.check_produce_service(cr, uid, procurement, context)
+                else:
+                    res = self.check_produce_product(cr, uid, procurement, context)
+                if not res:
+                    return False
+                return True
+            else:
+                return super(ProcurementOrder, self).check_produce(
+                    cr, uid, ids, context=context)
+
+    def check_buy(self, cr, uid, ids, context=None):
+        """ Checks supply method.
+
+        Checking the supply_method on the procurement order first.
+        @return: True or Product Id.
+        """
+        for procurement in self.browse(cr, uid, ids, context=context):
+            supply_method = procurement.supply_method
+            if supply_method:
+                if supply_method != 'buy':
+                    return False
+                else:
+                    return True
+            else:
+                return super(ProcurementOrder, self).check_buy(
+                    cr, uid, ids, context=context)
+
+
+class SaleOrder(osv.osv):
+    _inherit = 'sale.order'
+
+    def action_ship_create(self, cr, uid, ids, context=None):
+        '''after creating procurement order for the sale order,
+        we assign the supply method'''
+        if super(SaleOrder, self).action_ship_create(cr, uid, ids, context=context):
+            proc_obj = self.pool.get('procurement.order')
+            for order in self.browse(cr, uid, ids, context={}):
+                for line in order.order_line:
+                    if line.procurement_id and line.product_id:
+                        proc_obj.write(
+                            cr, uid,
+                            [line.procurement_id.id],
+                            {'supply_method': line.product_id.supply_method})
+        return True
+
+
+class MrpProduction(osv.osv):
+    _inherit = 'mrp.production'
+
+    def _hook_create_post_procurement(
+            self, cr, uid, production, procurement_id, context=None):
+        '''write back the supply_method to the procurement order'''
+        if procurement_id:
+            procurement_obj = self.pool.get('procurement.order')
+            procurement_order = procurement_obj.browse(
+                cr, uid, procurement_id, context=context)
+            product_id = procurement_order.product_id
+            if not procurement_order.supply_method:
+                supply_method = product_id.supply_method
+                procurement_order.write({'supply_method': supply_method}, context=context)
+        return super(self._name, self)._hook_create_post_procurement(
+            cr, uid, production, procurement_id, context=context)
+
+# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/procurement_supply_method/procurement.py
+++ b/procurement_supply_method/procurement.py
@@ -99,40 +99,4 @@ class ProcurementOrder(osv.osv):
                 return super(ProcurementOrder, self).check_buy(
                     cr, uid, ids, context=context)
 
-
-class SaleOrder(osv.osv):
-    _inherit = 'sale.order'
-
-    def action_ship_create(self, cr, uid, ids, context=None):
-        '''after creating procurement order for the sale order,
-        we assign the supply method'''
-        if super(SaleOrder, self).action_ship_create(cr, uid, ids, context=context):
-            proc_obj = self.pool.get('procurement.order')
-            for order in self.browse(cr, uid, ids, context={}):
-                for line in order.order_line:
-                    if line.procurement_id and line.product_id:
-                        proc_obj.write(
-                            cr, uid,
-                            [line.procurement_id.id],
-                            {'supply_method': line.product_id.supply_method})
-        return True
-
-
-class MrpProduction(osv.osv):
-    _inherit = 'mrp.production'
-
-    def _hook_create_post_procurement(
-            self, cr, uid, production, procurement_id, context=None):
-        '''write back the supply_method to the procurement order'''
-        if procurement_id:
-            procurement_obj = self.pool.get('procurement.order')
-            procurement_order = procurement_obj.browse(
-                cr, uid, procurement_id, context=context)
-            product_id = procurement_order.product_id
-            if not procurement_order.supply_method:
-                supply_method = product_id.supply_method
-                procurement_order.write({'supply_method': supply_method}, context=context)
-        return super(self._name, self)._hook_create_post_procurement(
-            cr, uid, production, procurement_id, context=context)
-
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/procurement_supply_method/procurement_supply_method_views.xml
+++ b/procurement_supply_method/procurement_supply_method_views.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="procurement_tree_view_supplymethod">
+            <field name="name">procurement_tree_view_supplymethod</field>
+            <field name="model">procurement.order</field>
+            <field name="inherit_id" ref="procurement.procurement_tree_view"/>
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                <field name="procure_method" position="after">
+                    <field name="supply_method" />
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="procurement_form_view_supplymethod">
+            <field name="name">procurement_form_view.supplymethod</field>
+            <field name="model">procurement.order</field>
+            <field name="inherit_id" ref="procurement.procurement_form_view"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <field name='procure_method' position="after">
+                     <field name="supply_method"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/procurement_supply_method/sale.py
+++ b/procurement_supply_method/sale.py
@@ -28,7 +28,8 @@ class SaleOrder(orm.Model):
     def action_ship_create(self, cr, uid, ids, context=None):
         '''after creating procurement order for the sale order,
         we assign the supply method'''
-        if super(SaleOrder, self).action_ship_create(cr, uid, ids, context=context):
+        if super(SaleOrder, self).action_ship_create(
+                cr, uid, ids, context=context):
             proc_obj = self.pool.get('procurement.order')
             for order in self.browse(cr, uid, ids, context={}):
                 for line in order.order_line:


### PR DESCRIPTION
[ADD] add a new module to allow planner changing the supply method on procurement order level
 Changes to be committed:

```
new file:   procurement_supply_method/__init__.py
new file:   procurement_supply_method/__openerp__.py
new file:   procurement_supply_method/procurement.py
new file:   procurement_supply_method/procurement_supply_method_views.xml
```
