### PR TITLE
[8.0][FIX] mrp_project: Fix singleton exception in 'ProjectTask.write'

### DIFF
--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -101,5 +101,7 @@ class MrpProductionWorkcenterLine(models.Model):
 
     @api.multi
     def write(self, vals, update=True):
-        return super(MrpProductionWorkcenterLine, self.with_context(
-            production=self.production_id)).write(vals)
+        for rec in self:
+            super(MrpProductionWorkcenterLine, rec.with_context(
+                production=rec.production_id)).write(vals)
+        return True

--- a/mrp_project/models/project_task.py
+++ b/mrp_project/models/project_task.py
@@ -32,5 +32,7 @@ class ProjectTask(models.Model):
 
     @api.multi
     def write(self, vals):
-        return super(ProjectTask, self.with_context(
-            production=self.mrp_production_id)).write(vals)
+        for rec in self:
+            super(ProjectTask, rec.with_context(
+                production=rec.mrp_production_id)).write(vals)
+        return True


### PR DESCRIPTION
The `write` method was not able to process multiple records, so they are now iterated to avoid singleton errors. Same fix has been applied in `MrpProductionWorkcenterLine.write` also.
