### PR TITLE
Fix ACL error

### DIFF
--- a/mrp_production_request/models/stock_warehouse_orderpoint.py
+++ b/mrp_production_request/models/stock_warehouse_orderpoint.py
@@ -9,7 +9,7 @@ class Orderpoint(models.Model):
 
     def _quantity_in_progress(self):
         res = super()._quantity_in_progress()
-        mrp_requests = self.env['mrp.production.request'].search([
+        mrp_requests = self.env['mrp.production.request'].sudo().search([
             ('state', 'not in', ('done', 'cancel')),
             ('orderpoint_id', 'in', self.ids),
         ])


### PR DESCRIPTION
An ACL error is raised when a user without valid rights try to access `mrp.production.request` by opening a purchase order line form.

Computing quantity can be done as SU to avoid this.