### PR TITLE
[FIX] mrp_operations_project - fix operators time in WO

### DIFF
--- a/mrp_operations_project/views/mrp_production_view.xml
+++ b/mrp_operations_project/views/mrp_production_view.xml
@@ -12,6 +12,7 @@
                            on_change="onchange_task_id(task_id)"
                     />
                     <field name="user_id"/>
+                    <field name="name"/>
                     <field name="date"/>
                     <field name="hours" widget="float_time"/>
                     <button name="button_end_work"
@@ -32,7 +33,7 @@
                 <page string="Information" position="after">
                     <page string="Operators time">
                         <field name="task_m2m" invisible="1"/>
-                        <field name="work_ids" context="{'name_show_user': True, 'tree_view_ref': 'mrp_project.project_task_work_mrp'}"/>
+                        <field name="work_ids" context="{'name_show_user': True, 'tree_view_ref': 'mrp_operations_project.project_task_work_mrp'}"/>
                     </page>
                 </page>
             </field>
@@ -46,7 +47,7 @@
                 <xpath expr="//field[@name='workcenter_lines']/form//page[@string='Information']" position="after">
                     <page string="Operators time">
                         <field name="task_m2m" invisible="1"/>
-                        <field name="work_ids" context="{'name_show_user': True, 'tree_view_ref': 'mrp_project.project_task_work_mrp'}"/>
+                        <field name="work_ids" context="{'name_show_user': True, 'tree_view_ref': 'mrp_operations_project.project_task_work_mrp'}"/>
                     </page>
                 </xpath>
             </field>


### PR DESCRIPTION
I believe "project_task_work_mrp" view is defined in "mrp_operations_project" and not in "mrp_project". 

Also we need to add the "name" (Work Summary) in "project_task_work_mrp" view, otherwise we get a KeyError at save and you probably need the work summary anyway.

Now the "Operators Time" looks like this :

![screen shot 2016-01-16 at 6 26 57 pm](https://cloud.githubusercontent.com/assets/7885477/12375050/14583df6-bc7f-11e5-869b-31a348d39777.png)
