### PR TITLE
[12.0][FIX] repair_refurbish: do not set destination location for no refurbish repair

### DIFF
--- a/repair_refurbish/models/repair.py
+++ b/repair_refurbish/models/repair.py
@@ -64,7 +64,8 @@ class RepairOrder(models.Model):
     @api.multi
     def action_repair_done(self):
         res = super(RepairOrder, self.with_context(
-            force_refurbish_location_dest_id=self.location_dest_id.id
+            force_refurbish_location_dest_id=self.location_dest_id.id,
+            to_refurbish=self.to_refurbish,
         )).action_repair_done()
         for repair in self:
             if repair.to_refurbish:

--- a/repair_refurbish/models/stock_move.py
+++ b/repair_refurbish/models/stock_move.py
@@ -9,10 +9,12 @@ class StockMove(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        if 'force_refurbish_location_dest_id' in self.env.context:
-            for vals in vals_list:
-                vals['location_dest_id'] = self.env.context[
-                    'force_refurbish_location_dest_id']
+        if 'to_refurbish' in self.env.context and \
+                self.env.context['to_refurbish']:
+            if 'force_refurbish_location_dest_id' in self.env.context:
+                for vals in vals_list:
+                    vals['location_dest_id'] = self.env.context[
+                        'force_refurbish_location_dest_id']
         return super().create(vals_list)
 
 
@@ -22,8 +24,10 @@ class StockMoveLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        if 'force_refurbish_location_dest_id' in self.env.context:
-            for vals in vals_list:
-                vals['location_dest_id'] = self.env.context[
-                    'force_refurbish_location_dest_id']
+        if 'to_refurbish' in self.env.context and \
+                self.env.context['to_refurbish']:
+            if 'force_refurbish_location_dest_id' in self.env.context:
+                for vals in vals_list:
+                    vals['location_dest_id'] = self.env.context[
+                        'force_refurbish_location_dest_id']
         return super().create(vals_list)

--- a/repair_refurbish/tests/test_repair_refurbish.py
+++ b/repair_refurbish/tests/test_repair_refurbish.py
@@ -31,6 +31,10 @@ class TestMrpMtoWithStock(TransactionCase):
             'name': 'Materials',
             'type': 'consu',
         })
+        self.material2 = self.product_obj.create({
+            'name': 'Materials',
+            'type': 'product',
+        })
         self._update_product_qty(self.product, self.stock_location_stock, 10.0)
 
     def _update_product_qty(self, product, location, quantity):
@@ -97,3 +101,39 @@ class TestMrpMtoWithStock(TransactionCase):
                                  self.customer_location)
             else:
                 self.assertTrue(False, "Unexpected move.")
+
+    def test_02_repair_no_refurbish(self):
+        """Tests normal repairs does not fail and normal location for consumed
+        material"""
+        repair = self.repair_obj.create({
+            'product_id': self.product.id,
+            'product_qty': 3.0,
+            'product_uom': self.product.uom_id.id,
+            'location_dest_id': self.customer_location.id,
+            'to_refurbish': False
+        })
+
+        line = self.repair_line_obj.with_context(
+            to_refurbish=repair.to_refurbish,
+            refurbish_location_dest_id=repair.refurbish_location_dest_id,
+        ).create({
+            'name': 'consume stuff to repair',
+            'repair_id': repair.id,
+            'type': 'add',
+            'product_id': self.material2.id,
+            'product_uom': self.material2.uom_id.id,
+            'product_uom_qty': 1.0,
+            'price_unit': 50.0,
+            'location_id': self.stock_location_stock.id,
+            'location_dest_id': self.customer_location.id
+        })
+        line.onchange_product_id()
+        line.onchange_operation_type()
+        # Complete repair:
+        repair.action_validate()
+        repair.action_repair_start()
+        repair.action_repair_end()
+        move = self.move_obj.search([
+            ('product_id', '=', self.material2.id)],
+            order='create_date desc', limit=1)[0]
+        self.assertEqual(move.location_dest_id, self.customer_location)


### PR DESCRIPTION
repair_refurbish fails when the repair order is not refurbish. Basically, if the repair is not refurbish we are overriding incorrectly the destination location of the stock move. 

The fix is quite dumb, but seems to work. We only change the destination location for the refurbish move.