### PR TITLE
[11.0][IMP] account_move_line_manufacture_info

### DIFF
--- a/account_move_line_manufacture_info/views/mrp_production_views.xml
+++ b/account_move_line_manufacture_info/views/mrp_production_views.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                     <button name="%(action_mrp_account_moves)d" type="action" string="Account Moves"
-                            class="oe_stat_button" icon="fa-list"
+                            class="oe_stat_button" icon="fa-list" groups="account.group_account_user"
                             attrs="{'invisible': [('state', 'not in', ('progress', 'done'))]}"/>
                 </xpath>
             </field>

--- a/account_move_line_manufacture_info/views/mrp_unbuild_views.xml
+++ b/account_move_line_manufacture_info/views/mrp_unbuild_views.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_button_box')]" position="inside">
                 <button name="%(action_mrp_uo_account_moves)d" type="action" string="Account Moves"
-                        class="oe_stat_button" icon="fa-list"
+                        class="oe_stat_button" icon="fa-list" groups="account.group_account_user"
                         attrs="{'invisible': [('state', 'not in', ('done'))]}"/>
             </xpath>
         </field>


### PR DESCRIPTION
Related to comment:
https://github.com/OCA/manufacture/pull/339#discussion_r260720988

Account move lines buttons are now only available to account users.

cc ~ @lreficent 