### PR TITLE
[10.0][FIX] mrp_production_request: issue propagating context to undesired places

### DIFF
--- a/mrp_production_request/tests/test_mrp_production_request.py
+++ b/mrp_production_request/tests/test_mrp_production_request.py
@@ -51,9 +51,7 @@ class TestMrpProductionRequest(TransactionCase):
         request.button_to_approve()
         request.button_approved()
         self.assertEqual(request.pending_qty, 4.0)
-        wiz = self.wiz_model.create({
-            'mrp_production_request_id': request.id,
-        })
+        wiz = self.wiz_model.with_context(active_ids=request.ids).create({})
         wiz.compute_product_line_ids()
         wiz.mo_qty = 4.0
         wiz.create_mo()
@@ -68,9 +66,7 @@ class TestMrpProductionRequest(TransactionCase):
         request and not from manufacturing order."""
         proc = self.create_procurement('TEST/02', self.product)
         request = proc.mrp_production_request_id
-        wiz = self.wiz_model.create({
-            'mrp_production_request_id': request.id,
-        })
+        wiz = self.wiz_model.with_context(active_ids=request.ids).create({})
         wiz.mo_qty = 4.0
         wiz.create_mo()
         with self.assertRaises(UserError):

--- a/mrp_production_request/views/mrp_production_request_view.xml
+++ b/mrp_production_request/views/mrp_production_request_view.xml
@@ -21,7 +21,6 @@
                         string="Approve" type="object" class="oe_highlight"
                         groups="mrp_production_request.group_mrp_production_request_manager"/>
                 <button name="%(mrp_production_request_create_mo_action)d"
-                        context="{'default_mrp_production_request_id':active_id}"
                         states="approved"
                         string="Create Manufacturing Order" type="action"/>
                 <button name="button_done" states="approved"

--- a/mrp_production_request/wizards/mrp_production_request_create_mo.py
+++ b/mrp_production_request/wizards/mrp_production_request_create_mo.py
@@ -2,8 +2,9 @@
 # Copyright 2017-18 Eficent Business and IT Consulting Services S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 import odoo.addons.decimal_precision as dp
+from odoo.exceptions import UserError
 
 
 class MrpProductionRequestCreateMo(models.TransientModel):
@@ -58,6 +59,17 @@ class MrpProductionRequestCreateMo(models.TransientModel):
         comodel_name="mrp.production.request.create.mo.line",
         string="Products needed",
         inverse_name="mrp_production_request_create_mo_id", readonly=True)
+
+    @api.model
+    def default_get(self, fields):
+        rec = super(MrpProductionRequestCreateMo, self).default_get(fields)
+        active_ids = self._context.get('active_ids')
+        if not active_ids:
+            raise UserError(_(
+                "Programming error: wizard action executed without "
+                "active_ids in context."))
+        rec['mrp_production_request_id'] = active_ids[0]
+        return rec
 
     def _prepare_product_line(self, pl):
         return {


### PR DESCRIPTION
The context was causing issues when using manufacturing requests in conjuctions with mrp_mto_with_stock and mrp_auto_assign. The subsequent MOs created as for the need of the original MO created from the MR were being crated with a wrong `mrp_production_request_id`.

Using `default_get` instead of a context to pass the active MR solves the problem.