### PR TITLE
8.0 mrp_project: settings to deactivate automatic task generation

### DIFF
--- a/mrp_project/__openerp__.py
+++ b/mrp_project/__openerp__.py
@@ -25,7 +25,8 @@
         "views/project_project_view.xml",
         "views/account_analytic_line_view.xml",
         "views/project_task_view.xml",
-        "views/hr_analytic_timesheet.xml"
+        "views/hr_analytic_timesheet.xml",
+        "views/res_config_view.xml",
     ],
     'installable': True,
     'auto_install': False,

--- a/mrp_project/models/__init__.py
+++ b/mrp_project/models/__init__.py
@@ -9,3 +9,4 @@ from . import project_project
 from . import project_task
 from . import project_task_work
 from . import hr_analytic_timesheet
+from . import res_config

--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -16,10 +16,10 @@ class MrpProduction(models.Model):
         related="project_id.analytic_account_id", store=True)
     create_tasks = fields.Boolean(
         string="Automatically create tasks",
-        help=_(""" Automatically create tasks linked to manufacturing orders in
+        help=""" Automatically create tasks linked to manufacturing orders in
                assigned project. The tasks will be created when the production
                is started.
-               """),
+               """,
         readonly=True,
         states={'draft': [('readonly', False)],
                 'confirmed': [('readonly', False)]
@@ -27,10 +27,10 @@ class MrpProduction(models.Model):
     )
     create_project = fields.Boolean(
         string="Automatically create project if not assigned",
-        help=_("""
+        help="""
                Automatically create and assign a project if none is selected.
                The project will be created when confirming the production order.
-               """),
+               """,
         readonly=True,
         states={'draft': [('readonly', False)]},
     )
@@ -92,7 +92,10 @@ class MrpProduction(models.Model):
             for record in self:
                 task_domain = [
                     ('mrp_production_id', '=', record.id),
-                    ('workorder', '=', False)]
+                    '|',
+                    ('workorder', 'in', record.workcenter_lines),
+                    ('workorder', '=', False),
+                ]
                 tasks = task_obj.search(task_domain)
                 if not tasks:
                     task_obj.create(self._prepare_production_task(record))

--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -14,6 +14,10 @@ class MrpProduction(models.Model):
         readonly=True, states={'draft': [('readonly', False)]})
     analytic_account_id = fields.Many2one(
         related="project_id.analytic_account_id", store=True)
+    create_tasks = fields.Boolean(string="Automatically create tasks")
+    create_project = fields.Boolean(
+        string="Automatically create project if not assigned",
+    )
 
     @api.model
     def _prepare_project_vals(self, production):
@@ -57,6 +61,9 @@ class MrpProduction(models.Model):
 
     @api.multi
     def action_in_production(self):
+        """
+        Look for tasks related to the current MO without a workorder
+        """
         task_obj = self.env['project.task']
         for record in self:
             task_domain = [('mrp_production_id', '=', record.id),

--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -3,7 +3,7 @@
 # (c) 2015 Pedro M. Baeza - Serv. Tecnol. Avanzados
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from openerp import models, fields, api, _
+from openerp import models, fields, api, _, exceptions
 
 
 class MrpProduction(models.Model):
@@ -14,9 +14,25 @@ class MrpProduction(models.Model):
         readonly=True, states={'draft': [('readonly', False)]})
     analytic_account_id = fields.Many2one(
         related="project_id.analytic_account_id", store=True)
-    create_tasks = fields.Boolean(string="Automatically create tasks")
+    create_tasks = fields.Boolean(
+        string="Automatically create tasks",
+        help=_(""" Automatically create tasks linked to manufacturing orders in
+               assigned project. The tasks will be created when the production
+               is started.
+               """),
+        readonly=True,
+        states={'draft': [('readonly', False)],
+                'confirmed': [('readonly', False)]
+                },
+    )
     create_project = fields.Boolean(
         string="Automatically create project if not assigned",
+        help=_("""
+               Automatically create and assign a project if none is selected.
+               The project will be created when confirming the production order.
+               """),
+        readonly=True,
+        states={'draft': [('readonly', False)]},
     )
 
     @api.model
@@ -63,21 +79,35 @@ class MrpProduction(models.Model):
     def action_in_production(self):
         """
         Look for tasks related to the current MO without a workorder
+        and create if create_tasks is set and no results where found.
         """
-        task_obj = self.env['project.task']
-        for record in self:
-            task_domain = [('mrp_production_id', '=', record.id),
-                           ('workorder', '=', False)]
-            tasks = task_obj.search(task_domain)
-            if not tasks:
-                task_obj.create(self._prepare_production_task(record))
+        if not self.project_id:
+            raise exceptions.ValidationError(_(
+                "To create a task per work order, a project must be selected. "
+                "Please select a project or uncheck the field 'Automatically "
+                "create tasks' before starting production (no tasks will be "
+                "created."))
+        if self.create_tasks:
+            task_obj = self.env['project.task']
+            for record in self:
+                task_domain = [
+                    ('mrp_production_id', '=', record.id),
+                    ('workorder', '=', False)]
+                tasks = task_obj.search(task_domain)
+                if not tasks:
+                    task_obj.create(self._prepare_production_task(record))
         return super(MrpProduction, self).action_in_production()
 
     @api.multi
     def action_confirm(self):
+        """
+        When confirming a manufacturing order, if create_project is set
+        and no project is assigned, a new one is created and linked in
+        project_id field.
+        """
         project_obj = self.env['project.project']
         result = super(MrpProduction, self).action_confirm()
-        for production in self:
+        for production in self.filtered('create_project'):
             if not production.project_id:
                 project_vals = self._prepare_project_vals(production)
                 project = project_obj.create(project_vals)

--- a/mrp_project/models/res_config.py
+++ b/mrp_project/models/res_config.py
@@ -2,24 +2,23 @@
 ##############################################################################
 # For copyright and license notices, see __openerp__.py file in root directory
 ##############################################################################
-from openerp import fields, models, _, api
+from openerp import fields, models, api
 
 
 class MrpConfigSettings(models.TransientModel):
     _inherit = 'mrp.config.settings'
     default_create_project = fields.Boolean(
-        string=_("Create projects from manufacturing orders"),
-        help=_("""Automatically create projects from manufacturing orders if a
-                 project is not assigned."""),
+        string="Create projects from manufacturing orders",
+        help="""Automatically create projects from manufacturing orders if a
+                 project is not assigned.""",
         default_model="mrp.production",
                  )
     default_create_tasks = fields.Boolean(
-        string=_("Create tasks for each work order in production"),
-        help=_(""" Automatically create tasks linked to manufacturing orders in
-               assigned project."""),
+        string="Create tasks for each work order in production",
+        help=""" Automatically create tasks linked to manufacturing orders in
+               assigned project.""",
         default_model="mrp.production"
     )
-
 
     def _get_parameter(self, key, default=False):
         param_obj = self.env['ir.config_parameter']
@@ -50,4 +49,3 @@ class MrpConfigSettings(models.TransientModel):
     @api.multi
     def set_parameter_cycle_bom(self):
         self._write_or_create_param('cycle.by.bom', self.cycle_by_bom)
-

--- a/mrp_project/models/res_config.py
+++ b/mrp_project/models/res_config.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+from openerp import fields, models, _, api
+
+
+class MrpConfigSettings(models.TransientModel):
+    _inherit = 'mrp.config.settings'
+    default_create_project = fields.Boolean(
+        string=_("Create projects from manufacturing orders"),
+        help=_("""Automatically create projects from manufacturing orders if a
+                 project is not assigned."""),
+        default_model="mrp.production",
+                 )
+    default_create_tasks = fields.Boolean(
+        string=_("Create tasks for each work order in production"),
+        help=_(""" Automatically create tasks linked to manufacturing orders in
+               assigned project."""),
+        default_model="mrp.production"
+    )
+
+
+    def _get_parameter(self, key, default=False):
+        param_obj = self.env['ir.config_parameter']
+        rec = param_obj.search([('key', '=', key)])
+        return rec or default
+
+    def _write_or_create_param(self, key, value):
+        param_obj = self.env['ir.config_parameter']
+        rec = self._get_parameter(key)
+        if rec:
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
+
+    @api.multi
+    def get_default_create(self, fields):
+        def get_value(key, default=True):
+            rec = self._get_parameter(key)
+            return rec and rec.value or default
+        return {
+            'default_create_project': get_value('default.create.project', True),
+            'default_create_tasks': get_value('default.create.tasks', True),
+        }
+
+    @api.multi
+    def set_parameter_cycle_bom(self):
+        self._write_or_create_param('cycle.by.bom', self.cycle_by_bom)
+

--- a/mrp_project/views/mrp_production_view.xml
+++ b/mrp_project/views/mrp_production_view.xml
@@ -12,6 +12,10 @@
                 <field name="analytic_account_id" position="after">
                     <field name="project_id"/>
                 </field>
+                <field name="allow_reorder" position="after">
+                    <field name="create_project"/>
+                    <field name="create_tasks"/>
+                </field>
             </field>
         </record>
 

--- a/mrp_project/views/res_config_view.xml
+++ b/mrp_project/views/res_config_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="mrp_settings_form_view">
+            <field name="name">mrp.settings.project.form</field>
+            <field name="model">mrp.config.settings</field>
+            <field name="inherit_id" ref="mrp.view_mrp_config" />
+            <field name="arch" type="xml">
+                <xpath expr="//label[@string='Planning']/../div" position="inside">
+                    <div>
+                        <field name="default_create_tasks" class="oe_inline"/>
+                        <label for="default_create_tasks"/>
+                    </div>
+                    <div>
+                        <field name="default_create_project" class="oe_inline"/>
+                        <label for="default_create_project"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This changes add 2 settings in Manufacturing Settings to set default value for 2 Boolean fields in MO.

These fields are the condition checked before creating a related project for the current MO and the Automatically generated tasks when changing states to "In production". 

The default behavior doesn't change the current one. 