### PR TITLE
[8.0][FIX] mrp_operations_extension: Check option "Calc Cycles by BoM…

### DIFF
--- a/mrp_operations_extension/models/res_config.py
+++ b/mrp_operations_extension/models/res_config.py
@@ -30,7 +30,7 @@ class MrpConfigSettings(models.TransientModel):
     def get_default_parameter_cycle_bom(self):
         def get_value(key, default=''):
             rec = self._get_parameter(key)
-            return rec and rec.value or default
+            return rec and rec.value and rec.value != 'False' or default
         return {'cycle_by_bom': get_value('cycle.by.bom', False)}
 
     @api.multi

--- a/mrp_operations_extension/tests/test_mrp_operations_extension.py
+++ b/mrp_operations_extension/tests/test_mrp_operations_extension.py
@@ -239,9 +239,9 @@ class TestMrpOperationsExtension(common.TransactionCase):
         rec.unlink()
         record = wiz_config_obj.new()
         record.set_parameter_cycle_bom()
-        rec = param_obj.search([('key', '=', 'cycle.by.bom')])
-        self.assertEqual(rec.value, 'False', 'Error cycle.by.bom is marked')
+        data = record.get_default_parameter_cycle_bom()
+        self.assertFalse(data['cycle_by_bom'], 'Error cycle.by.bom is marked')
         record.cycle_by_bom = True
         record.set_parameter_cycle_bom()
-        rec = param_obj.search([('key', '=', 'cycle.by.bom')])
-        self.assertEqual(rec.value, 'True', 'Error cycle.by.bom not marked')
+        data = record.get_default_parameter_cycle_bom()
+        self.assertTrue(data['cycle_by_bom'], 'Error cycle.by.bom not marked')


### PR DESCRIPTION
Check option "Calc Cycles by Bom Quantity" does not update correctly.

Comes from here:  #181 - Now 'False' is like True, so set function is not correctly updated.