### PR TITLE
[IMP] mrp_production_real_cost - save WO on AAL

### DIFF
--- a/mrp_project/models/account_analytic_line.py
+++ b/mrp_project/models/account_analytic_line.py
@@ -12,6 +12,5 @@ class AccountAnalyticLine(models.Model):
     mrp_production_id = fields.Many2one(
         comodel_name='mrp.production', string='Manufacturing Order')
     workorder = fields.Many2one(
-        comodel_name='mrp.production.workcenter.line', string='Work Order',
-        related="task_id.workorder", store=True)
+        comodel_name='mrp.production.workcenter.line', string='Work Order')
     task_id = fields.Many2one('project.task', 'Project Task')


### PR DESCRIPTION
When account_analytic_line(s) are created they don't have the originating WO saved. With the exception of the first item in the materials all other are missing.

Workorder is defined as a related field (on task_id) here:
https://github.com/OCA/manufacture/blob/8.0/mrp_project/models/account_analytic_line.py#L14
So we don't need to add workorder to the analytic_vals, instead we just need to ensure the correct task is saved.

Before this PR:

![screen shot 2016-01-24 at 9 52 17 am](https://cloud.githubusercontent.com/assets/7885477/12536972/eaebe5f4-c281-11e5-9526-1d2f02249548.png)

With this PR:
![screen shot 2016-01-24 at 9 53 16 am](https://cloud.githubusercontent.com/assets/7885477/12536974/f482152a-c281-11e5-8e42-c57adbee5828.png)
