### PR TITLE
[12.0][FIX] mrp_multi_level: when grouping demand, if supply and

### DIFF
--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -250,3 +250,17 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         prev = self.mrp_inventory_obj.search([
             ('mrp_area_id', '!=', self.secondary_area.id)], limit=1)
         self.assertNotEqual(this.create_uid, prev.create_uid)
+
+    def test_11_special_scenario_1(self):
+        """When grouping demand supply and demand are in the same day but
+        supply goes first."""
+        moves = self.mrp_move_obj.search([
+            ('product_id', '=', self.product_scenario_1.id)])
+        self.assertEqual(len(moves), 4)
+        mrp_invs = self.mrp_inventory_obj.search([
+            ('product_id', '=', self.product_scenario_1.id)])
+        self.assertEqual(len(mrp_invs), 2)
+        # Net needs = 124 + 90 - 87 = 127 -> 130 (because of qty multiple)
+        self.assertEqual(mrp_invs[0].to_procure, 130)
+        # Net needs = 18, available on-hand = 3 -> 15
+        self.assertEqual(mrp_invs[1].to_procure, 15)

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -488,7 +488,8 @@ class MultiLevelMrp(models.TransientModel):
                         or (onhand + last_qty)
                         < product_mrp_area.mrp_minimum_stock):
                 name = 'Grouped Demand for %d Days' % grouping_delta
-                qtytoorder = product_mrp_area.mrp_minimum_stock - last_qty
+                qtytoorder = product_mrp_area.mrp_minimum_stock - \
+                    onhand - last_qty
                 cm = self.create_action(
                     product_mrp_area_id=product_mrp_area,
                     mrp_date=last_date,


### PR DESCRIPTION
demand moves have the same date it can happen that the supply is
effectively ignored if considered as staring move of the
grouping and there are more groups to be done after it.

A test case include in this fix depicts in detail the
the problem and ensures no regression.

forward port 127017798c601c69bf9c1e8f9f01380a57e30b81

@Eficent