### PR TITLE
[12.0] [FIX] quality_control: Fixed error thrown when editing 'qc.trigger.line's

### DIFF
--- a/quality_control/views/product_category_view.xml
+++ b/quality_control/views/product_category_view.xml
@@ -16,7 +16,7 @@
                 <group name="qc" string="Quality control">
                     <field name="qc_triggers" nolabel="1">
                         <tree string="Quality control triggers" editable="bottom">
-                            <field name="trigger" widget="selection" />
+                            <field name="trigger" options="{'no_create': True, 'no_edit': True, 'no_open': True}" />
                             <field name="test" />
                             <field name="user" />
                             <field name="partners" widget="many2many_tags" />

--- a/quality_control/views/product_template_view.xml
+++ b/quality_control/views/product_template_view.xml
@@ -17,7 +17,7 @@
                 <group name="qc" string="Quality control">
                     <field name="qc_triggers" nolabel="1">
                         <tree string="Quality control triggers" editable="bottom">
-                            <field name="trigger" widget="selection"/>
+                            <field name="trigger" options="{'no_create': True, 'no_edit': True, 'no_open': True}"/>
                             <field name="test"/>
                             <field name="user" />
                             <field name="partners" widget="many2many_tags" />


### PR DESCRIPTION
Whenever an user tries to edit a 'qc.trigger.product_template_line', 'qc.trigger.product_product_line' or 'qc.trigger.product_category_line', Odoo throws the following error:

![Edit error in product template](https://user-images.githubusercontent.com/20474104/68136907-51ef7b00-ff26-11e9-9c69-4f1c0e3b841f.png)

(with '?debug=assets')

![Edit error in product template (with debug)](https://user-images.githubusercontent.com/20474104/68137022-882cfa80-ff26-11e9-8272-578dcc61279e.png)

I've managed to reproduce this error in runbot (12.0) with the following steps:
1. Go to any 'product.template', 'product.product' or 'product.category'.
2. Create a new valid 'qc.trigger.product_*_line'. E.g.
![Example qc.trigger.line](https://user-images.githubusercontent.com/20474104/68137671-aa734800-ff27-11e9-95d9-16c79f1635c4.png)
3. Save.
4. Try to edit the newly created line. It should throw the error.

This seems to be an issue with how Odoo renders a 'selection' field inside the 'tree' view. I've fixed the issue by removing the 'selection' widget in the 'trigger' field.