### PR TITLE
[8.0] mrp_operations_extension: Remove write MO's state on 'action_start_working'

### DIFF
--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -133,6 +133,4 @@ class MrpProductionWorkcenterLine(models.Model):
                     ['assigned', 'cancel', 'done']):
                 raise exceptions.Warning(
                     _("Missing materials to start the production"))
-            if workorder.production_id.state in ('confirmed', 'ready'):
-                workorder.production_id.state = 'in_production'
         return super(MrpProductionWorkcenterLine, self).action_start_working()


### PR DESCRIPTION
Modify state on WO it isn't necessary at all because the **mrp_operations**
changes the state to **in_production** through the workflow.

Issue #102 
