### PR TITLE
[11.0][FIX] mrp_multi_level: locale issue

### DIFF
--- a/mrp_multi_level/__manifest__.py
+++ b/mrp_multi_level/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': 'MRP Multi Level',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'development_status': 'Beta',
     'license': 'AGPL-3',
     'author': 'Ucamco, '

--- a/mrp_multi_level/data/mrp_area_data.xml
+++ b/mrp_multi_level/data/mrp_area_data.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
+
     <record id="mrp_area_stock_wh0" model="mrp.area">
         <field name="name">WH/Stock</field>
         <field name="warehouse_id" ref="stock.warehouse0"/>
         <field name="location_id" ref="stock.stock_location_stock"/>
-        <field name="calendar_id" ref="resource.resource_calendar_std"/>
     </record>
+
 </odoo>

--- a/mrp_multi_level/models/mrp_area.py
+++ b/mrp_multi_level/models/mrp_area.py
@@ -19,5 +19,8 @@ class MrpArea(models.Model):
         required=True,
     )
     active = fields.Boolean(default=True)
-    calendar_id = fields.Many2one('resource.calendar',
-                                  'Working Hours')
+    calendar_id = fields.Many2one(
+        comodel_name='resource.calendar',
+        string='Working Hours',
+        related='warehouse_id.calendar_id',
+    )

--- a/mrp_multi_level/readme/HISTORY.rst
+++ b/mrp_multi_level/readme/HISTORY.rst
@@ -1,0 +1,10 @@
+11.0.1.0.1 (2018-08-03)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [FIX] User and system locales doesn't break MRP calculation.
+  (`#290 <https://github.com/OCA/manufacture/pull/290>`_)
+
+11.0.1.0.0 (2018-07-09)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Start of the history.

--- a/mrp_multi_level/readme/HISTORY.rst
+++ b/mrp_multi_level/readme/HISTORY.rst
@@ -3,6 +3,9 @@
 
 * [FIX] User and system locales doesn't break MRP calculation.
   (`#290 <https://github.com/OCA/manufacture/pull/290>`_)
+* [FIX] Working Hours are now defined only at Warehouse level and displayed
+  as a related on MRP Areas.
+  (`#290 <https://github.com/OCA/manufacture/pull/290>`__)
 
 11.0.1.0.0 (2018-07-09)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -38,6 +38,8 @@ class TestMrpMultiLevel(SavepointCase):
         cls.customer_location = cls.env.ref(
             'stock.stock_location_customers')
         cls.calendar = cls.env.ref('resource.resource_calendar_std')
+        # Add calendar to WH:
+        cls.wh.calendar_id = cls.calendar
 
         # Partner:
         vendor1 = cls.partner_obj.create({'name': 'Vendor 1'})
@@ -367,9 +369,8 @@ class TestMrpMultiLevel(SavepointCase):
             ('product_id', '=', self.fp_1.id)])
         self.assertTrue(mos)
         self.assertEqual(mos.product_qty, 100.0)
-        datetime_5 = fields.Datetime.to_string(
-            self.calendar.plan_days(5 + 1, datetime.today()).date())
-        self.assertEqual(mos.date_planned_start, datetime_5)
+        mo_date_start = mos.date_planned_start.split(' ')[0]
+        self.assertEqual(mo_date_start, self.date_5)
 
     # TODO: test procure wizard: pos, multiple...
     # TODO: test multiple destination IDS:...

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -274,11 +274,7 @@ class MultiLevelMrp(models.TransientModel):
                                 mrp_date_demand_2,
                                 bom, name)
                         mrpmove_id2 = self.env['mrp.move'].create(move_data)
-                        sql_stat = "INSERT INTO mrp_move_rel (" \
-                                   "move_up_id, " \
-                                   "move_down_id) values (%d, %d)" % \
-                                   (mrpmove_id, mrpmove_id2, )
-                        self.env.cr.execute(sql_stat)
+                        mrpmove_id.mrp_move_down_ids = [(4, mrpmove_id2.id)]
         values['qty_ordered'] = qty_ordered
         log_msg = '%s' % qty_ordered
         logger.info(log_msg)

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, exceptions, _
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 from datetime import date, datetime, timedelta
+import locale
 import logging
 
 logger = logging.getLogger(__name__)
@@ -638,10 +639,24 @@ class MultiLevelMrp(models.TransientModel):
         logger.info('END MRP CALCULATION')
 
     @api.model
+    def _convert_group_date_to_default(self, group_date):
+        """Odoo read_group time format include the month as locale’s
+        abbreviated name (%b). Using 'en_GB' as common language for read_group
+        calls and this conversion avoids possible issues with locales."""
+        lc = locale.setlocale(locale.LC_TIME)
+        try:
+            locale.setlocale(locale.LC_TIME, 'en_GB.UTF-8')
+            return datetime.strptime(
+                group_date, ODOO_READ_GROUP_DAY_FORMAT).strftime(
+                DEFAULT_SERVER_DATE_FORMAT)
+        finally:
+            locale.setlocale(locale.LC_TIME, lc)
+
+    @api.model
     def _init_mrp_inventory(self, mrp_product):
         mrp_move_obj = self.env['mrp.move']
         # Read Demand
-        demand_groups = mrp_move_obj.read_group(
+        demand_groups = mrp_move_obj.with_context(lang='en_GB').read_group(
             [('mrp_product_id', '=', mrp_product.id),
              ('mrp_type', '=', 'd')],
             ['mrp_date', 'mrp_qty'], ['mrp_date:day'],
@@ -649,13 +664,12 @@ class MultiLevelMrp(models.TransientModel):
         demand_qty_by_date = {}
         for group in demand_groups:
             # Reformat date back to default server format.
-            group_date = datetime.strptime(
-                group['mrp_date:day'], ODOO_READ_GROUP_DAY_FORMAT).strftime(
-                DEFAULT_SERVER_DATE_FORMAT)
+            group_date = self._convert_group_date_to_default(
+                group['mrp_date:day'])
             demand_qty_by_date[group_date] = group['mrp_qty']
 
         # Read Supply
-        supply_groups = mrp_move_obj.read_group(
+        supply_groups = mrp_move_obj.with_context(lang='en_GB').read_group(
             [('mrp_product_id', '=', mrp_product.id),
              ('mrp_type', '=', 's'),
              ('mrp_action', '=', 'none')],
@@ -664,16 +678,15 @@ class MultiLevelMrp(models.TransientModel):
         supply_qty_by_date = {}
         for group in supply_groups:
             # Reformat date back to default server format.
-            group_date = datetime.strptime(
-                group['mrp_date:day'], ODOO_READ_GROUP_DAY_FORMAT).strftime(
-                DEFAULT_SERVER_DATE_FORMAT)
+            group_date = self._convert_group_date_to_default(
+                group['mrp_date:day'])
             supply_qty_by_date[group_date] = group['mrp_qty']
 
         # Read supply actions
         # TODO: if we remove cancel take it into account here,
         # TODO: as well as mrp_type ('r').
         exclude_mrp_actions = ['none', 'cancel']
-        action_groups = mrp_move_obj.read_group(
+        action_groups = mrp_move_obj.with_context(lang='en_GB').read_group(
             [('mrp_product_id', '=', mrp_product.id),
              ('mrp_qty', '!=', 0.0),
              ('mrp_type', '=', 's'),
@@ -683,9 +696,8 @@ class MultiLevelMrp(models.TransientModel):
         supply_actions_qty_by_date = {}
         for group in action_groups:
             # Reformat date back to default server format.
-            group_date = datetime.strptime(
-                group['mrp_date:day'], ODOO_READ_GROUP_DAY_FORMAT).strftime(
-                DEFAULT_SERVER_DATE_FORMAT)
+            group_date = self._convert_group_date_to_default(
+                group['mrp_date:day'])
             supply_actions_qty_by_date[group_date] = group['mrp_qty']
 
         # Dates


### PR DESCRIPTION
The user and system locales could make the MRP run break because of differences in month locale’s abbreviated name.