### PR TITLE
[12.0][ADD] mrp_production_show_post_inventory

### DIFF
--- a/mrp_production_show_post_inventory/__manifest__.py
+++ b/mrp_production_show_post_inventory/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Production Show Post Inventory',
+    'version': '12.0.1.0.0',
+    'category': 'MRP',
+    'author': 'Camptocamp, '
+              'Odoo Community Association (OCA)',
+    'website': 'https://github.com/oca/manufacture',
+    'license': 'AGPL-3',
+    'depends': [
+        'mrp',
+    ],
+    'data': [
+        'views/mrp_production.xml',
+    ],
+    'installable': True,
+}

--- a/mrp_production_show_post_inventory/readme/CONTRIBUTORS.rst
+++ b/mrp_production_show_post_inventory/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>

--- a/mrp_production_show_post_inventory/readme/DESCRIPTION.rst
+++ b/mrp_production_show_post_inventory/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module allows to always show the "post inventory" button on manufacturing
+order form view. Normally this button is only available in debug mode.

--- a/mrp_production_show_post_inventory/views/mrp_production.xml
+++ b/mrp_production_show_post_inventory/views/mrp_production.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+  Copyright 2020 Camptocamp
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+
+<odoo>
+
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">mrp.production.form.with.post_inventory</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='post_inventory']" position="attributes">
+                <attribute name="groups">mrp.group_mrp_user</attribute>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
this module removes the need to have debug mode enabled to display
the post inventory button on manufacturing orders