### PR TITLE
[8.0][IMP][mrp_project] Set workorder in analytic.line related with a task from a work order

### DIFF
--- a/mrp_project/README.rst
+++ b/mrp_project/README.rst
@@ -54,6 +54,7 @@ Contributors
 
 * Daniel Campos <danielcampos@avanzosc.es>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Maintainer
 ----------

--- a/mrp_project/__openerp__.py
+++ b/mrp_project/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "MRP Project Link",
     "summary": "Link production with projects",
-    "version": "8.0.1.1.1",
+    "version": "8.0.1.2.0",
     "depends": [
         "mrp_analytic",
         "project",

--- a/mrp_project/__openerp__.py
+++ b/mrp_project/__openerp__.py
@@ -6,10 +6,11 @@
 {
     "name": "MRP Project Link",
     "summary": "Link production with projects",
-    "version": "8.0.1.1.0",
+    "version": "8.0.1.1.1",
     "depends": [
         "mrp_analytic",
         "project",
+        "project_timesheet",
     ],
     'license': 'AGPL-3',
     "images": [],

--- a/mrp_project/models/hr_analytic_timesheet.py
+++ b/mrp_project/models/hr_analytic_timesheet.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2016 Daniel Dico <dd@oerp.ca>
+# (c) 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import models, api

--- a/mrp_project/models/hr_analytic_timesheet.py
+++ b/mrp_project/models/hr_analytic_timesheet.py
@@ -10,7 +10,10 @@ class HrAnalyticTimesheet(models.Model):
 
     @api.model
     def create(self, vals):
-        production = self._context.get('production', False)
+        production = self.env.context.get('production', False)
+        workorder = self.env.context.get('workorder', False)
         vals['mrp_production_id'] = vals.get(
             'mrp_production_id', False) or production and production.id
+        vals['workorder'] = vals.get(
+            'workorder', False) or workorder and workorder.id
         return super(HrAnalyticTimesheet, self).create(vals)

--- a/mrp_project/models/project_task_work.py
+++ b/mrp_project/models/project_task_work.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # (c) 2015 Pedro M. Baeza - Serv. Tecnol. Avanzados
+# (c) 2016 Antiun Ingenieria S.L. - Antonio Espinosa
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from openerp import models, fields, api

--- a/mrp_project/models/project_task_work.py
+++ b/mrp_project/models/project_task_work.py
@@ -28,3 +28,9 @@ class ProjectTaskWork(models.Model):
             task = self.env['project.task'].browse(task_id)
             res['value'] = {'user_id': task.user_id.id}
         return res
+
+    @api.model
+    def _create_analytic_entries(self, vals):
+        task = self.env['project.task'].browse(vals.get('task_id', False))
+        return super(ProjectTaskWork, self.with_context(
+            workorder=task.workorder))._create_analytic_entries(vals)


### PR DESCRIPTION
This PR improves @ddico work added here https://github.com/OCA/manufacture/commit/b82abb6ecea258586e34802d48e9a700d935118b
Setting also work order to `account.analytic.line` when creating task work from a task related with a work order 
