### PR TITLE
[13.0][FIX] mrp_multi_level: origin for "mv" was never being set.

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -58,24 +58,22 @@ class MultiLevelMrp(models.TransientModel):
             origin = "po"
             po = move.purchase_line_id.order_id.id
             po_line = move.purchase_line_id.id
-        if move.production_id:
-            order_number = move.production_id.name
+        elif move.production_id or move.raw_material_production_id:
+            production = move.production_id or move.raw_material_production_id
+            order_number = production.name
             origin = "mo"
-            mo = move.production_id.id
+            mo = production.id
+        elif move.move_dest_ids:
+            for move_dest_id in move.move_dest_ids.filtered("production_id"):
+                order_number = move_dest_id.production_id.name
+                origin = "mo"
+                mo = move_dest_id.production_id.id
+                parent_product_id = (
+                    move_dest_id.production_id.product_id or move_dest_id.product_id
+                ).id
         else:
-            if move.move_dest_ids:
-                # move_dest_id = move.move_dest_ids[:1]
-                for move_dest_id in move.move_dest_ids:
-                    if move_dest_id.production_id:
-                        order_number = move_dest_id.production_id.name
-                        origin = "mo"
-                        mo = move_dest_id.production_id.id
-                        if move_dest_id.production_id.product_id:
-                            parent_product_id = move_dest_id.production_id.product_id.id
-                        else:
-                            parent_product_id = move_dest_id.product_id.id
-        if order_number is None:
-            order_number = move.name
+            order_number = (move.picking_id or move).name
+            origin = "mv"
         mrp_date = date.today()
         if move.date_expected.date() > date.today():
             mrp_date = move.date_expected.date()
@@ -109,7 +107,7 @@ class MultiLevelMrp(models.TransientModel):
             "order_release_date": mrp_action_date,
             "mrp_action": product_mrp_area.supply_method,
             "qty_released": 0.0,
-            "name": "Supply: " + name,
+            "name": "Planned supply for: " + name,
             "fixed": False,
         }
 


### PR DESCRIPTION
Also, improve mrp.move by using picking name if the move is part of a picking.

Forward port of https://github.com/OCA/manufacture/pull/473.

@ForgeFlow