### PR TITLE
[IMP] mrp_operations_extension: load workorder in new stock_moves 

### DIFF
--- a/mrp_operations_extension/models/mrp_production.py
+++ b/mrp_operations_extension/models/mrp_production.py
@@ -44,6 +44,17 @@ class MrpProduction(models.Model):
             move.work_order = line.work_order.id
         return move_id
 
+    @api.model
+    def _make_consume_line_from_data(self, production, product, uom_id, qty,
+                                     uos_id, uos_qty):
+        move_id = super(MrpProduction, self)._make_consume_line_from_data(
+            production, product, uom_id, qty, uos_id, uos_qty)
+        work_order = self.env.context.get('default_work_order', False)
+        if work_order:
+            move = self.env['stock.move'].browse(move_id)
+            move.work_order = work_order
+        return move_id
+
 
 class MrpProductionProductLine(models.Model):
     _inherit = 'mrp.production.product.line'

--- a/mrp_operations_extension/wizard/mrp_work_order_produce.py
+++ b/mrp_operations_extension/wizard/mrp_work_order_produce.py
@@ -34,22 +34,27 @@ class MrpWorkOrderProduce(models.TransientModel):
     def do_consume(self, cr, uid, ids, context=None):
         work_line = self.pool['mrp.production.workcenter.line'].browse(
             cr, uid, context.get("active_id"), context=context)
+        new_context = context.copy()
+        new_context.update({'default_work_order': work_line.id})
         production_id = work_line.production_id.id
         assert production_id
-        data = self.browse(cr, uid, ids[0], context=context)
+        data = self.browse(cr, uid, ids[0], context=new_context)
         self.pool['mrp.production'].action_produce(
-            cr, uid, production_id, False, 'consume', data, context=context)
+            cr, uid, production_id, False, 'consume', data,
+            context=new_context)
         return {}
 
     def do_consume_produce(self, cr, uid, ids, context=None):
         work_line = self.pool['mrp.production.workcenter.line'].browse(
             cr, uid, context.get("active_id"), context=context)
+        new_context = context.copy()
+        new_context.update({'default_work_order': work_line.id})
         production_id = work_line.production_id.id
         assert production_id
-        data = self.browse(cr, uid, ids[0], context=context)
+        data = self.browse(cr, uid, ids[0], context=new_context)
         self.pool['mrp.production'].action_produce(
             cr, uid, production_id, data.product_qty, 'consume_produce', data,
-            context=context)
+            context=new_context)
         return {}
 
     def on_change_qty(self, cr, uid, ids, product_qty, consume_lines,


### PR DESCRIPTION
We found a new issue.
When we launch consume/produce wizard from workorders and we add a new product in consume lines, when stock move is created for that product, the system doesn't load the workorder id in the move.
