### PR TITLE
[10.0][FIX] mrp_production_request: do not allow to add MOs manually.

### DIFF
--- a/mrp_production_request/models/mrp_production_request.py
+++ b/mrp_production_request/models/mrp_production_request.py
@@ -99,7 +99,7 @@ class MrpProductionRequest(models.Model):
         required=True, default=_company_get)
     mrp_production_ids = fields.One2many(
         comodel_name="mrp.production", string="Manufacturing Orders",
-        inverse_name="mrp_production_request_id")
+        inverse_name="mrp_production_request_id", readonly=True)
     state = fields.Selection(
         selection=[("draft", "Draft"),
                    ("to_approve", "To Be Approved"),


### PR DESCRIPTION
When creating a MR manually the "add an item" button on the Manufacturing Order tab was genereting some confusion. It is definitely meant to not be used, thus made readonly.