### PR TITLE
[12.0][IMP]mrp_multi_level, specific group to run mrp manually

### DIFF
--- a/mrp_multi_level/readme/newsfragments/492.feature
+++ b/mrp_multi_level/readme/newsfragments/492.feature
@@ -1,0 +1,1 @@
+Show *Run MRP Multi Level* menu only to a specific new security group *Run MRP Manually*.

--- a/mrp_multi_level/security/mrp_multi_level_security.xml
+++ b/mrp_multi_level/security/mrp_multi_level_security.xml
@@ -7,6 +7,13 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="group_mrp_multi_level_run" model="res.groups">
+        <field name="name">Run MRP Manually</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]" />
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
+    </record>
+
     <record id="mrp_area_comp_rule" model="ir.rule">
         <field name="name">MRP Area multi-company rule</field>
         <field name="model_id" ref="model_mrp_area"/>

--- a/mrp_multi_level/views/mrp_menuitem.xml
+++ b/mrp_multi_level/views/mrp_menuitem.xml
@@ -24,7 +24,7 @@
               id="menu_mrp_multi_level"
               action="action_mrp_multi_level"
               parent="mrp.menu_mrp_manufacturing"
-              groups="mrp.group_mrp_manager"
+              groups="mrp_multi_level.group_mrp_multi_level_run"
               sequence="40"/>
 
 </odoo>


### PR DESCRIPTION
When the MRP involves deep BOMs and many products are under MRP, the process  may take much time. The schedule action runs every day so the need of running it manually is not under normal execution. In order to prevent running this process when it is not needed,  I think it would be a good idea to hide this option except for very specific users.

Suggestions are welcome.

cc @LoisRForgeFlow 
