### PR TITLE
[8.0][FIX][mrp_operations_time_control] Set end date only when not defined

### DIFF
--- a/mrp_operations_time_control/models/operation_time.py
+++ b/mrp_operations_time_control/models/operation_time.py
@@ -19,7 +19,8 @@ class MrpProductionWorkcenterLine(models.Model):
             'user': self.env.uid})
 
     def _write_end_date_operation_line(self):
-        self.operation_time_lines[-1].end_date = fields.Datetime.now()
+        if not self.operation_time_lines[-1].end_date:
+            self.operation_time_lines[-1].end_date = fields.Datetime.now()
 
     @api.multi
     def action_start_working(self):


### PR DESCRIPTION
When pressing "Finished" button in a Work Order the last "Machine up time" line is overwritten at "End date" field with the today date, even if "End date" is assigned or not.

This PR adds a condition for setting "End date" only when not set.
