### PR TITLE
[FIX] quality_control: Fix TypeError on new test category

### DIFF
--- a/quality_control/models/qc_test_category.py
+++ b/quality_control/models/qc_test_category.py
@@ -9,16 +9,16 @@ class QcTestTemplateCategory(models.Model):
     _name = 'qc.test.category'
     _description = 'Test category'
 
-    @api.one
+    @api.multi
     @api.depends('name', 'parent_id')
     def _get_complete_name(self):
-        if self.name:
-            names = [self.name]
-            parent = self.parent_id
+        for record in self:
+            names = [record.name or '']
+            parent = record.parent_id
             while parent:
                 names.append(parent.name)
                 parent = parent.parent_id
-            self.complete_name = " / ".join(reversed(names))
+            record.complete_name = " / ".join(reversed(names))
 
     @api.constrains('parent_id')
     def _check_recursion(self):

--- a/quality_control/models/qc_test_category.py
+++ b/quality_control/models/qc_test_category.py
@@ -12,7 +12,9 @@ class QcTestTemplateCategory(models.Model):
     @api.one
     @api.depends('name', 'parent_id')
     def _get_complete_name(self):
-        names = [self.name or '']
+        if not self.name:
+            continue
+        names = [self.name]
         parent = self.parent_id
         while parent:
             names.append(parent.name)

--- a/quality_control/models/qc_test_category.py
+++ b/quality_control/models/qc_test_category.py
@@ -12,14 +12,13 @@ class QcTestTemplateCategory(models.Model):
     @api.one
     @api.depends('name', 'parent_id')
     def _get_complete_name(self):
-        if not self.name:
-            continue
-        names = [self.name]
-        parent = self.parent_id
-        while parent:
-            names.append(parent.name)
-            parent = parent.parent_id
-        self.complete_name = " / ".join(reversed(names))
+        if self.name:
+            names = [self.name]
+            parent = self.parent_id
+            while parent:
+                names.append(parent.name)
+                parent = parent.parent_id
+            self.complete_name = " / ".join(reversed(names))
 
     @api.constrains('parent_id')
     def _check_recursion(self):

--- a/quality_control/models/qc_test_category.py
+++ b/quality_control/models/qc_test_category.py
@@ -12,7 +12,7 @@ class QcTestTemplateCategory(models.Model):
     @api.one
     @api.depends('name', 'parent_id')
     def _get_complete_name(self):
-        names = [self.name]
+        names = [self.name or '']
         parent = self.parent_id
         while parent:
             names.append(parent.name)


### PR DESCRIPTION
`TestQualityControl` is failing on `QcTestTemplateCatergory._get_complete_name`
when `name` is set as `False`.