### PR TITLE
[ADD] procurement_service_timesheet

### DIFF
--- a/procurement_service_timesheet/README.rst
+++ b/procurement_service_timesheet/README.rst
@@ -1,0 +1,59 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=============================
+Procurement service timesheet
+=============================
+
+This module allows the sale_timesheet module to create a project and a task
+when a properly configured product is sold.
+The product must be configured as follows:
+* Type: service
+* Inventory rules: Buy, Make to order (see procurement_service configuration)
+* Invoicing: Create task
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/129/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/manufacture/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Simone Rubino <simone.rubino@agilebg.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/procurement_service_timesheet/__init__.py
+++ b/procurement_service_timesheet/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/procurement_service_timesheet/__manifest__.py
+++ b/procurement_service_timesheet/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Procurement service timesheet",
+    "version": "10.0.1.0.0",
+    "category": "Procurements",
+    "website": "https://github.com/OCA/manufacture/"
+               "tree/10.0/procurement_service_timesheet",
+    "author": "Simone Rubino, Agile Business Group, "
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto-install": True,
+    "depends": [
+        "procurement_service",
+        "sale_timesheet"
+    ]
+}

--- a/procurement_service_timesheet/models/__init__.py
+++ b/procurement_service_timesheet/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import procurement_order

--- a/procurement_service_timesheet/models/procurement_order.py
+++ b/procurement_service_timesheet/models/procurement_order.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import models, api
+from odoo.addons.purchase.models.purchase import \
+    ProcurementOrder as PurchaseProcurementOrder
+
+
+class ProcurementOrder(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.multi
+    def _run(self):
+        if self._is_procurement_service() and self._is_procurement_task():
+            self.make_po()
+            # Call super in order to create the task
+            return super(PurchaseProcurementOrder, self)._run()
+        return super(ProcurementOrder, self)._run()

--- a/procurement_service_timesheet/tests/__init__.py
+++ b/procurement_service_timesheet/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_procurement_order

--- a/procurement_service_timesheet/tests/test_procurement_order.py
+++ b/procurement_service_timesheet/tests/test_procurement_order.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProcurementOrder(TransactionCase):
+    def setUp(self, *args, **kwargs):
+        super(TestProcurementOrder, self).setUp()
+        self.product_model = self.env['product.product']
+        self.partner_model = self.env['res.partner']
+        self.sale_model = self.env['sale.order']
+        self.project_task_model = self.env['project.task']
+
+        service_product_vals = {
+            'name': 'Service Generated Procurement',
+            'standard_price': 20.5,
+            'list_price': 30.75,
+            'type': 'service',
+            'route_ids': [(6, 0,
+                           [self.env.ref('stock.route_warehouse0_mto').id,
+                            self.env.ref('purchase.route_warehouse0_buy').id
+                            ])]}
+        seller_vals = {'name': self.env.ref('base.res_partner_2').id}
+        service_product_vals['seller_ids'] = [(0, 0, seller_vals)]
+        self.service_product = \
+            self.product_model.create(service_product_vals)
+
+        partner_vals = {'name': 'Customer for procurement service',
+                        'customer': True}
+        self.partner = self.partner_model.create(partner_vals)
+        service_sale_vals = {
+            'partner_id': self.partner.id,
+            'partner_shipping_id': self.partner.id,
+            'partner_invoice_id': self.partner.id,
+            'pricelist_id': self.env.ref('product.list0').id,
+            'picking_policy': 'direct'}
+        service_sale_line_vals = {
+            'product_id': self.service_product.id,
+            'name': self.service_product.name,
+            'product_uom_qty': 1,
+            'product_uom': self.service_product.uom_id.id,
+            'price_unit': self.service_product.list_price}
+        service_sale_vals['order_line'] = [(0, 0, service_sale_line_vals)]
+        self.service_sale_order = \
+            self.sale_model.create(service_sale_vals.copy())
+
+    def test_create_project_and_task(self):
+        self.service_sale_order.action_confirm()
+        for line in self.service_sale_order.order_line:
+            cond = [('sale_line_id', '=', line.id)]
+            tasks = self.project_task_model.search(cond)
+            self.assertGreater(len(tasks), 0, "Task not created")


### PR DESCRIPTION
Hi,
I am adding this module to restore the classical behaviour of service products with "create task" option: when a sale order containing a service is confirmed, a new project&task is created.
This behaviour is broken if you install the module in #228 as is.
Please check