### PR TITLE
[13.0][FIX]  mrp_product_request : stock_rule.py   Allow  to create more than one MR per sale/order for different products.

### DIFF
--- a/mrp_production_request/models/stock_rule.py
+++ b/mrp_production_request/models/stock_rule.py
@@ -116,7 +116,7 @@ class StockRule(models.Model):
     def _run_manufacture(self, procurements):
         for procurement, _rule in procurements:
             if self._need_production_request(procurement.product_id):
-                return self._run_production_request(
+                self._run_production_request(
                     procurement.product_id,
                     procurement.product_qty,
                     procurement.product_uom,

--- a/mrp_production_request/models/stock_rule.py
+++ b/mrp_production_request/models/stock_rule.py
@@ -79,6 +79,14 @@ class StockRule(models.Model):
             )
 
         # create the MR as SUPERUSER because the current user may not
+        # to avoid everytime MR creation
+        existing_MRs = request_obj.search(
+            [('product_id', '=', product_id.id),
+             ('state', '=', 'to_approve'),
+             ('company_id', '=', values['company_id'].id),
+             ('procurement_group_id', '=', values.get('group_id').id)])
+        if existing_MRs:
+            return True
         # have the rights to do it (mto product launched by a sale for example)
         request = request_obj_sudo.create(
             self._prepare_mrp_production_request(


### PR DESCRIPTION
This is a FIX to allow create more MR per sale/order for  different Products.
The current version is only allowed to have one MR per sale/order

https://github.com/OCA/manufacture/issues/529
Follow the discussion.