### PR TITLE
[FIX] mrp_production_real_cost - override _costs_generate to avoid duplicates

### DIFF
--- a/mrp_production_real_cost/models/mrp_production.py
+++ b/mrp_production_real_cost/models/mrp_production.py
@@ -73,3 +73,13 @@ class MrpProduction(models.Model):
             'product_uom_id': product.uom_id.id,
             'general_account_id': general_account.id,
         }
+
+    @api.multi
+    def _costs_generate(self):
+        """
+        As we are generating the account_analytic_lines for MO in the
+        current module, we override this method in order to avoid
+        duplicates created in the parent class. Any other module
+        inheriting this method should take this into account!
+        """
+        return


### PR DESCRIPTION
I would like to suggest that we override "_costs_generate" in order to avoid creating duplicate entries in account_analytic_line when action_production_end. 

I don't think this behaviour was intentional. The records created in "_costs_generate" don't have MO#, TASK#, WO# so it is not possible to relate them to the originating MO. If I understand correctly the scope of mrp_production_real_cost module I believe we should prevent these records to be created.

I'm going to attach a picture from account_analytic_line table as it's easier to see all the above.

![screen shot 2016-01-20 at 11 52 33 pm](https://cloud.githubusercontent.com/assets/7885477/12528553/5397f0ae-c168-11e5-89b6-7405a3a6cbbe.png)

I hope i'm not missing anything here...

Thank you
