### PR TITLE
[8.0][IMP][mrp_project] If production come from a sale order, set project parent

### DIFF
--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -17,10 +17,17 @@ class MrpProduction(models.Model):
 
     @api.model
     def _prepare_project_vals(self, production):
+        # If this production come from a sale order and that order
+        # has an analytic account assigned, then project is child of
+        # that analytic account
+        parent_id = False
+        if 'sale_id' in production._fields:
+            parent_id = production.sale_id.project_id.id
         return {
             'name': production.name,
             'use_tasks': True,
             'automatic_creation': True,
+            'parent_id': parent_id,
         }
 
     @api.model


### PR DESCRIPTION
This PR improves `mrp_project` for this case use:

A production order created by a sale order with an analytic account assigned.

With this PR the project created to manage task related with production order will be child of analytic account assigned to the sale order. This allows to have outcomes (from materials and human resources) and income (invoice generated when sale order is delivered) together below the analytic account assigned to sale order. 
