### PR TITLE
[13.0][IMP] mrp_multi_level: Minor changes 

### DIFF
--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -42,8 +42,8 @@ class MrpPlannedOrder(models.Model):
     due_date = fields.Date(
         string="Due Date", help="Date in which the supply must have been completed."
     )
-    qty_released = fields.Float()
-    fixed = fields.Boolean()
+    qty_released = fields.Float(readonly=True)
+    fixed = fields.Boolean(default=True)
     mrp_qty = fields.Float(string="Quantity")
     mrp_move_down_ids = fields.Many2many(
         comodel_name="mrp.move",

--- a/mrp_multi_level/readme/CONTRIBUTORS.rst
+++ b/mrp_multi_level/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Wim Audenaert <wim.audenaert@ucamco.com>
 * Jordi Ballester <jordi.ballester@forgeflow.com>
 * Lois Rilo <lois.rilo@forgeflow.com>
+* Héctor Villarreal <hector.villarreal@forgeflow.com>

--- a/mrp_multi_level/readme/HISTORY.rst
+++ b/mrp_multi_level/readme/HISTORY.rst
@@ -1,3 +1,29 @@
+13.0.1.2.0 (2020-02-20)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] Minor changes
+  (`#468 <https://github.com/OCA/manufacture/pull/468>`_).
+
+  * Planned Orders become fixed on manual creation by default
+  * Released Quantity becomes readonly
+  * Add product reference if Planned Order name is not defined on bom explosion
+
+13.0.1.1.0 (2020-02-21)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [FIX] Minor changes
+  (`#469 <https://github.com/OCA/manufacture/pull/469>`_).
+
+  * Fix Main supplier computation in multi company
+  * Drop Triplicated field in search view
+
+
+* [IMP] Minor changes
+  (`#463 <https://github.com/OCA/manufacture/pull/463>`_).
+
+  * Show supply method on MRP Inventory
+  * Allow no-MRP users to look into Products
+
 13.0.1.0.0 (2019-12-18)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -110,6 +110,7 @@ class MultiLevelMrp(models.TransientModel):
             "mrp_action": product_mrp_area.supply_method,
             "qty_released": 0.0,
             "name": "Supply: " + name,
+            "fixed": False,
         }
 
     @api.model
@@ -138,9 +139,11 @@ class MultiLevelMrp(models.TransientModel):
             "mrp_origin": "mrp",
             "mrp_order_number": None,
             "parent_product_id": bom.product_id.id,
-            "name": ("Demand Bom Explosion: " + name).replace(
-                "Demand Bom Explosion: Demand Bom " "Explosion: ",
-                "Demand Bom Explosion: ",
+            "name": (
+                "Demand Bom Explosion: %s"
+                % (name or product.product_id.default_code or product.product_id.name)
+            ).replace(
+                "Demand Bom Explosion: Demand Bom Explosion: ", "Demand Bom Explosion: "
             ),
         }
 


### PR DESCRIPTION
Minor changes:
* Planned Orders become fixed on manual creation by default
* Released Quantity become readonly

CC @Forgeflow @LoisRForgeFlow @JordiBForgeFlow 

Release with: /ocabot merge minor