### PR TITLE
[9.0] mrp_bom_dismantling: remove dependency

### DIFF
--- a/mrp_bom_dismantling/__openerp__.py
+++ b/mrp_bom_dismantling/__openerp__.py
@@ -4,7 +4,7 @@
 {
     "name": "BOM Dismantling",
     "summary": "Ability to create a dismantling BOM by reversing a BOM.",
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "category": "Manufacturing",
     "website": "http://www.camptocamp.com/",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/mrp_bom_dismantling/__openerp__.py
+++ b/mrp_bom_dismantling/__openerp__.py
@@ -13,7 +13,6 @@
     "installable": True,
     "depends": [
         'mrp_byproduct',
-        "stock_available_mrp",
     ],
     "data": [
         "views/mrp_bom.xml",

--- a/mrp_bom_dismantling/models/mrp_bom.py
+++ b/mrp_bom_dismantling/models/mrp_bom.py
@@ -74,7 +74,7 @@ class MrpBom(models.Model):
         self._check_bom_validity(check_dismantling=True)
 
         product = self._get_bom_product()
-        components = self._get_components_needs()
+        components = self._get_component_needs()
 
         # If no main component, take first sorted by Id
         if not main_component:
@@ -143,14 +143,14 @@ class MrpBom(models.Model):
         if warning:
             raise exceptions.UserError(_(warning))
 
-    def _get_components_needs(self):
+    def _get_component_needs(self):
         """ Return this BoM components and their needed qties.
 
         The result is like {component_1: 1, component_2: 5, ...}
 
         :rtype: dict(product_product, float)
         """
-        components = self.product_id._get_components_needs(
+        components = self.product_id._get_component_needs(
             product=self.product_id, bom=self
         )
         return dict(components)

--- a/mrp_bom_dismantling/models/product_product.py
+++ b/mrp_bom_dismantling/models/product_product.py
@@ -20,7 +20,7 @@ class ProductProduct(models.Model):
         result['domain'] = [('dismantling', '=', False)]
         return result
 
-    def _get_components_needs(self, product, bom):
+    def _get_component_needs(self, product, bom):
         """ Return the needed qty of each compoments in the *bom* of *product*.
 
         :type product: product_product

--- a/mrp_bom_dismantling/models/product_product.py
+++ b/mrp_bom_dismantling/models/product_product.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services S.L.
 # © 2016 Cyril Gaudin (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from collections import Counter
 from openerp import models
 
 
@@ -17,3 +19,28 @@ class ProductProduct(models.Model):
         )
         result['domain'] = [('dismantling', '=', False)]
         return result
+
+    def _get_components_needs(self, product, bom):
+        """ Return the needed qty of each compoments in the *bom* of *product*.
+
+        :type product: product_product
+        :type bom: mrp_bom
+        :rtype: collections.Counter
+        """
+        bom_obj = self.env['mrp.bom']
+        uom_obj = self.env['product.uom']
+        product_obj = self.env['product.product']
+        needs = Counter()
+        for bom_component in bom_obj._bom_explode(bom, product, 1.0)[0]:
+            product_uom = uom_obj.browse(bom_component['product_uom'])
+            component = product_obj.browse(bom_component['product_id'])
+
+            component_qty = uom_obj._compute_qty_obj(
+                product_uom,
+                bom_component['product_qty'],
+                component.uom_id,
+            )
+            needs += Counter(
+                {component: component_qty}
+            )
+        return needs

--- a/mrp_bom_dismantling/tests/test_template.py
+++ b/mrp_bom_dismantling/tests/test_template.py
@@ -16,7 +16,7 @@ class TestTemplate(TransactionCase):
         # Create a BoM for this template
         bom_model = self.env['mrp.bom']
         bom_model.create({'product_tmpl_id': tmpl1.id})
-
+        tmpl1._bom_count()
         self.assertEqual(1, tmpl1.bom_count)
 
         # Create a dismantling BoM
@@ -34,9 +34,7 @@ class TestTemplate(TransactionCase):
 
         # Check count on another template
         tmpl2 = tmpl_model.create({'name': 'Template 2'})
-        self.assertEqual(0, tmpl2
-
-                         .bom_count)
+        self.assertEqual(0, tmpl2.bom_count)
 
         # And on dismantled product
         self.assertEqual(0, other_product.product_tmpl_id.bom_count)

--- a/mrp_bom_dismantling/wizards/dismantling_product_choice.py
+++ b/mrp_bom_dismantling/wizards/dismantling_product_choice.py
@@ -28,7 +28,7 @@ class DismantlingProductChoice(models.TransientModel):
         """ Update component_id domain to include only BOM components.
         """
         component_ids = sorted(
-            [c.id for c in self.bom_id._get_components_needs()]
+            [c.id for c in self.bom_id._get_component_needs()]
         )
         if not component_ids:
             raise UserError(_('This BoM does not have components.'))


### PR DESCRIPTION
Little change to remove the dependency in stock_available_mrp of mrp_bom_dismantling as response to discussion in https://github.com/OCA/manufacture/issues/189