### PR TITLE
[12.0][FIX] mrp_multi_level: send company recordset to _get_rule

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -173,7 +173,7 @@ class ProductMRPArea(models.Model):
             proc_loc = rec.location_proc_id or rec.mrp_area_id.location_id
             values = {
                 'warehouse_id': rec.mrp_area_id.warehouse_id,
-                'company_id': self.env.user.company_id.id,
+                'company_id': self.env.user.company_id,
                 # TODO: better way to get company
             }
             rule = group_obj._get_rule(rec.product_id, proc_loc, values)


### PR DESCRIPTION
Error was raising due to odoo/odoo@31a54b5.

cc @pedrobaeza fix for https://github.com/OCA/manufacture/issues/550.

@ForgeFlow