### PR TITLE
[IMP] mrp_operations_extension: WO finish, do not consume with the remaining raw materials

### DIFF
--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -30,6 +30,7 @@
     "data": [
         "data/mrp_operations_extension_data.xml",
         "wizard/mrp_workorder_produce_view.xml",
+        "wizard/workcerter_line_finish_view.xml",
         "views/mrp_workcenter_view.xml",
         "views/mrp_routing_operation_view.xml",
         "views/mrp_production_view.xml",

--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -135,3 +135,25 @@ class MrpProductionWorkcenterLine(models.Model):
             if workorder.production_id.state in ('confirmed', 'ready'):
                 workorder.production_id.state = 'in_production'
         return super(MrpProductionWorkcenterLine, self).action_start_working()
+
+    @api.multi
+    def button_done(self):
+        res = {}
+        move_list = self.move_lines.filtered(
+            lambda x: x.state not in('cancel', 'done'))
+        if move_list:
+            idform = self.env.ref(
+                'mrp_operations_extension.finish_wo_form_view')
+            res = {
+                'type': 'ir.actions.act_window',
+                'name': _('Finish WO'),
+                'res_model': 'workcenter.line.finish',
+                'view_type': 'form',
+                'view_mode': 'form',
+                'views': [(idform.id, 'form')],
+                'target': 'new',
+                'context': self.env.context
+                }
+        else:
+            self.signal_workflow('button_done')
+        return res

--- a/mrp_operations_extension/views/mrp_production_view.xml
+++ b/mrp_operations_extension/views/mrp_production_view.xml
@@ -118,6 +118,7 @@
                 <button name="button_done" position="attributes">
                     <attribute name="icon"/>
                     <attribute name="class">oe_highlight</attribute>
+                    <attribute name="type">object</attribute>
                 </button>
                 <button name="button_pause" position="attributes">
                     <attribute name="icon"/>
@@ -148,12 +149,26 @@
             </field>
         </record>
 
+       <record model="ir.ui.view" id="mrp_production_form_inherit_view2">
+            <field name="name">mrp.production.form.inherit2</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp_operations.mrp_production_form_inherit_view2" />
+            <field name="arch" type="xml">
+            <xpath expr="//field[@name='workcenter_lines']/tree/button[@name='button_done']" position="attributes">
+                <attribute name="type">object</attribute>
+            </xpath>
+            </field>
+       </record>
+
         <record model="ir.ui.view" id="workcenter_line_inh_form_view">
             <field name="name">Workcenter line inh</field>
             <field name="model">mrp.production.workcenter.line</field>
             <field name="inherit_id"
                 ref="mrp_operations.mrp_production_workcenter_form_view_inherit" />
             <field name="arch" type="xml">
+                <button name="button_done" position="attributes">
+                    <attribute name="type">object</attribute>
+                </button>
                 <field name="workcenter_id" position="before">
                     <field name="possible_workcenters" invisible="1"/>
                 </field>

--- a/mrp_operations_extension/wizard/__init__.py
+++ b/mrp_operations_extension/wizard/__init__.py
@@ -3,3 +3,4 @@
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
 from . import mrp_work_order_produce
+from . import workcenter_line_finish

--- a/mrp_operations_extension/wizard/workcenter_line_finish.py
+++ b/mrp_operations_extension/wizard/workcenter_line_finish.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import models, api
+
+
+class WorkcenterLineFinish(models.TransientModel):
+    _name = "workcenter.line.finish"
+
+    @api.multi
+    def make_them_done(self):
+        if ('active_id' in self.env.context and
+                (self.env.context['active_model'] ==
+                 'mrp.production.workcenter.line')):
+            wc_line_obj = self.env['mrp.production.workcenter.line']
+            wc_line = wc_line_obj.browse(self.env.context['active_id'])
+            wc_line.move_lines.filtered(
+                lambda x: x.state not in ('cancel', 'done')).action_done()
+            wc_line.signal_workflow('button_done')
+
+    @api.multi
+    def cancel_all(self):
+        if ('active_id' in self.env.context and
+                (self.env.context['active_model'] ==
+                 'mrp.production.workcenter.line')):
+            wc_line_obj = self.env['mrp.production.workcenter.line']
+            wc_line = wc_line_obj.browse(self.env.context['active_id'])
+            wc_line.move_lines.filtered(
+                lambda x: x.state not in ('cancel', 'done')).action_cancel()
+            if wc_line.do_production:
+                wc_line.production_id.move_created_ids.filtered(
+                    lambda x: x.state not in
+                    ('cancel', 'done')).action_cancel()
+                wc_line.production_id.refresh()
+            wc_line.signal_workflow('button_done')

--- a/mrp_operations_extension/wizard/workcerter_line_finish_view.xml
+++ b/mrp_operations_extension/wizard/workcerter_line_finish_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="finish_wo_form_view" model="ir.ui.view">
+            <field name="name">finish.wo.form.view</field>
+            <field name="model">workcenter.line.finish</field>
+            <field name="arch" type="xml">
+                <form string="Finish Work Order">
+                    <separator
+                        string="There are still some pending moves on WO"
+                        colspan="4" />
+                    <footer>
+                        <button class="oe_highlight" name="make_them_done"
+                            string="Do all movements" type="object" />
+                        or
+                        <button class="oe_highlight" name="cancel_all"
+                            string="Cancel all movements" type="object" />
+                        or
+                        <button class="oe_link" special="cancel"
+                            string="Cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
- New behaviour added when finishing WO and there are pending movements

all info:
https://github.com/odoomrp/odoomrp-wip/pull/966
