### PR TITLE
[11.0][FIX][mrp_production_grouped_by_product]

### DIFF
--- a/mrp_production_grouped_by_product/tests/test_mrp_production_grouped_by_product.py
+++ b/mrp_production_grouped_by_product/tests/test_mrp_production_grouped_by_product.py
@@ -70,6 +70,7 @@ class TestProductionGroupedByProduct(common.SavepointCase):
             'procure_method': 'make_to_order',
             'warehouse_id': cls.warehouse.id,
             'date': '2018-06-01 18:00:00',
+            'date_expected': '2018-06-01 18:00:00',
         })
 
     def test_mo_by_product(self):
@@ -85,7 +86,9 @@ class TestProductionGroupedByProduct(common.SavepointCase):
         self.assertEqual(mo.product_qty, 12)
 
     def test_mo_other_date(self):
-        self.move.date = '2018-06-01 20:01:00'
+        self.move.write(
+            {'date_expected': '2018-06-01 20:01:00',
+             'date': '2018-06-01 20:01:00'})
         self.move.with_context(test_group_mo=True)._action_confirm(merge=False)
         self.ProcurementGroup.with_context(test_group_mo=True).run_scheduler()
         mo = self.MrpProduction.search([('product_id', '=', self.product1.id)])


### PR DESCRIPTION
Fixes error in module  mrp_production_grouped_by_product due to the recent introduction of https://github.com/odoo/odoo/commit/70ddff760ff23e960028dbc2cacc630da5b185fc