### PR TITLE
[FIX] quality_control: created new notebook page to avoid activate variants

### DIFF
--- a/quality_control/__manifest__.py
+++ b/quality_control/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Quality control",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "category": "Quality control",
     "license": "AGPL-3",
     "summary": "Generic infrastructure for quality tests.",

--- a/quality_control/views/product_template_view.xml
+++ b/quality_control/views/product_template_view.xml
@@ -11,19 +11,22 @@
         <field name="name">product.template.qc</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="groups_id" eval="[(4, ref('quality_control.group_quality_control_manager'))]" />
         <field name="arch" type="xml">
-            <xpath expr="//page[2]" position="inside">
-                <group name="qc" string="Quality control">
-                    <field name="qc_triggers" nolabel="1">
-                        <tree string="Quality control triggers" editable="bottom">
-                            <field name="trigger" widget="selection"/>
-                            <field name="test"/>
-                            <field name="user" />
-                            <field name="partners" widget="many2many_tags" />
-                        </tree>
-                    </field>
-                </group>
-            </xpath>
+            <page name="variants" position="after">
+                <page name="quality_control" string="Quality Control">
+                    <group name="qc" string="Quality control">
+                        <field name="qc_triggers" nolabel="1">
+                            <tree string="Quality control triggers" editable="bottom">
+                                <field name="trigger" widget="selection"/>
+                                <field name="test"/>
+                                <field name="user" />
+                                <field name="partners" widget="many2many_tags" />
+                            </tree>
+                        </field>
+                    </group>
+                </page>
+            </page>
         </field>
     </record>
 

--- a/quality_control/views/product_template_view.xml
+++ b/quality_control/views/product_template_view.xml
@@ -11,7 +11,7 @@
         <field name="name">product.template.qc</field>
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
-        <field name="groups_id" eval="[(4, ref('quality_control.group_quality_control_manager'))]" />
+        <field name="groups_id" eval="[(4, ref('quality_control.group_quality_control_user'))]" />
         <field name="arch" type="xml">
             <page name="inventory" position="inside">
                 <group name="qc" string="Quality control">

--- a/quality_control/views/product_template_view.xml
+++ b/quality_control/views/product_template_view.xml
@@ -13,19 +13,17 @@
         <field name="inherit_id" ref="product.product_template_only_form_view"/>
         <field name="groups_id" eval="[(4, ref('quality_control.group_quality_control_manager'))]" />
         <field name="arch" type="xml">
-            <page name="variants" position="after">
-                <page name="quality_control" string="Quality Control">
-                    <group name="qc" string="Quality control">
-                        <field name="qc_triggers" nolabel="1">
-                            <tree string="Quality control triggers" editable="bottom">
-                                <field name="trigger" widget="selection"/>
-                                <field name="test"/>
-                                <field name="user" />
-                                <field name="partners" widget="many2many_tags" />
-                            </tree>
-                        </field>
-                    </group>
-                </page>
+            <page name="inventory" position="inside">
+                <group name="qc" string="Quality control">
+                    <field name="qc_triggers" nolabel="1">
+                        <tree string="Quality control triggers" editable="bottom">
+                            <field name="trigger" widget="selection"/>
+                            <field name="test"/>
+                            <field name="user" />
+                            <field name="partners" widget="many2many_tags" />
+                        </tree>
+                    </field>
+                </group>
             </page>
         </field>
     </record>


### PR DESCRIPTION
cc @anajuaristi @pedrobaeza 

This fix is to avoid selecting **"Manage Product Variants"**
