### PR TITLE
[10.0] Add mrp_progress_button

### DIFF
--- a/mrp_progress_button/README.rst
+++ b/mrp_progress_button/README.rst
@@ -1,0 +1,60 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+MRP Progress Button
+===================
+
+Simple module that add a button on MO to mark the Manufacturing Order to 
+*In Progress* state. This module is usefull only when you do not use routing and
+operations. Indeed, the *In Progress* state is automatically put when the
+first operation is started.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to *Manufacturing* and create a Manufacturing Order.
+#. Click on *Mark As Started* button
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/manufacture/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Florian da Costa <florian.dacosta@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mrp_progress_button/__init__.py
+++ b/mrp_progress_button/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/mrp_progress_button/__manifest__.py
+++ b/mrp_progress_button/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Mrp Progress Button",
+    "summary": "Add a button on MO to make the MO state 'In Progress'",
+    "author": "Akretion, Odoo Community Association (OCA)",
+    "website": "https://akretion.com/",
+    "category": "Manufacturing",
+    "version": "10.0.1.0.0",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["mrp"],
+    "data": ["views/production.xml"],
+}

--- a/mrp_progress_button/models/__init__.py
+++ b/mrp_progress_button/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import mrp_production

--- a/mrp_progress_button/models/mrp_production.py
+++ b/mrp_progress_button/models/mrp_production.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime
+from odoo import api, models
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    @api.multi
+    def action_progress(self):
+        self.write({
+            'state': 'progress',
+            'date_start': datetime.now(),
+        })
+        return True

--- a/mrp_progress_button/tests/__init__.py
+++ b/mrp_progress_button/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_progress_button

--- a/mrp_progress_button/tests/test_progress_button.py
+++ b/mrp_progress_button/tests/test_progress_button.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2017 Akretion (http://www.akretion.com). All Rights Reserved
+# @author Florian DA COSTA <florian.dacosta@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProgressButton(TransactionCase):
+
+    def setUp(self, *args, **kwargs):
+        super(TestProgressButton, self).setUp(*args, **kwargs)
+        self.production_model = self.env['mrp.production']
+        self.bom_model = self.env['mrp.bom']
+        self.stock_location_stock = self.env.ref('stock.stock_location_stock')
+        self.manufacture_route = self.env.ref(
+            'mrp.route_warehouse0_manufacture')
+        self.uom_unit = self.env.ref('product.product_uom_unit')
+
+        self.product_manuf = self.env['product.product'].create({
+            'name': 'Manuf',
+            'type': 'product',
+            'uom_id': self.uom_unit.id,
+            'route_ids': [(4, self.manufacture_route.id)]
+        })
+        self.product_raw_material = self.env['product.product'].create({
+            'name': 'Raw Material',
+            'type': 'product',
+            'uom_id': self.uom_unit.id,
+        })
+
+        self._update_product_qty(self.product_raw_material,
+                                 self.stock_location_stock, 1)
+
+        self.bom = self.env['mrp.bom'].create({
+            'product_id': self.product_manuf.id,
+            'product_tmpl_id': self.product_manuf.product_tmpl_id.id,
+            'bom_line_ids': ([
+                (0, 0, {
+                    'product_id': self.product_raw_material.id,
+                    'product_qty': 1,
+                    'product_uom_id': self.uom_unit.id
+                }),
+            ])
+        })
+
+    def _update_product_qty(self, product, location, quantity):
+        """Update Product quantity."""
+        product_qty = self.env['stock.change.product.qty'].create({
+            'location_id': location.id,
+            'product_id': product.id,
+            'new_quantity': quantity,
+        })
+        product_qty.change_product_qty()
+        return product_qty
+
+    def test_manufacture_with_forecast_stock(self):
+        """
+            Test Manufacture mto with stock based on forecast quantity
+            and no link between sub assemblies MO's and Main MO raw material
+        """
+
+        production = self.production_model.create({
+            'product_id': self.product_manuf.id,
+            'product_qty': 1,
+            'product_uom_id': self.uom_unit.id,
+            'bom_id': self.bom.id
+        })
+        production.action_progress()
+        self.assertEqual(production.state, 'progress')

--- a/mrp_progress_button/views/production.xml
+++ b/mrp_progress_button/views/production.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<odoo>
+
+        <record id="mrp_production_progress_button_form_view" model="ir.ui.view">
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+            <field name="arch" type="xml">
+                <button name="action_assign" position="after">
+                    <button name="action_progress" attrs="{'invisible': ['|', ('state', '!=', 'confirmed'), ('routing_id', '!=', False)]}"
+                            type="object" string="Mark As Started" class="oe_highlight"/>
+                </button>
+            </field>
+        </record>
+
+</odoo>


### PR DESCRIPTION
Small module that ad a 'Mark As started' button on MOs.
The button is only visible if there are no routing linked to the MO, because if you use routing, then you can plan the MO and start workorders, which already do the same.