### PR TITLE
[8.0][FIX]mrp_production_real_cost: fix error in old api inherit

### DIFF
--- a/mrp_production_real_cost/models/mrp_production.py
+++ b/mrp_production_real_cost/models/mrp_production.py
@@ -81,8 +81,8 @@ class MrpProduction(models.Model):
             'general_account_id': general_account.id,
         }
 
-    @api.multi
-    def _costs_generate(self):
+    @api.model
+    def _costs_generate(self, production):
         """
         As we are generating the account_analytic_lines for MO in the
         current module, we override this method in order to avoid


### PR DESCRIPTION
The function '_costs_generate' has an api.multi, expecting that the 3rd parameter in old API is 'ids', but it is a 'mrp.production' record instead. Convert to api.model resolves the error.
This could be related to this issue #124 
