### PR TITLE
[13.0][IMP] mrp_multi_level: Show supply method on mrp inventory

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -62,6 +62,12 @@ class MrpInventory(models.Model):
     planned_order_ids = fields.One2many(
         comodel_name="mrp.planned.order", inverse_name="mrp_inventory_id", readonly=True
     )
+    supply_method = fields.Selection(
+        string="Supply Method",
+        related="product_mrp_area_id.supply_method",
+        readonly=True,
+        store=True,
+    )
 
     def _compute_uom_id(self):
         for rec in self:

--- a/mrp_multi_level/security/ir.model.access.csv
+++ b/mrp_multi_level/security/ir.model.access.csv
@@ -7,5 +7,6 @@ access_mrp_area_user,mrp.area user,model_mrp_area,mrp.group_mrp_user,1,0,0,0
 access_mrp_area_manager,mrp.area manager,model_mrp_area,mrp.group_mrp_manager,1,1,1,1
 access_product_mrp_area_user,product.mrp.area user,model_product_mrp_area,mrp.group_mrp_user,1,1,1,0
 access_product_mrp_area_manager,product.mrp.area manager,model_product_mrp_area,mrp.group_mrp_manager,1,1,1,1
+access_product_mrp_area_read,product.mrp.area read,model_product_mrp_area,base.group_user,1,0,0,0
 access_mrp_planned_order_user,mrp.planned.order user,model_mrp_planned_order,mrp.group_mrp_user,1,0,0,0
 access_mrp_planned_order_manager,mrp.planned.order manager,model_mrp_planned_order,mrp.group_mrp_manager,1,1,1,1

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -14,6 +14,7 @@
                             <field name="company_id" groups="base.group_multi_company"/>
                             <field name="product_id"/>
                             <field name="product_mrp_area_id"/>
+                            <field name="supply_method"/>
                             <field name="date"/>
                         </group>
                         <group>
@@ -51,6 +52,7 @@
                         name="%(mrp_multi_level.act_mrp_inventory_procure)d"
                         icon="fa-cogs" type="action"
                         attrs="{'invisible':[('to_procure','&lt;=',0.0)]}"/>
+                <field name="supply_method"/>
                 <field name="running_availability"/>
             </tree>
         </field>
@@ -103,6 +105,9 @@
                     <filter name="group_mrp_area"
                             string="MRP Area"
                             context="{'group_by':'mrp_area_id'}"/>
+                    <filter name="group_supply_method"
+                            string="Supply Method"
+                            context="{'group_by':'supply_method'}"/>
                     <filter name="group_release_date_day"
                             string="Date to Procure (By Day)"
                             context="{'group_by':'order_release_date:day'}"/>

--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -25,6 +25,7 @@ class MrpInventoryProcure(models.TransientModel):
             "warehouse_id": planned_order.mrp_area_id.warehouse_id.id,
             "location_id": planned_order.product_mrp_area_id.location_proc_id.id
             or planned_order.mrp_area_id.location_id.id,
+            "supply_method": planned_order.product_mrp_area_id.supply_method,
         }
 
     @api.model
@@ -116,6 +117,17 @@ class MrpInventoryProcureItem(models.TransientModel):
     product_id = fields.Many2one(string="Product", comodel_name="product.product")
     warehouse_id = fields.Many2one(string="Warehouse", comodel_name="stock.warehouse")
     location_id = fields.Many2one(string="Location", comodel_name="stock.location")
+    supply_method = fields.Selection(
+        string="Supply Method",
+        selection=[
+            ("buy", "Buy"),
+            ("none", "Undefined"),
+            ("manufacture", "Produce"),
+            ("pull", "Pull From"),
+            ("push", "Push To"),
+            ("pull_push", "Pull & Push"),
+        ],
+    )
 
     def _prepare_procurement_values(self, group=False):
         return {

--- a/mrp_multi_level/wizards/mrp_inventory_procure_views.xml
+++ b/mrp_multi_level/wizards/mrp_inventory_procure_views.xml
@@ -23,6 +23,7 @@
                             <field name="qty"/>
                             <field name="uom_id" groups="uom.group_uom"/>
                             <field name="date_planned"/>
+                            <field name="supply_method"/>
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
UX enhance that allow planners to sort/group by supply method.
![image](https://user-images.githubusercontent.com/32061121/73723644-d28e6500-4729-11ea-8d4e-fcff92ab4838.png)
CC @Forgeflow 