### PR TITLE
[IMP] Show estimated and real sum in tree view

### DIFF
--- a/mrp_production_estimated_cost/views/mrp_production_view.xml
+++ b/mrp_production_estimated_cost/views/mrp_production_view.xml
@@ -67,7 +67,7 @@
                 <field name="product_uom" position="after">
                     <field name="product_cost"/>
                     <field name="product_manual_cost"/>
-                    <field name="avg_cost" />
+                    <field name="avg_cost" sum="Total Estimated Cost"/>
                 </field>
             </field>
         </record>

--- a/mrp_production_real_cost/views/mrp_production_view.xml
+++ b/mrp_production_real_cost/views/mrp_production_view.xml
@@ -41,7 +41,7 @@
             <field name="inherit_id" ref="mrp.mrp_production_tree_view"/>
             <field name="arch" type="xml">
                 <field name="product_uom" position="after">
-                    <field name="real_cost" />
+                    <field name="real_cost" sum="Total Real Cost"/>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
This little PR adds sum for 'estimated cost' and 'real cost' columns at `mrp.production` tree view 
