### PR TITLE
[FIX] mrp_operations_extension: Modified action_start_working method …

### DIFF
--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -133,5 +133,7 @@ class MrpProductionWorkcenterLine(models.Model):
                 raise exceptions.Warning(
                     _("Missing materials to start the production"))
             if workorder.production_id.state in ('confirmed', 'ready'):
+                workorder.production_id.signal_workflow('moves_ready')
+                # bypass force_production method in production order
                 workorder.production_id.state = 'in_production'
         return super(MrpProductionWorkcenterLine, self).action_start_working()


### PR DESCRIPTION
Modified action_start_working method on WO, to avoid force production without breaking production workflow.

As we talk here:

https://github.com/OCA/manufacture/pull/103
