### PR TITLE
[9.0][ADD] mrp_disable_force_availability_button

### DIFF
--- a/mrp_disable_force_availability_button/README.rst
+++ b/mrp_disable_force_availability_button/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================================
+MRP Disable Force Availability Button
+=====================================
+
+This module creates a security group that limits the visibility of "Force
+availability" button on manufacture order to those that belong to
+this group.
+
+Usage
+=====
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/9.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/manufacture/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mrp_disable_force_availability_button/__init__.py
+++ b/mrp_disable_force_availability_button/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/mrp_disable_force_availability_button/__openerp__.py
+++ b/mrp_disable_force_availability_button/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "MRP Disable force availability button",
+    "version": "9.0.1.0.0",
+    "summary": "Disable force availability button in manufacturing orders.",
+    "author": "Eficent"
+              "Odoo Community Association (OCA),",
+    "website": "http://www.odoomrp.com",
+    "category": "Manufacturing",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["mrp"],
+    "data": [
+        "security/mrp_disable_force_availability_button_security.xml",
+        "views/mrp_operation_view.xml",
+    ],
+}

--- a/mrp_disable_force_availability_button/security/mrp_disable_force_availability_button_security.xml
+++ b/mrp_disable_force_availability_button/security/mrp_disable_force_availability_button_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo noupdate="1">
+    
+    <record id="mrp.group_mrp_force_availability" model="res.groups">
+        <field name="name">Allow to force availability on 
+            Manufacturing Orders</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+    </record>
+    
+</odoo>

--- a/mrp_disable_force_availability_button/views/mrp_operation_view.xml
+++ b/mrp_disable_force_availability_button/views/mrp_operation_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+
+    <record model="ir.ui.view" id="mrp_production_form_view">
+        <field name="name">mrp.production - mrp_disable_force_availability_button</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+        <field name="arch" type="xml">
+            <button name="force_production" position="attributes">
+                <attribute name="groups">mrp.group_mrp_force_availability</attribute>
+            </button>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
MRP Disable Force Availability Button
===============================

This module creates a security group that limits the visibility of "Force
availability" button on manufacture order to those that belong to
this group.