### PR TITLE
[IMP] mrp_operations_extension: allow to load operation in routing lines

### DIFF
--- a/mrp_operations_extension/models/mrp_routing.py
+++ b/mrp_operations_extension/models/mrp_routing.py
@@ -66,7 +66,6 @@ class MrpRoutingWorkcenter(models.Model):
                 op_wc_lst.append(data)
                 is_default = False
             self.op_wc_lines = op_wc_lst
-        self.operation = False
 
     @api.one
     @api.onchange('op_wc_lines')


### PR DESCRIPTION
@anajuaristi reported an issue in routing lines. When you select an operation it disappears. I don't know why was it like this, but i think it is a bug.
