### PR TITLE
[13.0][mrp_multi_level] fix error in _compute_order_release_date of mrp.inventory

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -97,10 +97,12 @@ class MrpInventory(models.Model):
                 order_release_date = rec.mrp_area_id.calendar_id.plan_days(
                     -delay, dt_date
                 ).date()
-            else:
+            elif delay:
                 order_release_date = fields.Date.from_string(rec.date) - timedelta(
                     days=delay
                 )
+            else:
+                order_release_date = rec.date
             if order_release_date < today:
                 order_release_date = today
             rec.order_release_date = order_release_date


### PR DESCRIPTION
This error occurs when you have products with no lead time