### PR TITLE
[11.0][IMP] mrp_progress_button

### DIFF
--- a/mrp_progress_button/models/mrp_production.py
+++ b/mrp_progress_button/models/mrp_production.py
@@ -16,3 +16,11 @@ class MrpProduction(models.Model):
             'date_start': datetime.now(),
         })
         return True
+
+    @api.multi
+    def action_confirm(self):
+        self.write({
+            'state': 'confirmed',
+            'date_start': False,
+        })
+        return True

--- a/mrp_progress_button/views/production.xml
+++ b/mrp_progress_button/views/production.xml
@@ -9,6 +9,11 @@
                     <button name="action_progress" attrs="{'invisible': ['|', ('state', '!=', 'confirmed'), ('routing_id', '!=', False)]}"
                             type="object" string="Mark As Started" class="oe_highlight"/>
                 </button>
+                <button name="open_produce_product" position="after">
+                    <button name="action_confirm"
+                            attrs="{'invisible': ['|', '|', ('state', '!=', 'progress'), ('routing_id', '!=', False), ('post_visible', '=', True)]}"
+                            type="object" string="Set to Confirmed"/>
+                </button>
             </field>
         </record>
 


### PR DESCRIPTION
Basic improvement to module mrp_progress_button that adds a button to set the state back to confirmed when in progress and no products have been produced.

![image](https://user-images.githubusercontent.com/44768500/61288347-33bf0d00-a7c7-11e9-97ba-6204f3b66f8e.png)

cc ~ @Eficent @florian-dacosta 