### PR TITLE
[FIX] mrp_operations_project - fix incorrect operator name in tasks

### DIFF
--- a/mrp_operations_project/models/mrp_production.py
+++ b/mrp_operations_project/models/mrp_production.py
@@ -65,7 +65,7 @@ class MrpProductionWorkcenterLine(models.Model):
                           str(workorder.sequence).zfill(3),
                           str(i).zfill(3), workorder.name))
             task_vals['name'] = task_name
-            tasks_vals.append(task_vals)
+            tasks_vals.append(task_vals.copy())
         return tasks_vals
 
     @api.multi


### PR DESCRIPTION
A workcenter with multiple operators will trigger identical tasks for the same operation.

![screen shot 2016-01-20 at 1 50 35 am](https://cloud.githubusercontent.com/assets/7885477/12441910/bbec4124-bf19-11e5-831c-f9c3a3c6ff9e.png)
