### PR TITLE
[12.0][FIX] repair_refurbish, product with tracking show error when end repair order

### DIFF
--- a/repair_refurbish/__manifest__.py
+++ b/repair_refurbish/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "MRP Repair Refurbish",
     "summary": "Create refurbished products during repair",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.1.1",
     "category": "Manufacturing",
     "website": "https://github.com/OCA/manufacture",
     "author": "Eficent, Odoo Community Association (OCA)",

--- a/repair_refurbish/models/repair.py
+++ b/repair_refurbish/models/repair.py
@@ -49,8 +49,17 @@ class RepairOrder(models.Model):
             self.address_id.id or False,
             'location_id': self.location_dest_id.id,
             'location_dest_id': self.refurbish_location_dest_id.id,
-            'restrict_lot_id': self.refurbish_lot_id.id,
-        }
+            'move_line_ids': [(0, 0, {
+                'product_id': self.refurbish_product_id.id,
+                'lot_id': self.refurbish_lot_id.id,
+                'product_uom_qty': self.product_qty,
+                'product_uom_id': self.product_uom.id or
+                self.refurbish_product_id.uom_id.id,
+                'qty_done': self.product_qty,
+                'package_id': False,
+                'result_package_id': False,
+                'location_id': self.location_dest_id.id,
+                'location_dest_id': self.refurbish_location_dest_id.id})]}
 
     @api.multi
     def action_repair_done(self):

--- a/repair_refurbish/readme/CONTRIBUTORS.rst
+++ b/repair_refurbish/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
 * Lois Rilo <lois.rilo@eficent.com>
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Bhavesh Odedra <bodedra@opensourceintegrators.com>


### PR DESCRIPTION
Issue reference: https://github.com/OCA/manufacture/issues/347

Analysis:

- Create a stock move (https://github.com/OCA/manufacture/blob/12.0/repair_refurbish/models/repair.py#L62)
- When Odoo creates stock move line, we receive following values.
![Screenshot from 2019-04-12 21-22-53](https://user-images.githubusercontent.com/14229503/56055759-06059a80-5d78-11e9-975b-0a1ca1337125.png)
- It fails at https://github.com/odoo/odoo/blob/12.0/addons/stock/models/stock_move_line.py#L408
- So instead of Odoo creates stock move line, we create it and pass lot number.