### PR TITLE
[FIX] mrp_production_real_cost - include timesheet in cost

### DIFF
--- a/mrp_production_real_cost/README.rst
+++ b/mrp_production_real_cost/README.rst
@@ -26,14 +26,15 @@ https://github.com/OCA/product-variant
 Usage
 =====
 
-Operating with a manufacture order, analytic entries adding costs will be
+Processing a manufacture order, analytic entries adding costs will be
 created when:
 
 * Some raw material is consumed.
 * A work order is finished or paused.
+* Also, together with *project_timesheet* module, users time is also translated
+  to costs in the linked analytic account.
 
-Also, thanks to *project_timesheet* modules, users time is also translated to
-costs in the linked analytic account.
+The sum of all these analytic entries is the real cost.
 
 
 

--- a/mrp_project/__openerp__.py
+++ b/mrp_project/__openerp__.py
@@ -12,6 +12,7 @@
         "project",
     ],
     'license': 'AGPL-3',
+    "images": [],
     "author": "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
@@ -22,7 +23,8 @@
         "views/mrp_production_view.xml",
         "views/project_project_view.xml",
         "views/account_analytic_line_view.xml",
-        "views/project_task_view.xml"
+        "views/project_task_view.xml",
+        "views/hr_analytic_timesheet.xml"
     ],
     'installable': True,
     'auto_install': False,

--- a/mrp_project/models/__init__.py
+++ b/mrp_project/models/__init__.py
@@ -8,3 +8,4 @@ from . import account_analytic_line
 from . import project_project
 from . import project_task
 from . import project_task_work
+from . import hr_analytic_timesheet

--- a/mrp_project/models/hr_analytic_timesheet.py
+++ b/mrp_project/models/hr_analytic_timesheet.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Daniel Dico <dd@oerp.ca>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class HrAnalyticTimesheet(models.Model):
+    _inherit = "hr.analytic.timesheet"
+
+    @api.model
+    def create(self, vals):
+        production = self._context.get('production', False)
+        vals['mrp_production_id'] = vals.get(
+            'mrp_production_id', False) or production and production.id
+        return super(HrAnalyticTimesheet, self).create(vals)

--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -91,3 +91,8 @@ class MrpProductionWorkcenterLine(models.Model):
     work_ids = fields.One2many(
         comodel_name="project.task.work", inverse_name="workorder",
         string="Task works")
+
+    @api.multi
+    def write(self, vals, update=True):
+        return super(MrpProductionWorkcenterLine, self.with_context(
+            production=self.production_id)).write(vals)

--- a/mrp_project/models/project_task.py
+++ b/mrp_project/models/project_task.py
@@ -29,3 +29,8 @@ class ProjectTask(models.Model):
                     (task.id, "[%s] %s" % (task.user_id.name, task.name)))
             return res
         return super(ProjectTask, self).name_get()
+
+    @api.multi
+    def write(self, vals):
+        return super(ProjectTask, self.with_context(
+            production=self.mrp_production_id)).write(vals)

--- a/mrp_project/views/hr_analytic_timesheet.xml
+++ b/mrp_project/views/hr_analytic_timesheet.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="hr_timesheet_line_tree_mrp" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.tree.mrp</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
+            <field name="arch" type="xml">
+                <field name="account_id" position="after">
+                    <field name="mrp_production_id" domain="[('analytic_account_id','=',account_id)]" options="{'no_open': True, 'no_create': True}"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
In the readme file of this module it states that:

_...thanks to project_timesheet modules, users time is also translated to costs in the linked analytic account._

My findings are that time sheet entries created for the correct analytic account (MO/Project) are **not** included in the cost calculation as the timesheet entry is missing the `mrp_production_id` value. 

A little more technical: [_compute_real_cost](https://github.com/OCA/manufacture/blob/8.0/mrp_production_real_cost/models/mrp_production.py#L15) method will only sum account_analytic_line where mrp_production_id was set (as per the field definition [here](https://github.com/OCA/manufacture/blob/8.0/mrp_production_real_cost/models/mrp_production.py#L23))

This PR will add mrp_production_id into the timesheet and now cost calculation will include the timesheet amounts.
