### PR TITLE
[FIX] mrp_production_real_cost - create analytic lines before done

### DIFF
--- a/mrp_production_real_cost/models/mrp_production_workcenter_line.py
+++ b/mrp_production_real_cost/models/mrp_production_workcenter_line.py
@@ -97,7 +97,7 @@ class MrpProductionWorkcenterLine(models.Model):
 
     @api.multi
     def action_done(self):
-        result = super(MrpProductionWorkcenterLine, self).action_done()
         self._create_analytic_line()
         self._create_pre_post_cost_lines(cost_type='post')
+        result = super(MrpProductionWorkcenterLine, self).action_done()
         return result


### PR DESCRIPTION
Calling "action_done" before creating "account_analytic_line" triggers an "account_move_line" amount without the value of the last operation.

If we call "action_done" after the "account_analtic_line" is created it will give us the correct amount (including the last operation).
