### PR TITLE
[IMP] mrp_operations_extension: configurable cycle compute

### DIFF
--- a/mrp_operations_extension/README.rst
+++ b/mrp_operations_extension/README.rst
@@ -31,6 +31,8 @@ Configuration
 
 Go to *Settings > Manufacturing* and activate "Manage routings and work orders"
 for handling the features of this module.
+Go to *Settings > Manufacturing* and deactivate "Compute Cycles by BoM Quantity"
+in order to compute cycles without BoM product quantity.
 
 Usage
 =====

--- a/mrp_operations_extension/data/mrp_operations_extension_data.xml
+++ b/mrp_operations_extension/data/mrp_operations_extension_data.xml
@@ -10,4 +10,10 @@
             <field name="object">mrp.production.workcenter.line</field>
         </record>
     </data>
+    <data noupdate="1">
+        <record forcecreate="True" id="config_parameter_cycle_by_bom" model="ir.config_parameter">
+            <field name="key">cycle.by.bom</field>
+            <field name="value" eval="True"/>
+        </record>
+    </data>
 </openerp>

--- a/mrp_operations_extension/models/mrp_bom.py
+++ b/mrp_operations_extension/models/mrp_bom.py
@@ -13,6 +13,12 @@ class MrpBom(models.Model):
     def _prepare_wc_line(self, wc_use, level=0, factor=1):
         res = super(MrpBom, self)._prepare_wc_line(
             wc_use, level=level, factor=factor)
+        if not self.env['mrp.config.settings']._get_parameter('cycle.by.bom',
+                                                              False):
+            production = self.env.context.get('production')
+            factor = self._factor(production and production.product_qty or 1,
+                                  self.product_efficiency,
+                                  self.product_rounding)
         cycle = int(math.ceil(factor / (wc_use.cycle_nbr or 1)))
         hour = wc_use.hour_nbr * cycle
         default_wc_line = wc_use.op_wc_lines.filtered(lambda r: r.default)

--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -26,8 +26,8 @@ class MrpProduction(models.Model):
 
     @api.multi
     def _action_compute_lines(self, properties=None):
-        res = super(MrpProduction, self)._action_compute_lines(
-            properties=properties)
+        res = super(MrpProduction, self.with_context(production=self)
+                    )._action_compute_lines(properties=properties)
         # Assign work orders to each consume line
         for product_line in self.product_lines:
             product_line.work_order = self.workcenter_lines.filtered(

--- a/mrp_operations_extension/models/res_config.py
+++ b/mrp_operations_extension/models/res_config.py
@@ -2,7 +2,7 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from openerp import fields, models
+from openerp import fields, models, api
 
 
 class MrpConfigSettings(models.TransientModel):
@@ -11,3 +11,31 @@ class MrpConfigSettings(models.TransientModel):
     group_mrp_workers = fields.Boolean(
         string='Manage operators in work centers',
         implied_group='mrp_operations_extension.group_mrp_workers')
+    cycle_by_bom = fields.Boolean(string="Calc Cycles by BoM Quantity")
+
+    def _get_parameter(self, key, default=False):
+        param_obj = self.env['ir.config_parameter']
+        rec = param_obj.search([('key', '=', key)])
+        return rec or default
+
+    def _write_or_create_param(self, key, value):
+        param_obj = self.env['ir.config_parameter']
+        rec = self._get_parameter(key)
+        if rec:
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
+
+    @api.multi
+    def get_default_parameter_cycle_bom(self):
+        def get_value(key, default=''):
+            rec = self._get_parameter(key)
+            return rec and rec.value or default
+        return {'cycle_by_bom': get_value('cycle.by.bom', False)}
+
+    @api.multi
+    def set_parameter_cycle_bom(self):
+        self._write_or_create_param('cycle.by.bom', self.cycle_by_bom)

--- a/mrp_operations_extension/views/res_config_view.xml
+++ b/mrp_operations_extension/views/res_config_view.xml
@@ -11,9 +11,13 @@
                         <field name="group_mrp_workers" class="oe_inline"/>
                         <label for="group_mrp_workers"/>
                     </div>
+                    <div>
+                        <field name="cycle_by_bom" class="oe_inline"/>
+                        <label for="cycle_by_bom"/>
+                    </div>
                 </xpath>
             </field>
         </record>
-    
+
     </data>
 </openerp>


### PR DESCRIPTION
Added new config parameter "Calc Cycles by BoM Quantity".
If it is activated (Default option), the system will calculate the number of cycles like before.
If it is deactivated, the system will calculate the number of cycles without taking into account BoM product quantity.
