### PR TITLE
Set cycle_nbr to visible and delete onchange field assignation

### DIFF
--- a/mrp_operations_extension/i18n/es.po
+++ b/mrp_operations_extension/i18n/es.po
@@ -1,25 +1,21 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * mrp_operations_extension
-# 
-# Translators:
-# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
-# oihane <oihanecruce@gmail.com>, 2016
-# oihane <oihanecruce@gmail.com>, 2016
-# oihane <oihanecruce@gmail.com>, 2016
+# 	* mrp_operations_extension
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: manufacture (8.0)\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-17 22:50+0000\n"
-"PO-Revision-Date: 2016-10-04 09:43+0000\n"
-"Last-Translator: oihane <oihanecruce@gmail.com>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-manufacture-8-0/language/es/)\n"
+"POT-Creation-Date: 2016-11-02 08:34+0000\n"
+"PO-Revision-Date: 2016-11-02 09:40+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Language: es\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #. module: mrp_operations_extension
 #: field:mrp.workcenter,op_number:0
@@ -36,13 +32,13 @@ msgstr "operadores"
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Actual Production Date"
-msgstr ""
+msgstr "Actual Production Date"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_production.py:23
 #, python-format
 msgid "At least one work order must have checked 'Produce here'"
-msgstr ""
+msgstr "At least one work order must have checked 'Produce here'"
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_bom
@@ -52,7 +48,7 @@ msgstr "Lista de material"
 #. module: mrp_operations_extension
 #: field:mrp.production.product.line,bom_line:0
 msgid "Bom line"
-msgstr ""
+msgstr "Bom line"
 
 #. module: mrp_operations_extension
 #: field:mrp.config.settings,cycle_by_bom:0
@@ -69,37 +65,35 @@ msgstr "Cancelar"
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 msgid "Cancel Order"
-msgstr ""
+msgstr "Cancel Order"
 
 #. module: mrp_operations_extension
 #: view:workcenter.line.finish:mrp_operations_extension.finish_wo_form_view
 msgid "Cancel all movements"
-msgstr ""
+msgstr "Cancel all movements"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,capacity_per_cycle:0
 msgid "Capacity per cycle"
-msgstr ""
+msgstr "Capacity per cycle"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_bom.py:54
 #, python-format
 msgid "Changing Routing"
-msgstr ""
+msgstr "Changing Routing"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_bom.py:55
 #, python-format
-msgid ""
-"Changing routing will cause to change the operation in which each component "
-"will be consumed, by default it is set the first one of the routing"
-msgstr ""
+msgid "Changing routing will cause to change the operation in which each component will be consumed, by default it is set the first one of the routing"
+msgstr "Changing routing will cause to change the operation in which each component will be consumed, by default it is set the first one of the routing"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Check Availability"
-msgstr ""
+msgstr "Check Availability"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.operation,code:0
@@ -112,29 +106,36 @@ msgstr "Código"
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_consume_wizard
 msgid "Consume"
-msgstr ""
+msgstr "Consume"
 
 #. module: mrp_operations_extension
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_produce_wizard
 #: selection:mrp.work.order.produce,mode:0
 msgid "Consume & Produce"
-msgstr ""
+msgstr "Consume & Produce"
 
 #. module: mrp_operations_extension
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_consume_wizard
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_produce_wizard
 msgid "Consume Lines"
-msgstr ""
+msgstr "Consume Lines"
 
 #. module: mrp_operations_extension
 #: selection:mrp.work.order.produce,mode:0
 msgid "Consume Only"
-msgstr ""
+msgstr "Consume Only"
 
 #. module: mrp_operations_extension
 #: field:mrp.bom.line,operation:0
 msgid "Consumed in"
-msgstr ""
+msgstr "Consumed in"
+
+#. module: mrp_operations_extension
+#: code:addons/mrp_operations_extension/models/mrp_routing.py:41
+#: field:mrp.routing.workcenter,cost_related:0
+#, python-format
+msgid "Cost per hour"
+msgstr "Coste por hora"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,create_uid:0
@@ -155,17 +156,17 @@ msgstr "Creado en"
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,custom_data:0
 msgid "Custom"
-msgstr ""
+msgstr "Custom"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,default:0
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 #. module: mrp_operations_extension
 #: view:mrp.routing.workcenter:mrp_operations_extension.mrp_routing_workcenter_tree_view_inh
 msgid "Default workcenter"
-msgstr ""
+msgstr "Default workcenter"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.operation,description:0
@@ -183,60 +184,60 @@ msgstr "Nombre mostrado"
 #. module: mrp_operations_extension
 #: view:workcenter.line.finish:mrp_operations_extension.finish_wo_form_view
 msgid "Do all movements"
-msgstr ""
+msgstr "Do all movements"
 
 #. module: mrp_operations_extension
 #: help:mrp.operation.workcenter,time_stop:0
 msgid "Duartion for the cleaning."
-msgstr ""
+msgstr "Duartion for the cleaning."
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Duration"
-msgstr ""
+msgstr "Duration"
 
 #. module: mrp_operations_extension
 #: help:mrp.operation.workcenter,time_cycle:0
 msgid "Duration for one cycle."
-msgstr ""
+msgstr "Duration for one cycle."
 
 #. module: mrp_operations_extension
 #: help:mrp.operation.workcenter,time_start:0
 msgid "Duration for the setup."
-msgstr ""
+msgstr "Duration for the setup."
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,time_efficiency:0
 msgid "Efficiency factor"
-msgstr ""
+msgstr "Efficiency factor"
 
 #. module: mrp_operations_extension
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Extra Information"
-msgstr ""
+msgstr "Extra Information"
 
 #. module: mrp_operations_extension
 #: field:mrp.work.order.produce,final_product:0
 msgid "Final Product to Stock"
-msgstr ""
+msgstr "Final Product to Stock"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_production.py:151
 #, python-format
 msgid "Finish WO"
-msgstr ""
+msgstr "Finish WO"
 
 #. module: mrp_operations_extension
 #: view:workcenter.line.finish:mrp_operations_extension.finish_wo_form_view
 msgid "Finish Work Order"
-msgstr ""
+msgstr "Finish Work Order"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Force Reservation"
-msgstr ""
+msgstr "Force Reservation"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,id:0 field:mrp.routing.operation,id:0
@@ -246,18 +247,13 @@ msgstr "ID"
 
 #. module: mrp_operations_extension
 #: help:mrp.routing.workcenter,do_production:0
-msgid ""
-"If enabled, the production and movement to stock of the final products will "
-"be done in this operation. There can be only one operation per route with "
-"this check marked."
-msgstr ""
+msgid "If enabled, the production and movement to stock of the final products will be done in this operation. There can be only one operation per route with this check marked."
+msgstr "If enabled, the production and movement to stock of the final products will be done in this operation. There can be only one operation per route with this check marked."
 
 #. module: mrp_operations_extension
 #: help:mrp.operation.workcenter,custom_data:0
-msgid ""
-"If you mark this check, this means that the work center in this routing has "
-"different capacity data than the defined on the work center itself"
-msgstr ""
+msgid "If you mark this check, this means that the work center in this routing has different capacity data than the defined on the work center itself"
+msgstr "If you mark this check, this means that the work center in this routing has different capacity data than the defined on the work center itself"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
@@ -297,53 +293,53 @@ msgstr "Lote"
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_operation_workcenter
 msgid "MRP Operation Workcenter"
-msgstr ""
+msgstr "MRP Operation Workcenter"
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_routing_operation
 msgid "MRP Routing Operation"
-msgstr ""
+msgstr "MRP Routing Operation"
 
 #. module: mrp_operations_extension
 #: field:mrp.config.settings,group_mrp_workers:0
 msgid "Manage operators in work centers"
-msgstr ""
+msgstr "Manage operators in work centers"
 
 #. module: mrp_operations_extension
 #: model:res.groups,name:mrp_operations_extension.group_mrp_workers
 msgid "Manufacturing Operators"
-msgstr ""
+msgstr "Manufacturing Operators"
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_production
 msgid "Manufacturing Order"
-msgstr "Orden de fabricación"
+msgstr "Manufacturing Order"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
 msgid "Materials"
-msgstr ""
+msgstr "Materials"
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,is_material_ready:0
 msgid "Materials Ready"
-msgstr ""
+msgstr "Materials Ready"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_production.py:134
 #, python-format
 msgid "Missing materials to start the production"
-msgstr ""
+msgstr "Missing materials to start the production"
 
 #. module: mrp_operations_extension
 #: field:mrp.work.order.produce,mode:0
 msgid "Mode"
-msgstr ""
+msgstr "Mode"
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,move_lines:0
 msgid "Moves"
-msgstr ""
+msgstr "Moves"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.operation,name:0
@@ -352,45 +348,43 @@ msgstr "Nombre"
 
 #. module: mrp_operations_extension
 #: view:mrp.routing.workcenter:mrp_operations_extension.mrp_routing_workcenter_form_view_inh
-msgid ""
-"Once copied, if you change operation data, it won't be reflected here, "
-"unless you select it again."
-msgstr ""
+msgid "Once copied, if you change operation data, it won't be reflected here, unless you select it again."
+msgstr "Once copied, if you change operation data, it won't be reflected here, unless you select it again."
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.workcenter,operation:0
 msgid "Operation"
-msgstr ""
+msgstr "Operation"
 
 #. module: mrp_operations_extension
 #: model:ir.ui.menu,name:mrp_operations_extension.mrp_routing_menu
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_future_calendar
 msgid "Operations"
-msgstr ""
+msgstr "Operations"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,op_avg_cost:0
 #: field:mrp.workcenter,op_avg_cost:0
 msgid "Operator average hourly cost"
-msgstr ""
+msgstr "Operator average hourly cost"
 
 #. module: mrp_operations_extension
 #: view:mrp.workcenter:mrp_operations_extension.mrp_workcenter_form_view_inh
 #: field:mrp.workcenter,operators:0
 msgid "Operators"
-msgstr ""
+msgstr "Operators"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.operation,picking_type_id:0
 #: field:mrp.routing.workcenter,picking_type_id:0
 msgid "Picking Type"
-msgstr ""
+msgstr "Picking Type"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Planned Date"
-msgstr ""
+msgstr "Planned Date"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.workcenter,op_wc_lines:0
@@ -405,23 +399,23 @@ msgstr "Posibles centros de trabajo"
 #. module: mrp_operations_extension
 #: field:mrp.workcenter,post_op_product:0
 msgid "Post-operation costing product"
-msgstr ""
+msgstr "Post-operation costing product"
 
 #. module: mrp_operations_extension
 #: field:mrp.workcenter,pre_op_product:0
 msgid "Pre-operation costing product"
-msgstr ""
+msgstr "Pre-operation costing product"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.workcenter,previous_operations_finished:0
 msgid "Previous operations finished"
-msgstr ""
+msgstr "Previous operations finished"
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_production.py:130
 #, python-format
 msgid "Previous operations not finished"
-msgstr ""
+msgstr "Previous operations not finished"
 
 #. module: mrp_operations_extension
 #: model:ir.actions.act_window,name:mrp_operations_extension.act_mrp_work_order_produce
@@ -430,13 +424,13 @@ msgstr ""
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_consume_wizard
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_produce_wizard
 msgid "Produce"
-msgstr ""
+msgstr "Produce"
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,do_production:0
 #: field:mrp.routing.workcenter,do_production:0
 msgid "Produce here"
-msgstr ""
+msgstr "Produce here"
 
 #. module: mrp_operations_extension
 #: field:mrp.work.order.produce,product_id:0
@@ -448,12 +442,12 @@ msgstr "Product"
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 #: field:mrp.production.workcenter.line,product_line:0
 msgid "Product Lines"
-msgstr ""
+msgstr "Product Lines"
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_product_produce_line
 msgid "Product Produce Consume lines"
-msgstr ""
+msgstr "Product Produce Consume lines"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_view_inh
@@ -464,40 +458,40 @@ msgstr "Producto a producir"
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_production_product_line
 msgid "Production Scheduled Product"
-msgstr ""
+msgstr "Production Scheduled Product"
 
 #. module: mrp_operations_extension
 #: field:mrp.work.order.produce,consume_lines:0
 msgid "Products Consumed"
-msgstr ""
+msgstr "Products Consumed"
 
 #. module: mrp_operations_extension
 #: field:mrp.routing.operation,steps:0
 msgid "Relevant Steps"
-msgstr ""
+msgstr "Relevant Steps"
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_mrp_routing
 msgid "Routing"
-msgstr ""
+msgstr "Routing"
 
 #. module: mrp_operations_extension
 #: model:ir.actions.act_window,name:mrp_operations_extension.mrp_routing_operation_action
 #: view:mrp.routing.operation:mrp_operations_extension.rountig_operation_form
 #: view:mrp.routing.operation:mrp_operations_extension.rountig_operation_tree
 msgid "Routing Operation"
-msgstr ""
+msgstr "Routing Operation"
 
 #. module: mrp_operations_extension
 #: view:mrp.workcenter:mrp_operations_extension.mrp_workcenter_form_view_inh
 #: field:mrp.workcenter,rt_operations:0
 msgid "Routing Operations"
-msgstr ""
+msgstr "Routing Operations"
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,routing_wc_line:0
 msgid "Routing WC Line"
-msgstr ""
+msgstr "Routing WC Line"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,routing_workcenter:0
@@ -507,65 +501,69 @@ msgstr "Centro de trabajo de la ruta"
 #. module: mrp_operations_extension
 #: field:mrp.work.order.produce,product_qty:0
 msgid "Select Quantity"
-msgstr ""
+msgstr "Select Quantity"
 
 #. module: mrp_operations_extension
 #: view:mrp.routing.workcenter:mrp_operations_extension.mrp_routing_workcenter_form_view_inh
 msgid "Select the operation to copy its current data to this routing line."
-msgstr ""
+msgstr "Select the operation to copy its current data to this routing line."
+
+#. module: mrp_operations_extension
+#: help:mrp.routing.workcenter,cost_related:0
+msgid "Specify Cost of Work Center per hour."
+msgstr "Specify Cost of Work Center per hour."
 
 #. module: mrp_operations_extension
 #: model:ir.model,name:mrp_operations_extension.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de stock"
+msgstr "Movimiento de existencias"
 
 #. module: mrp_operations_extension
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "Stock Moves"
-msgstr ""
+msgstr "Stock Moves"
 
 #. module: mrp_operations_extension
 #: view:workcenter.line.finish:mrp_operations_extension.finish_wo_form_view
 msgid "There are still some pending moves on WO"
-msgstr ""
+msgstr "There are still some pending moves on WO"
 
 #. module: mrp_operations_extension
-#: code:addons/mrp_operations_extension/models/mrp_routing.py:43
+#: code:addons/mrp_operations_extension/models/mrp_routing.py:53
 #, python-format
 msgid "There must be one and only one line set as default."
-msgstr ""
+msgstr "There must be one and only one line set as default."
 
 #. module: mrp_operations_extension
 #: code:addons/mrp_operations_extension/models/mrp_routing.py:17
 #, python-format
-msgid ""
-"There must be one and only one operation with 'Produce here' check marked."
-msgstr ""
+msgid "There must be one and only one operation with 'Produce here' check marked."
+msgstr "There must be one and only one operation with 'Produce here' check marked."
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,time_start:0
 msgid "Time Start"
-msgstr ""
+msgstr "Time Start"
 
 #. module: mrp_operations_extension
 #: field:mrp.production.workcenter.line,time_stop:0
 msgid "Time Stop"
-msgstr ""
+msgstr "Time Stop"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,time_stop:0
 msgid "Time after prod."
-msgstr ""
+msgstr "Tiempo después de producción"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,time_start:0
 msgid "Time before prod."
-msgstr ""
+msgstr "Tiempo antes de producción"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,time_cycle:0
 msgid "Time for 1 cycle (hours)"
-msgstr ""
+msgstr "Tiempo para 1 ciclo (horas)"
 
 #. module: mrp_operations_extension
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_consume_wizard
@@ -579,9 +577,23 @@ msgid "Total"
 msgstr "Total"
 
 #. module: mrp_operations_extension
+#: code:addons/mrp_operations_extension/models/mrp_routing.py:44
+#: field:mrp.routing.workcenter,total_costs:0
+#, python-format
+msgid "Total cost per operation"
+msgstr "Coste total por operación"
+
+#. module: mrp_operations_extension
+#: code:addons/mrp_operations_extension/models/mrp_routing.py:38
+#: field:mrp.routing.workcenter,total_hours:0
+#, python-format
+msgid "Total hours per operation in route"
+msgstr "Horas totales de la operación en la ruta"
+
+#. module: mrp_operations_extension
 #: field:mrp.work.order.produce,track_production:0
 msgid "Track production"
-msgstr ""
+msgstr "Seguir producción"
 
 #. module: mrp_operations_extension
 #: view:mrp.routing.workcenter:mrp_operations_extension.mrp_routing_workcenter_form_view_inh
@@ -616,7 +628,7 @@ msgstr "Centros de producción"
 #. module: mrp_operations_extension
 #: field:mrp.product.produce.line,work_produce_id:0
 msgid "Work produce id"
-msgstr ""
+msgstr "Work produce id"
 
 #. module: mrp_operations_extension
 #: field:mrp.operation.workcenter,workcenter:0
@@ -631,19 +643,19 @@ msgstr "Centros de producción"
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 msgid "draft,startworking"
-msgstr ""
+msgstr "draft,startworking"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_form_inherit_view2
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 #: view:mrp.production.workcenter.line:mrp_operations_extension.workcenter_line_inh_form_view
 msgid "object"
-msgstr ""
+msgstr "object"
 
 #. module: mrp_operations_extension
 #: view:mrp.production:mrp_operations_extension.mrp_production_operation_buttons_form_view
 msgid "oe_highlight"
-msgstr ""
+msgstr "oe_highlight"
 
 #. module: mrp_operations_extension
 #: view:mrp.work.order.produce:mrp_operations_extension.view_mrp_product_consume_wizard

--- a/mrp_operations_extension/models/mrp_routing.py
+++ b/mrp_operations_extension/models/mrp_routing.py
@@ -74,7 +74,6 @@ class MrpRoutingWorkcenter(models.Model):
         line = self.op_wc_lines.filtered('default')[:1]
         self.workcenter_id = line.workcenter
         data_source = line if line.custom_data else line.workcenter
-        self.cycle_nbr = data_source.capacity_per_cycle
         self.hour_nbr = data_source.time_cycle
 
 

--- a/mrp_operations_extension/models/mrp_routing.py
+++ b/mrp_operations_extension/models/mrp_routing.py
@@ -35,12 +35,15 @@ class MrpRoutingWorkcenter(models.Model):
     picking_type_id = fields.Many2one('stock.picking.type', 'Picking Type',
                                       domain=[('code', '=', 'outgoing')])
 
-    total_hours = fields.Float('Total hours per operation in route',
-                               compute='_compute_total_hours')
-    cost_related = fields.Float(_('Cost per hour'),
-                                related='workcenter_id.costs_hour')
-    total_costs = fields.Float(_('Total cost per operation'),
-                               compute='_compute_total_cost')
+    total_hours = fields.Float(string=_('Total hours per operation in route'),
+                               compute='_compute_total_hours',
+                               )
+    cost_related = fields.Float(string=_('Cost per hour'),
+                                related='workcenter_id.costs_hour',
+                                )
+    total_costs = fields.Float(string=_('Total cost per operation'),
+                               compute='_compute_total_cost',
+                               )
 
     @api.constrains('op_wc_lines')
     def _check_default_op_wc_lines(self):

--- a/mrp_operations_extension/models/mrp_routing.py
+++ b/mrp_operations_extension/models/mrp_routing.py
@@ -35,6 +35,13 @@ class MrpRoutingWorkcenter(models.Model):
     picking_type_id = fields.Many2one('stock.picking.type', 'Picking Type',
                                       domain=[('code', '=', 'outgoing')])
 
+    total_hours = fields.Float('Total hours per operation in route',
+                               compute='_compute_total_hours')
+    cost_related = fields.Float(_('Cost per hour'),
+                                related='workcenter_id.costs_hour')
+    total_costs = fields.Float(_('Total cost per operation'),
+                               compute='_compute_total_cost')
+
     @api.constrains('op_wc_lines')
     def _check_default_op_wc_lines(self):
         num_default = len(self.op_wc_lines.filtered('default'))
@@ -75,6 +82,22 @@ class MrpRoutingWorkcenter(models.Model):
         self.workcenter_id = line.workcenter
         data_source = line if line.custom_data else line.workcenter
         self.hour_nbr = data_source.time_cycle
+
+    @api.one
+    @api.depends('cycle_nbr', 'hour_nbr')
+    def _compute_total_hours(self):
+        """
+        Change total hours based on cycle_nbr and hour_nbr.
+        """
+        self.total_hours = self.cycle_nbr * self.hour_nbr
+
+    @api.one
+    @api.depends('total_hours', 'cost_related')
+    def _compute_total_cost(self):
+        """
+        Change total hours based on cycle_nbr and hour_nbr.
+        """
+        self.total_costs = self.total_hours * self.cost_related
 
 
 class MrpOperationWorkcenter(models.Model):

--- a/mrp_operations_extension/views/mrp_routing_view.xml
+++ b/mrp_operations_extension/views/mrp_routing_view.xml
@@ -44,7 +44,7 @@
                     <field name="do_production" />
                 </field>
                 <field name="cycle_nbr" position="attributes">
-                    <attribute name="invisible">1</attribute>
+                    <attribute name="invisible">0</attribute>
                 </field>
                 <field name="hour_nbr" position="attributes">
                     <attribute name="invisible">1</attribute>


### PR DESCRIPTION
As mentioned in #159 , the column in the tree view references number of cycles but the onchange method assigns the capacity per cycle, resulting in a confusing output. 

As the field definition in the odoo mrp module states clearly that cycle_nbr is meant for:
Number of iterations this work center has to do in the specified operation of the routing
...and being in need for some counter for cycles when a manufacturing requires repeating an operation multiple times, modified back the onchange_lines_default and also the form view to show the Counter for cycles again. 
