### PR TITLE
Move refresh just before _check (fixes #124 for multi level BoM as well)

### DIFF
--- a/mrp_production_real_cost/models/__init__.py
+++ b/mrp_production_real_cost/models/__init__.py
@@ -7,3 +7,4 @@ from . import mrp_bom
 from . import mrp_production
 from . import mrp_production_workcenter_line
 from . import stock_move
+from . import procurement_order

--- a/mrp_production_real_cost/models/procurement_order.py
+++ b/mrp_production_real_cost/models/procurement_order.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eska Yazılım ve Danışmanlık A.Ş. - Levent Karakaş
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import models, api
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.model
+    def _check(self, procurement):
+        if procurement.production_id:
+            # This is needed because commit
+            # https://github.com/odoo/odoo/commit/
+            # 6f29bfc181d23d70d29776d96b4318e9ee2c93a9
+            # introduces a weird behavior on the next call, provoking an error.
+            procurement.production_id.sudo().refresh()
+        return super(ProcurementOrder, self)._check(procurement)


### PR DESCRIPTION
fixes https://github.com/OCA/manufacture/issues/124 for multi level BoM's. 
