### PR TITLE
[13.0][mrp_multi_level] improve planned orders

### DIFF
--- a/mrp_multi_level/__manifest__.py
+++ b/mrp_multi_level/__manifest__.py
@@ -23,6 +23,7 @@
         "views/stock_location_views.xml",
         "wizards/mrp_inventory_procure_views.xml",
         "views/mrp_inventory_views.xml",
+        "views/mrp_planned_order_views.xml",
         "wizards/mrp_multi_level_views.xml",
         "views/mrp_menuitem.xml",
         "data/mrp_multi_level_cron.xml",

--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -1,8 +1,9 @@
 # Copyright 2019 ForgeFlow S.L. (https://www.forgeflow.com)
 # - Lois Rilo Antelo <lois.rilo@forgeflow.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from datetime import timedelta
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MrpPlannedOrder(models.Model):
@@ -70,3 +71,38 @@ class MrpPlannedOrder(models.Model):
         comodel_name="mrp.inventory",
         ondelete="set null",
     )
+    mrp_production_ids = fields.One2many(
+        "mrp.production", "planned_order_id", string="Manufacturing Orders"
+    )
+    mo_count = fields.Integer(compute="_compute_mrp_production_count")
+
+    def _compute_mrp_production_count(self):
+        for rec in self:
+            rec.mo_count = len(rec.mrp_production_ids)
+
+    @api.onchange("due_date")
+    def _onchange_due_date(self):
+        if self.due_date:
+            if self.product_mrp_area_id.mrp_lead_time:
+                calendar = self.mrp_area_id.calendar_id
+                if calendar:
+                    dt = fields.Datetime.from_string(self.due_date)
+                    res = calendar.plan_days(
+                        -1 * (self.product_mrp_area_id.mrp_lead_time + 1), dt
+                    )
+                    self.order_release_date = res.date()
+                else:
+                    self.order_release_date = fields.Date.from_string(
+                        self.due_date
+                    ) - timedelta(days=self.product_mrp_area_id.mrp_lead_time)
+
+    def action_toggle_fixed(self):
+        for rec in self:
+            rec.fixed = not rec.fixed
+
+    def action_open_linked_mrp_production(self):
+        action = self.env.ref("mrp.mrp_production_action")
+        result = action.read()[0]
+        result["context"] = {}
+        result["domain"] = "[('id','in',%s)]" % self.mrp_production_ids.ids
+        return result

--- a/mrp_multi_level/readme/HISTORY.rst
+++ b/mrp_multi_level/readme/HISTORY.rst
@@ -1,3 +1,10 @@
+13.0.1.4.0 (2020-03-26)
+~~~~~~~~~~~~~~~~~~~~~~~
+  * Add menu entry for planned orders
+  * Add button to navigate from planned orders to linked manufacturing orders
+  * Add action to convert planned orders to fixed
+  * When changing the due date in a planned order the release date is recomputed
+
 13.0.1.3.0 (2020-03-02)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2019-20 ForgeFlow S.L. (https://www.forgeflow.com)
+     Part of ForgeFlow. See LICENSE file for full copyright and licensing details. -->
+<odoo>
+    <record id="mrp_planned_order_view_tree" model="ir.ui.view">
+        <field name="name">mrp.planned.order.tree</field>
+        <field name="model">mrp.planned.order</field>
+        <field name="arch" type="xml">
+            <tree decoration-info="fixed != True">
+                <field name="product_mrp_area_id" />
+                <field name="product_id" />
+                <field name="mrp_area_id" />
+                <field name="order_release_date" />
+                <field name="due_date" />
+                <field name="qty_released" />
+                <field name="mrp_qty" />
+                <field name="fixed" />
+            </tree>
+        </field>
+    </record>
+    <record id="mrp_planned_order_view_form" model="ir.ui.view">
+        <field name="name">mrp.planned.order.form</field>
+        <field name="model">mrp.planned.order</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="action_open_linked_mrp_production"
+                            type="object"
+                            icon="fa-wrench"
+                            attrs="{'invisible':[('mo_count', '=', 0)]}"
+                            class="oe_stat_button"
+                        >
+                            <field name="mo_count" widget="statinfo" string="MOs" />
+                        </button>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="product_mrp_area_id" />
+                            <field name="product_id" />
+                            <field name="mrp_area_id" />
+                            <field name="name" />
+                            <field name="fixed" />
+                        </group>
+                        <group>
+                            <field name="mrp_action" />
+                            <field name="order_release_date" />
+                            <field name="due_date" />
+                            <field name="mrp_qty" />
+                            <field name="qty_released" />
+                        </group>
+                    </group>
+                    <group groups="base.group_no_one">
+                        <field name="mrp_move_down_ids" readonly="True" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="mrp_planned_order_view_pivot" model="ir.ui.view">
+        <field name="name">mrp.planned.order.pivot</field>
+        <field name="model">mrp.planned.order</field>
+        <field name="arch" type="xml">
+            <pivot>
+                <field name="mrp_area_id" type="row" />
+                <field name="product_id" type="row" />
+                <field name="mrp_qty" type="measure" />
+                <field name="due_date" interval="week" type="col" />
+            </pivot>
+        </field>
+    </record>
+    <record id="mrp_planned_order_view_search" model="ir.ui.view">
+        <field name="name">mrp.planned.order.search</field>
+        <field name="model">mrp.planned.order</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="product_id" />
+                <field name="mrp_area_id" />
+                <separator />
+                <filter string="Fixed" name="fixed" domain="[('fixed','=',True)]" />
+                <group name='group_by' expand="0" string="Group By...">
+                    <filter
+                        name='product_parameters'
+                        string="Product Parameters"
+                        context="{'group_by':'product_mrp_area_id'}"
+                    />
+                    <filter
+                        name='due_date'
+                        string="Due Date"
+                        context="{'group_by':'due_date'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+    <record id="mrp_planned_order_action" model="ir.actions.act_window">
+        <field name="name">Planned Orders</field>
+        <field name="res_model">mrp.planned.order</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_mode">tree,form,pivot</field>
+        <field name="context">{'search_default_fixed': 1}</field>
+    </record>
+    <menuitem
+        name="Planned Orders"
+        id="menu_mrp_planned_order"
+        action="mrp_planned_order_action"
+        parent="mrp.mrp_planning_menu_root"
+        sequence="20"
+    />
+    <record id="action_server_planned_order_toggle_fixed" model="ir.actions.server">
+        <field name="name">Toggle Fixed</field>
+        <field name="model_id" ref="mrp_multi_level.model_mrp_planned_order" />
+        <field name="binding_model_id" ref="mrp_multi_level.model_mrp_planned_order" />
+        <field name="state">code</field>
+        <field name="code">records.action_toggle_fixed()</field>
+    </record>
+    <record id="act_mrp_inventory_procure_planned_order" model="ir.actions.act_window">
+        <field name="name">Procure</field>
+        <field name="res_model">mrp.inventory.procure</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="binding_model_id" ref="mrp_multi_level.model_mrp_planned_order" />
+    </record>
+</odoo>


### PR DESCRIPTION
13.0.1.4.1 (2020-03-26)
~~~~~~~~~~~~~~~~~~~~~~~
  * Add menu entry for planned orders
  * Add button to navigate from planned orders to linked manufacturing orders
  * Add action to convert planned orders to fixed
  * When changing the due date in a planned order the release date is recomputed

cc @LoisRForgeFlow @HviorForgeFlow 