### PR TITLE
[12.0][FIX] mrp_subcontracting: Overwrite active_id context in create()

### DIFF
--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -72,10 +72,9 @@ class StockPicking(models.Model):
                         })
                 else:
                     for move_line in move.move_line_ids:
-                        active_id = production and production.id or False
                         produce = self.env['mrp.product.produce'].with_context(
                             default_production_id=production.id,
-                            active_id=active_id).create({
+                            active_id=production.id).create({
                                 'production_id': production.id,
                                 'product_id': production.product_id.id,
                                 'product_qty': move_line.qty_done,

--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -72,8 +72,10 @@ class StockPicking(models.Model):
                         })
                 else:
                     for move_line in move.move_line_ids:
+                        active_id = production and production.id or False
                         produce = self.env['mrp.product.produce'].with_context(
-                            default_production_id=production.id).create({
+                            default_production_id=production.id,
+                            active_id=active_id).create({
                                 'production_id': production.id,
                                 'product_id': production.product_id.id,
                                 'product_qty': move_line.qty_done,

--- a/mrp_subcontracting/tests/test_subcontracting.py
+++ b/mrp_subcontracting/tests/test_subcontracting.py
@@ -632,15 +632,21 @@ class TestSubcontractingTracking(TransactionCase):
 
         # 2. Create a BOM of subcontracting type
         # 2.1. Comp1 has tracking by lot
+        seller = self.env['product.supplierinfo'].create({
+            'name': self.subcontractor_partner1.id,
+            'price': 10.0,
+        })
         self.comp1_sn = self.env['product.product'].create({
             'name': 'Component1',
             'type': 'product',
+            'seller_ids': [(6, 0, [seller.id])],
             'categ_id': self.env.ref('product.product_category_all').id,
             'tracking': 'serial'
         })
         self.comp2 = self.env['product.product'].create({
             'name': 'Component2',
             'type': 'product',
+            'seller_ids': [(6, 0, [seller.id])],
             'categ_id': self.env.ref('product.product_category_all').id,
         })
 


### PR DESCRIPTION
Overwrite the active_id in context when creating the `mrp.product.produce` record in `action_done`
Fixes: #526 