### PR TITLE
[8.0][FIX][mrp_production_real_cost] Support several stock moves for the same product when calculating new price

### DIFF
--- a/mrp_production_real_cost/README.rst
+++ b/mrp_production_real_cost/README.rst
@@ -82,6 +82,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <ajuaristio@gmail.com>
 * Ainara Galdona <agaldona@avanzosc.es>
+* Antonio Espinosa <antonioea@antiun.com>
 
 Images
 ------

--- a/mrp_production_real_cost/__openerp__.py
+++ b/mrp_production_real_cost/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Real costs in manufacturing orders",
-    "version": "8.0.1.0.1",
+    "version": "8.0.1.0.2",
     "depends": [
         "project_timesheet",
         "mrp_project",


### PR DESCRIPTION
In a manufacture order you can produce a different product qty that initially provided. In that case, two stock moves are created.

Current `product_price_update_production_done` method only supports one stock move per product. This PR adds support for this use case.
