### PR TITLE
[11.0][FIX] mrp_multi_level: origin for "mv" was never being set.

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -86,26 +86,27 @@ class MultiLevelMrp(models.TransientModel):
             origin = 'po'
             po = move.purchase_line_id.order_id.id
             po_line = move.purchase_line_id.id
-        if move.production_id:
+        elif move.production_id:
             order_number = move.production_id.name
             origin = 'mo'
             mo = move.production_id.id
+        elif move.move_dest_ids:
+            for move_dest_id in move.move_dest_ids:
+                if move_dest_id.production_id:
+                    order_number = move_dest_id.production_id.name
+                    origin = 'mo'
+                    mo = move_dest_id.production_id.id
+                    if move_dest_id.production_id.product_id:
+                        parent_product_id = \
+                            move_dest_id.production_id.product_id.id
+                    else:
+                        parent_product_id = move_dest_id.product_id.id
         else:
-            # TODO: move.move_dest_id -> move.move_dest_ids. DONE, review
-            if move.move_dest_ids:
-                # move_dest_id = move.move_dest_ids[:1]
-                for move_dest_id in move.move_dest_ids:
-                    if move_dest_id.production_id:
-                        order_number = move_dest_id.production_id.name
-                        origin = 'mo'
-                        mo = move_dest_id.production_id.id
-                        if move_dest_id.production_id.product_id:
-                            parent_product_id = \
-                                move_dest_id.production_id.product_id.id
-                        else:
-                            parent_product_id = move_dest_id.product_id.id
-        if order_number is None:
-            order_number = move.name
+            if move.picking_id:
+                order_number = move.picking_id.name
+            else:
+                order_number = move.name
+            origin = "mv"
         mrp_date = date.today()
         if datetime.date(datetime.strptime(
                 move.date_expected,


### PR DESCRIPTION
Also, improve mrp.move by using picking name if the move is part of a picking.

@ForgeFlow