### PR TITLE
[9.0][ADD] mrp_split (WIP)

### DIFF
--- a/mrp_split/README.rst
+++ b/mrp_split/README.rst
@@ -1,0 +1,74 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========
+Mrp Split
+=========
+
+This module extends the functionality of Manufacturing to allow you to split
+existing Manufacturing Order (MO) in *New* or *Awaiting Raw Materials* state.
+The proposed quantity to split will ensure that the originating MO will be
+ready to produce (if possible).
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Manufacturing > Manufacturing Orders*.
+#. Open a Manufacturing Order in state *New* or *Awaiting Raw Materials*.
+#. Click the button *Split MO*.
+#. In the wizard, click on *Compute lines* to get a quantity recommendation to
+   split.
+#. Change the *Quantity to split* if desired and click on *Split* button at
+   the bottom of the form.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/9.0
+
+Known issues / Roadmap
+======================
+
+* Take into account consumable products.
+* Picking direct validation lead to error.
+* Add security group related to splitting MOs?
+* Cancelled stock moves are shown as consumed raw materials.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mrp_split/__init__.py
+++ b/mrp_split/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizards

--- a/mrp_split/__openerp__.py
+++ b/mrp_split/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "MRP split",
+    "summary": "Allows to split MO based on the available quantities.",
+    "version": "9.0.1.0.0",
+    "category": "Manufacturing",
+    "website": "https://odoo-community.org/",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["mrp", "stock_available_unreserved"],
+    "data": [
+        "wizards/mrp_split_view.xml",
+        "views/mrp_production_view.xml",
+    ],
+}

--- a/mrp_split/models/__init__.py
+++ b/mrp_split/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import mrp_production

--- a/mrp_split/models/mrp_production.py
+++ b/mrp_split/models/mrp_production.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    backorder_id = fields.Many2one(
+        comodel_name='mrp.production', string="Backorder of", copy=False)
+    backorder_ids = fields.One2many(
+        comodel_name='mrp.production', inverse_name='backorder_id')

--- a/mrp_split/models/mrp_production.py
+++ b/mrp_split/models/mrp_production.py
@@ -9,6 +9,8 @@ class MrpProduction(models.Model):
     _inherit = 'mrp.production'
 
     backorder_id = fields.Many2one(
-        comodel_name='mrp.production', string="Backorder of", copy=False)
+        comodel_name='mrp.production', string="Backorder of", copy=False,
+        readonly=True)
     backorder_ids = fields.One2many(
-        comodel_name='mrp.production', inverse_name='backorder_id')
+        comodel_name='mrp.production', inverse_name='backorder_id',
+        readonly=True)

--- a/mrp_split/views/mrp_production_view.xml
+++ b/mrp_split/views/mrp_production_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">mrp.production.form - mrp_split</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <button name="action_cancel" position="after">
+                <button name="%(mrp_split_action)d" string="Split MO" type="action"
+                        context="{'default_production_id':active_id}"
+                        states="draft,confirmed"/>
+            </button>
+            <xpath expr="//page[last()]" position="after">
+                <page name="backorder" string="Manufacturing Backorders">
+                    <field name="backorder_ids"/>
+                </page>
+            </xpath>
+            <field name="origin" position="after">
+                <field name="backorder_id"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>
+
+<!-- TODO ? <button groups="mrp.some_group"/> ???-->

--- a/mrp_split/wizards/__init__.py
+++ b/mrp_split/wizards/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import mrp_split

--- a/mrp_split/wizards/mrp_split.py
+++ b/mrp_split/wizards/mrp_split.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, fields, models
+import openerp.addons.decimal_precision as dp
+
+
+class MrpSplit(models.TransientModel):
+    _name = "mrp.split"
+    _description = "Wizard to split MOs."
+
+    @api.multi
+    def compute_product_line_ids(self):
+        self.product_line_ids.unlink()
+        self.production_id.action_compute()
+        for pl in self.production_id.product_lines:
+            vals = self._prepare_product_line(pl)
+            self.env['mrp.split.product.line'].create(vals)
+        self._get_split_qty()
+        return {"type": "ir.actions.do_nothing"}
+
+    @api.one
+    def _get_split_qty(self):
+        """Propose a split qty to split the MO into two with one totally
+        available to produce."""
+        bottle_neck = min(self.product_line_ids.mapped('bottle_neck_factor'))
+        bottle_neck = max(min(1, bottle_neck), 0)
+        self.split_qty = self.production_qty * bottle_neck
+
+    production_id = fields.Many2one(
+        comodel_name='mrp.production', string='Manufacturing Order',
+        readonly=True)
+    production_qty = fields.Float(
+        related='production_id.product_qty', readonly=True,
+        string="Original Quantity")
+    bom_id = fields.Many2one(related='production_id.bom_id', readonly=True)
+    product_line_ids = fields.One2many(
+        comodel_name='mrp.split.product.line', string='Products needed',
+        inverse_name='mrp_split_id', readonly=True)
+    split_qty = fields.Float(
+        string='Quantity to split')
+
+    def _prepare_product_line(self, pl):
+        return {
+            'product_id': pl.product_id.id,
+            'product_qty': pl.product_qty,
+            'product_uom': pl.product_uom.id,
+            'mrp_split_id': self.id,
+            'location_id': self.production_id.location_src_id.id,
+        }
+
+    @api.multi
+    def do_split(self):
+        # TODO: add constrains
+        res = self._do_split()
+        return res
+
+    @api.multi
+    def _do_split(self):
+        self.ensure_one()
+        original_qty = self.production_id.product_qty
+        self.production_id.write({'product_qty': self.split_qty})
+        self.production_id.action_compute()
+        if self.production_id.state == 'confirmed':
+            # Cancel moves related to product to consume to propagate to the
+            # procurement (in case we use module mrp_mto_with_stock.
+            self.production_id.move_lines.action_cancel()
+            # Delete moves related to products to produce to not propagete
+            # the cancel to pickings.
+            self.production_id.move_created_ids.write({'state': 'draft'})
+            self.production_id.move_created_ids.unlink()
+            self.production_id.product_lines.unlink()
+            self.production_id.with_context(
+                default_production_id=False).action_confirm()
+        backorder = self.production_id.copy()
+        backorder.write({
+            'product_qty': original_qty - self.split_qty,
+            'backorder_id': self.production_id.id,
+            'move_prod_id': self.production_id.move_prod_id.id,
+        })
+        if self.production_id.state == 'confirmed':
+            # If originating MO was confirmed confirm the new on to ensure
+            # that move_prod_id is still fulfilled with the whole original qty.
+            backorder.action_confirm()
+        # Open resulting MOs
+        ids = [self.production_id.id, backorder.id]
+        action = self.env.ref('mrp.mrp_production_action').read()[0]
+        action.update({'domain': [('id', 'in', ids)]})
+        return action
+
+
+class MrpSplitLine(models.TransientModel):
+    _name = "mrp.split.product.line"
+
+    @api.one
+    def _compute_available_qty(self):
+        product_available = self.product_id.with_context(
+            location=self.location_id.id)._product_available()[
+            self.product_id.id]['qty_available_not_res']
+        res = self.product_uom._compute_qty(
+            self.product_id.product_tmpl_id.uom_id.id, product_available,
+            self.product_uom.id)
+        self.available_qty = res
+
+    @api.one
+    def _compute_bottle_neck_factor(self):
+        if self.product_qty:
+            self.bottle_neck_factor = self.available_qty / self.product_qty
+
+    product_id = fields.Many2one(
+        comodel_name='product.product', string='Product', required=True)
+    product_qty = fields.Float(
+        string='Quantity Required', required=True,
+        digits_compute=dp.get_precision('Product Unit of Measure'))
+    product_uom = fields.Many2one(
+        comodel_name='product.uom', string='UoM', required=True)
+    mrp_split_id = fields.Many2one(comodel_name='mrp.split')
+    available_qty = fields.Float(
+        string='Quantity Available', compute=_compute_available_qty,
+        digits_compute=dp.get_precision('Product Unit of Measure'))
+    bottle_neck_factor = fields.Float(compute=_compute_bottle_neck_factor)
+    location_id = fields.Many2one(comodel_name='stock.location', required=True)

--- a/mrp_split/wizards/mrp_split_view.xml
+++ b/mrp_split/wizards/mrp_split_view.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="mrp_split_view" model="ir.ui.view">
+        <field name="name">mrp.split.form</field>
+        <field name="model">mrp.split</field>
+        <field name="arch" type="xml">
+            <form string="Select event to register">
+                <group name="origin" string="Original Manufacturing Order"
+                       col="6">
+                    <group colspan="2">
+                        <field name="production_id" options='{"no_open": True}'/>
+                        <field name="production_qty"/>
+                        <button name="compute_product_line_ids" type="object"
+                                string="Compute lines" colspan="2" icon="fa-cogs"/>
+                    </group>
+                    <group colspan="4">
+                        <field name="product_line_ids" nolabel="1">
+                            <tree>
+                                <field name="product_id"/>
+                                <field name="product_uom"/>
+                                <field name="product_qty"/>
+                                <field name="available_qty"/>
+                                <field name="bottle_neck_factor"/>
+                            </tree>
+                        </field>
+                    </group>
+                </group>
+                <group name="destination" string="Splitting Aim:">
+                    <field name="split_qty"/>
+                </group>
+
+                <footer>
+                    <button name="do_split"
+                            type="object"
+                            string="Split"
+                            class="oe_highlight"/>
+                    or
+                    <button special="cancel"
+                            string="Cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="mrp_split_action" model="ir.actions.act_window">
+        <field name="name">Split Manufacturing Order</field>
+        <field name="res_model">mrp.split</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Responds to issue https://github.com/OCA/manufacture/issues/206

This is still a WIP and there are some points to improve/discuss (maybe more):
* [ ] Take into account consumable products.
* [ ] Picking direct validation lead to error. 

To reproduce this, follow these steps for instance:
1. In the manufacture route add a procurement rule to feed a location A with location Stock.
2. Create a procurement for location A of a manufactured product (MP) this will create a MO1 for MP and a picking from stock to location A.
3. Split MO1 and produce both, MO1 and new MO2.
4. Go to the picking created previously.
5. A) If you modify the the "Done" qty with all the "To Do" qty and click on validate you will be asked to create a backorder (with the qty in MO2).
5. B) If you click in validate and accept the immediate transfer you won't create a backorder and the MO2 is stuck. 

* [ ] Add security group related to splitting MOs?
* [ ] Cancelled stock moves are shown as consumed raw materials. This will require to modify a standard field, not sure if it is the good call.
![image](https://user-images.githubusercontent.com/23449160/26928429-5f0e8c52-4c56-11e7-8706-126742afb18d.png)


