### PR TITLE
[10.0][mrp_production_request] Fix return of _generate_finished_moves method 

### DIFF
--- a/mrp_production_request/models/mrp_production.py
+++ b/mrp_production_request/models/mrp_production.py
@@ -17,3 +17,4 @@ class MrpProduction(models.Model):
         mr_proc = self.mrp_production_request_id.procurement_id
         if mr_proc and mr_proc.move_dest_id:
             move.write({"move_dest_id": mr_proc.move_dest_id.id})
+        return move


### PR DESCRIPTION
We should not change the return of such a method when overriding.
This will fail if another module override the same method, like https://github.com/OCA/account-analytic/tree/10.0/mrp_procurement_analytic
It seems it is fixed already in version 11 and 12

@lreficent @jbeficent @hparfr 