### PR TITLE
[FIX][REF] mrp_operations_extension: Fix WO raw stock move relation

### DIFF
--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Manufacturing Operations Extension",
-    "version": "8.0.3.0.0",
+    "version": "8.0.2.1.0",
     "category": "Manufacturing",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/mrp_operations_extension/__openerp__.py
+++ b/mrp_operations_extension/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Manufacturing Operations Extension",
-    "version": "8.0.2.0.0",
+    "version": "8.0.3.0.0",
     "category": "Manufacturing",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -65,8 +65,8 @@ class MrpProductionWorkcenterLine(models.Model):
     time_start = fields.Float(string="Time Start")
     time_stop = fields.Float(string="Time Stop")
     move_lines = fields.Many2many(
-        'stock.move', compute="_compute_move_lines", string='Moves',
-        store=False)
+        comodel_name='stock.move', compute="_compute_move_lines",
+        string='Moves', store=False)
     is_material_ready = fields.Boolean(
         string='Materials Ready', compute="_compute_is_material_ready")
     possible_workcenters = fields.Many2many(

--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -65,7 +65,8 @@ class MrpProductionWorkcenterLine(models.Model):
     time_start = fields.Float(string="Time Start")
     time_stop = fields.Float(string="Time Stop")
     move_lines = fields.Many2many(
-        'stock.move', compute="_compute_move_lines", string='Moves', store=False)
+        'stock.move', compute="_compute_move_lines", string='Moves',
+        store=False)
     is_material_ready = fields.Boolean(
         string='Materials Ready', compute="_compute_is_material_ready")
     possible_workcenters = fields.Many2many(


### PR DESCRIPTION
When a **MO** has subproducts, the resulting **WO** adds - wrongly - the
stock moves as raw materials, even if they aren't.

This fix, ensures that all the stock moves must be raw materials and
must belong to that **WO**.

In addition, I've refactored `_compute_is_material_ready` method to
use these calculated stock moves, and I have also moved the `_compute*`
methods position to follow Odoo's guidelines
