### PR TITLE
mrp_bom_dismantling: fix lot_id required bug.

### DIFF
--- a/mrp_bom_dismantling/tests/test_product_produce.py
+++ b/mrp_bom_dismantling/tests/test_product_produce.py
@@ -5,24 +5,25 @@ from openerp.tests import TransactionCase
 
 class TestProductProduce(TransactionCase):
 
-    def test_produced_products_lots(self):
-        produce_model = self.env['mrp.product.produce']
+    def setUp(self):
+        super(TestProductProduce, self).setUp()
+
+        self.produce_model = self.env['mrp.product.produce']
         product_model = self.env['product.product']
-        lot_model = self.env['stock.production.lot']
-        quant_model = self.env['stock.quant']
+        self.lot_model = self.env['stock.production.lot']
 
         unit_uom = self.browse_ref('product.product_uom_unit')
 
         wh_main = self.browse_ref('stock.warehouse0')
 
         # Create simple bom with by products
-        p1 = product_model.create({'name': 'Test P1'})
-        p2 = product_model.create({'name': 'Test P2'})
-        p3 = product_model.create({'name': 'Test P3'})
+        self.p1 = product_model.create({'name': 'Test p1'})
+        self.p2 = product_model.create({'name': 'Test p2'})
+        self.p3 = product_model.create({'name': 'Test p3'})
 
-        # We have 1 P2 in stock
+        # We have 1 self.p2 in stock
         inventory = self.env['stock.inventory'].create({
-            'name': 'P2 inventory',
+            'name': 'self.p2 inventory',
             'location_id': wh_main.lot_stock_id.id,
             'filter': 'partial'
         })
@@ -30,67 +31,104 @@ class TestProductProduce(TransactionCase):
 
         self.env['stock.inventory.line'].create({
             'inventory_id': inventory.id,
-            'product_id': p2.id,
+            'product_id': self.p2.id,
             'location_id': wh_main.lot_stock_id.id,
             'product_qty': 1
         })
         inventory.action_done()
 
-        # P1 need P2 and generates one byproduct P3
+        # self.p1 need self.p2 and generates one byproduct self.p3
         bom = self.env['mrp.bom'].create({
-            'product_tmpl_id': p1.product_tmpl_id.id,
-            'product_id': p1.id,
+            'product_tmpl_id': self.p1.product_tmpl_id.id,
+            'product_id': self.p1.id,
             'product_qty': 1,
             'product_uom': unit_uom.id,
         })
 
         self.env['mrp.bom.line'].create({
             'bom_id': bom.id,
-            'product_id': p2.id,
+            'product_id': self.p2.id,
             'product_qty': 1,
             'product_uom': unit_uom.id,
         })
 
         self.env['mrp.subproduct'].create({
             'bom_id': bom.id,
-            'product_id': p3.id,
+            'product_id': self.p3.id,
             'product_qty': 1,
             'product_uom': unit_uom.id,
         })
 
         # Create MRP Order
-        mrp_order_id = bom.create_mrp_production()['res_id']
-        mrp_order = self.env['mrp.production'].browse(mrp_order_id)
-        mrp_order.action_confirm()
-        mrp_order.action_assign()
+        self.mrp_order_id = bom.create_mrp_production()['res_id']
+        self.mrp_order = self.env['mrp.production'].browse(self.mrp_order_id)
+        self.mrp_order.action_confirm()
+        self.mrp_order.action_assign()
 
+    def test_produced_products_lots(self):
         # Wizard simulation
-        wizard = produce_model.with_context(active_id=mrp_order_id).create({})
+        wizard = self.produce_model.with_context(
+            active_id=self.mrp_order_id
+        ).create({})
         wizard.on_change_product_id()
         self.assertEqual(2, len(wizard.move_lot_ids))
-        self.assertEqual([p1, p3], [x.product_id for x in wizard.move_lot_ids])
+        self.assertEqual(
+            [self.p1, self.p3], [x.product_id for x in wizard.move_lot_ids]
+        )
 
-        lot_p1 = lot_model.create({'name': 'LOT_01', 'product_id': p1.id})
+        lot_p1 = self.lot_model.create(
+            {'name': 'LOT_01', 'product_id': self.p1.id}
+        )
         wizard.move_lot_ids[0].lot_id = lot_p1
 
-        lot_p3 = lot_model.create({'name': 'LOT_03', 'product_id': p3.id})
+        lot_p3 = self.lot_model.create(
+            {'name': 'LOT_03', 'product_id': self.p3.id}
+        )
         wizard.move_lot_ids[1].lot_id = lot_p3
 
         wizard.do_produce()
 
         # Check created move in mrp.production
-        mrp_order.refresh()
+        self.mrp_order.refresh()
         self.assertEqual(lot_p1,
-                         mrp_order.move_created_ids2[0].restrict_lot_id)
+                         self.mrp_order.move_created_ids2[0].restrict_lot_id)
         self.assertEqual(lot_p3,
-                         mrp_order.move_created_ids2[1].restrict_lot_id)
+                         self.mrp_order.move_created_ids2[1].restrict_lot_id)
 
         # Check stock.quants
-        p1_quants = quant_model.search([('product_id', '=', p1.id)])
+        quant_model = self.env['stock.quant']
+
+        p1_quants = quant_model.search([('product_id', '=', self.p1.id)])
         self.assertEqual(1, len(p1_quants))
         self.assertEqual(lot_p1, p1_quants.lot_id)
         self.assertEqual(1, p1_quants.qty)
 
-        p3_quants = quant_model.search([('product_id', '=', p3.id)])
+        p3_quants = quant_model.search([('product_id', '=', self.p3.id)])
         self.assertEqual(1, len(p3_quants))
         self.assertEqual(1, p3_quants.qty)
+
+    def test_tracking_lot(self):
+        wizard = self.produce_model.with_context(
+            active_id=self.mrp_order_id
+        ).create({})
+        wizard.on_change_product_id()
+
+        self.assertEqual(False, wizard.move_lot_ids[0].lot_required)
+        self.assertEqual(False, wizard.move_lot_ids[1].lot_required)
+
+        self.p1.tracking = 'serial'
+        self.p1.refresh()
+
+        self.assertEqual(True, wizard.move_lot_ids[0].lot_required)
+        self.assertEqual(False, wizard.move_lot_ids[1].lot_required)
+
+        self.p3.tracking = 'lot'
+        self.p3.refresh()
+
+        self.assertEqual(True, wizard.move_lot_ids[0].lot_required)
+        self.assertEqual(True, wizard.move_lot_ids[1].lot_required)
+
+        wizard.mode = 'consume'
+        wizard.refresh()
+        self.assertEqual(False, wizard.move_lot_ids[0].lot_required)
+        self.assertEqual(False, wizard.move_lot_ids[1].lot_required)

--- a/mrp_bom_dismantling/wizards/mrp_product_produce.py
+++ b/mrp_bom_dismantling/wizards/mrp_product_produce.py
@@ -15,12 +15,21 @@ class MrpByProductLine(models.TransientModel):
                                  related='move_id.product_id')
     lot_id = fields.Many2one('stock.production.lot', string='Lot')
 
+    lot_required = fields.Boolean(compute='_compute_lot_required')
+
+    @api.depends('produce_id.mode', 'product_id.tracking')
+    def _compute_lot_required(self):
+        for record in self:
+            record.lot_required = record.product_id.tracking != 'none' \
+                and record.produce_id.mode == 'consume_produce'
+
 
 class MrpProductProduce(models.TransientModel):
     _inherit = "mrp.product.produce"
     move_lot_ids = fields.One2many(
         'mrp.product.produced.line',
         inverse_name='produce_id',
+        string='Products to produce lots'
     )
 
     @api.onchange("product_id")

--- a/mrp_bom_dismantling/wizards/mrp_product_produce.xml
+++ b/mrp_bom_dismantling/wizards/mrp_product_produce.xml
@@ -7,9 +7,10 @@
         <field name="inherit_id" ref="mrp.view_mrp_product_produce_wizard"/>
         <field name="arch" type="xml">
 
-            <!-- Hide lot_id field -->
+            <!-- Hide lot_id field and remove his required attribute -->
             <field name="lot_id" position="attributes">
                 <attribute name="invisible">True</attribute>
+                <attribute name="attrs" />
             </field>
 
             <!-- Add produced products list for managing lot_id -->
@@ -18,8 +19,11 @@
                     <field name="move_lot_ids" nolabel="1">
                         <tree editable="bottom" create="false" delete="false">
                             <field name="move_id" invisible="True"/>
+                            <field name="lot_required" invisible="True"/>
+
                             <field name="product_id" readonly="True"/>
                             <field name="lot_id" domain="[('product_id', '=', product_id)]"
+                                   attrs="{'required': [('lot_required', '=', True)]}"
                                    context="{'default_product_id':product_id}"/>
                         </tree>
                     </field>


### PR DESCRIPTION
When products are configured with tracking serial number or lot, lot_id is mandatory in produce wizard but mrp_bom_dismantling hides this field.

I removed required on lot_id and implement the same required in the new wizard field.
