### PR TITLE
[12.0][FIX]repair_refurbish. Set correct destination location in stock move lines

### DIFF
--- a/repair_refurbish/models/stock_move.py
+++ b/repair_refurbish/models/stock_move.py
@@ -14,3 +14,16 @@ class StockMove(models.Model):
                 vals['location_dest_id'] = self.env.context[
                     'force_refurbish_location_dest_id']
         return super().create(vals_list)
+
+
+class StockMoveLine(models.Model):
+
+    _inherit = 'stock.move.line'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if 'force_refurbish_location_dest_id' in self.env.context:
+            for vals in vals_list:
+                vals['location_dest_id'] = self.env.context[
+                    'force_refurbish_location_dest_id']
+        return super().create(vals_list)

--- a/repair_refurbish/tests/test_repair_refurbish.py
+++ b/repair_refurbish/tests/test_repair_refurbish.py
@@ -84,8 +84,16 @@ class TestMrpMtoWithStock(TransactionCase):
             if m.product_id == self.product:
                 self.assertEqual(m.location_id, self.stock_location_stock)
                 self.assertEqual(m.location_dest_id, self.refurbish_loc)
+                self.assertEqual(m.mapped('move_line_ids.location_id'),
+                                 self.stock_location_stock)
+                self.assertEqual(m.mapped('move_line_ids.location_dest_id'),
+                                 self.refurbish_loc)
             elif m.product_id == self.refurbish_product:
                 self.assertEqual(m.location_id, self.refurbish_loc)
                 self.assertEqual(m.location_dest_id, self.customer_location)
+                self.assertEqual(m.mapped('move_line_ids.location_id'),
+                                 self.refurbish_loc)
+                self.assertEqual(m.mapped('move_line_ids.location_dest_id'),
+                                 self.customer_location)
             else:
                 self.assertTrue(False, "Unexpected move.")


### PR DESCRIPTION
This is not only about being consistent between the stock moves and the stock move lines.

Inventory valuation moves are not created correctly or not created because of the inconsistency between stock moves and stock move lines.

This seems to solve the issue.

