### PR TITLE
[FIX] when a bom has quantity multiplier, consider it

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -120,7 +120,13 @@ class MultiLevelMrp(models.TransientModel):
         )
         if not product_mrp_area:
             raise exceptions.Warning(_("No MRP product found"))
-
+        factor = (
+            product.product_id.uom_id._compute_quantity(
+                qty, bomline.bom_id.product_uom_id
+            )
+            / bomline.bom_id.product_qty
+        )
+        line_quantity = factor * bomline.product_qty
         return {
             "mrp_area_id": product.mrp_area_id.id,
             "product_id": bomline.product_id.id,
@@ -129,7 +135,7 @@ class MultiLevelMrp(models.TransientModel):
             "purchase_order_id": None,
             "purchase_line_id": None,
             "stock_move_id": None,
-            "mrp_qty": -(qty * bomline.product_qty),  # TODO: review with UoM
+            "mrp_qty": -line_quantity,  # TODO: review with UoM
             "current_qty": None,
             "mrp_date": mrp_date_demand_2,
             "current_date": None,


### PR DESCRIPTION
When the BOM is specified with a certain quantity, then consider it as a factor during the BOM explosion.

![image](https://user-images.githubusercontent.com/7683926/95776353-6e626e80-0cc4-11eb-8743-7641261bf03e.png)

cc @LoisRForgeFlow @HviorForgeFlow @AdriaGForgeFlow