### PR TITLE
8.0 mrp production real cost uptime update

### DIFF
--- a/mrp_production_real_cost/__openerp__.py
+++ b/mrp_production_real_cost/__openerp__.py
@@ -13,7 +13,6 @@
         "mrp_operations_extension",
         "mrp_operations_time_control",
         "stock_account",
-        "product_variant_cost_price",
     ],
     'license': 'AGPL-3',
     "author": "OdooMRP team, "

--- a/mrp_production_real_cost/__openerp__.py
+++ b/mrp_production_real_cost/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Real costs in manufacturing orders",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.0.1",
     "depends": [
         "project_timesheet",
         "mrp_project",


### PR DESCRIPTION
Up to now, you have to rely only on play/pause/stop controls, and the time passed between them for having real costs reflected, but there are manufacturing processes that reflects their times not directly, but afterwards introducing the summaries. This commit allows to reflect the changes on costs when you edit up times.

This PR also fixes an incorrect dependency that is not needed (you can have it installed to get the extra feature, but it's not a requirement).
