### PR TITLE
[FIX] mrp_production_putaway_strategy: not work with rating module

### DIFF
--- a/mrp_production_putaway_strategy/models/mrp_production.py
+++ b/mrp_production_putaway_strategy/models/mrp_production.py
@@ -21,5 +21,5 @@ class MrpProduction(models.Model):
                 "Applied Putaway strategy to finished products.\n"
                 "Finished Products Location: %s." %
                 mo.location_dest_id.complete_name)
-            mo.message_post(message, message_type='comment')
+            mo.message_post(body=message, message_type='comment')
         return mo


### PR DESCRIPTION
TypeError: message_post() takes 1 positional argument but 2 were given
since: https://github.com/odoo/odoo/commit/d7c24089ee6cee6f728553cd61143c034e4f08d2#diff-a2cd85e51cd48bdb61a17bb7edfcc631