### PR TITLE
[FIX] count_inspections methods should be able to manage recordsets

### DIFF
--- a/quality_control_stock/__manifest__.py
+++ b/quality_control_stock/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Quality control - Stock",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "category": "Quality control",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/quality_control_stock/models/qc_inspection.py
+++ b/quality_control_stock/models/qc_inspection.py
@@ -11,7 +11,7 @@ class QcInspection(models.Model):
 
     @api.multi
     @api.depends('object_id')
-    def get_picking(self):
+    def _compute_picking(self):
         for inspection in self:
             inspection.picking = False
             if inspection.object_id:
@@ -24,7 +24,7 @@ class QcInspection(models.Model):
 
     @api.multi
     @api.depends('object_id')
-    def get_lot(self):
+    def _compute_lot(self):
         for inspection in self:
             inspection.lot = False
             if inspection.object_id:
@@ -70,9 +70,10 @@ class QcInspection(models.Model):
         return res
 
     picking = fields.Many2one(
-        comodel_name="stock.picking", compute="get_picking", store=True)
+        comodel_name="stock.picking", compute="_compute_picking", store=True)
     lot = fields.Many2one(
-        comodel_name='stock.production.lot', compute="get_lot", store=True)
+        comodel_name='stock.production.lot', compute="_compute_lot",
+        store=True)
 
 
 class QcInspectionLine(models.Model):

--- a/quality_control_stock/models/stock_picking.py
+++ b/quality_control_stock/models/stock_picking.py
@@ -13,7 +13,7 @@ class StockPicking(models.Model):
 
     @api.multi
     @api.depends('qc_inspections', 'qc_inspections.state')
-    def _count_inspections(self):
+    def _compute_count_inspections(self):
         for picking in self:
             picking.created_inspections = len(picking.qc_inspections)
             picking.passed_inspections = \
@@ -29,13 +29,13 @@ class StockPicking(models.Model):
         comodel_name='qc.inspection', inverse_name='picking', copy=False,
         string='Inspections', help="Inspections related to this picking.")
     created_inspections = fields.Integer(
-        compute="_count_inspections", string="Created inspections")
+        compute="_compute_count_inspections", string="Created inspections")
     done_inspections = fields.Integer(
-        compute="_count_inspections", string="Done inspections")
+        compute="_compute_count_inspections", string="Done inspections")
     passed_inspections = fields.Integer(
-        compute="_count_inspections", string="Inspections OK")
+        compute="_compute_count_inspections", string="Inspections OK")
     failed_inspections = fields.Integer(
-        compute="_count_inspections", string="Inspections failed")
+        compute="_compute_count_inspections", string="Inspections failed")
 
     @api.multi
     def do_transfer(self):

--- a/quality_control_stock/models/stock_picking.py
+++ b/quality_control_stock/models/stock_picking.py
@@ -14,14 +14,16 @@ class StockPicking(models.Model):
     @api.multi
     @api.depends('qc_inspections', 'qc_inspections.state')
     def _count_inspections(self):
-        self.ensure_one()
-        self.created_inspections = len(self.qc_inspections)
-        self.passed_inspections = len([x for x in self.qc_inspections if
-                                       x.state == 'success'])
-        self.failed_inspections = len([x for x in self.qc_inspections if
-                                       x.state == 'failed'])
-        self.done_inspections = (self.passed_inspections +
-                                 self.failed_inspections)
+        for picking in self:
+            picking.created_inspections = len(picking.qc_inspections)
+            picking.passed_inspections = \
+                len([x for x in picking.qc_inspections
+                     if x.state == 'success'])
+            picking.failed_inspections = \
+                len([x for x in picking.qc_inspections
+                     if x.state == 'failed'])
+            picking.done_inspections = \
+                (picking.passed_inspections + picking.failed_inspections)
 
     qc_inspections = fields.One2many(
         comodel_name='qc.inspection', inverse_name='picking', copy=False,

--- a/quality_control_stock/models/stock_production_lot.py
+++ b/quality_control_stock/models/stock_production_lot.py
@@ -11,24 +11,24 @@ class StockProductionLot(models.Model):
 
     @api.multi
     @api.depends('qc_inspections', 'qc_inspections.state')
-    def _count_inspections(self):
+    def _compute_count_inspections(self):
         for lot in self:
             lot.created_inspections = len(lot.qc_inspections)
-            lot.passed_inspections = len([x for x in lot.qc_inspections if
-                                           x.state == 'success'])
-            lot.failed_inspections = len([x for x in lot.qc_inspections if
-                                           x.state == 'failed'])
-            lot.done_inspections = (lot.passed_inspections +
-                                     lot.failed_inspections)
+            lot.passed_inspections = \
+                len([x for x in lot.qc_inspections if x.state == 'success'])
+            lot.failed_inspections = \
+                len([x for x in lot.qc_inspections if x.state == 'failed'])
+            lot.done_inspections = \
+                (lot.passed_inspections + lot.failed_inspections)
 
     qc_inspections = fields.One2many(
         comodel_name='qc.inspection', inverse_name='lot', copy=False,
         string='Inspections', help="Inspections related to this lot.")
     created_inspections = fields.Integer(
-        compute="_count_inspections", string="Created inspections")
+        compute="_compute_count_inspections", string="Created inspections")
     done_inspections = fields.Integer(
-        compute="_count_inspections", string="Done inspections")
+        compute="_compute_count_inspections", string="Done inspections")
     passed_inspections = fields.Integer(
-        compute="_count_inspections", string="Inspections OK")
+        compute="_compute_count_inspections", string="Inspections OK")
     failed_inspections = fields.Integer(
-        compute="_count_inspections", string="Inspections failed")
+        compute="_compute_count_inspections", string="Inspections failed")

--- a/quality_control_stock/models/stock_production_lot.py
+++ b/quality_control_stock/models/stock_production_lot.py
@@ -12,14 +12,14 @@ class StockProductionLot(models.Model):
     @api.multi
     @api.depends('qc_inspections', 'qc_inspections.state')
     def _count_inspections(self):
-        self.ensure_one()
-        self.created_inspections = len(self.qc_inspections)
-        self.passed_inspections = len([x for x in self.qc_inspections if
-                                       x.state == 'success'])
-        self.failed_inspections = len([x for x in self.qc_inspections if
-                                       x.state == 'failed'])
-        self.done_inspections = (self.passed_inspections +
-                                 self.failed_inspections)
+        for lot in self:
+            lot.created_inspections = len(lot.qc_inspections)
+            lot.passed_inspections = len([x for x in lot.qc_inspections if
+                                           x.state == 'success'])
+            lot.failed_inspections = len([x for x in lot.qc_inspections if
+                                           x.state == 'failed'])
+            lot.done_inspections = (lot.passed_inspections +
+                                     lot.failed_inspections)
 
     qc_inspections = fields.One2many(
         comodel_name='qc.inspection', inverse_name='lot', copy=False,


### PR DESCRIPTION
Since they are called as compute methods, count_inspections methods should be able to manage recordsets