### PR TITLE
[IMP] mrp_production_real_cost - change AAL description

### DIFF
--- a/mrp_production_real_cost/__openerp__.py
+++ b/mrp_production_real_cost/__openerp__.py
@@ -15,6 +15,7 @@
         "stock_account",
         "product_variant_cost_price",
     ],
+    'license': 'AGPL-3',
     "author": "OdooMRP team, "
               "AvanzOSC, "
               "Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/mrp_production_real_cost/models/stock_move.py
+++ b/mrp_production_real_cost/models/stock_move.py
@@ -4,6 +4,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import api, models
+from openerp.tools.translate import _
 
 
 class StockMove(models.Model):
@@ -19,9 +20,12 @@ class StockMove(models.Model):
         for record in records:
             journal_id = self.env.ref('mrp.analytic_journal_materials', False)
             production = record.raw_material_production_id
-            name = ((production.name or '') + '-' +
-                    (record.work_order.routing_wc_line.operation.code or '') +
-                    '-' + (record.product_id.default_code or ''))
+            name = "-".join([
+                production.name or '',
+                record.work_order.workcenter_id.code or '',
+                record.work_order.routing_wc_line.routing_id.code or '',
+                record.product_id.default_code or '',
+                _('MAT')])
             analytic_vals = (production._prepare_real_cost_analytic_line(
                 journal_id, name, production, record.product_id,
                 workorder=record.work_order, qty=record.product_qty,


### PR DESCRIPTION
At the moment the description field in an account analytic line contains the following layout:
##### MO-OP-PC-INFO

MO = MO#
OP = Operation Code (as in operation.code - this is NULL now)
PC = Product Code (this is the "work center product" code as defined in work center)
INFO = Only for PRE and POST entries

In this PR I suggest a slight change and a fix to the Operation Code
##### MO-WC-OP-PC-INFO

MO = MO#
WC = Work Center Code
OP = Operation Code (replace operation.code with **routing_id.code**)
PC = Product Code (this is the "work center product" code as defined in work center)
INFO = For PRE and POST and HOUR

This way is going to be easier for everyone looking at the data to understand where the analytic line is coming from.

Thank you
