### PR TITLE
[12.0][FIX] mrp_subcontracting: Skip processed MO when validating receipt

### DIFF
--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -49,9 +49,9 @@ class StockPicking(models.Model):
         productions = self.env['mrp.production']
         for picking in self:
             for move in picking.move_lines:
-                if not move.is_subcontract:
-                    continue
                 production = move.move_orig_ids.mapped('production_id')
+                if not move.is_subcontract or production.state in ('done', 'cancel'):
+                    continue
                 if move._has_tracked_subcontract_components():
                     move.move_orig_ids.filtered(
                         lambda m: m.state not in ('done', 'cancel')


### PR DESCRIPTION
Check state of the MO before trying to process it, skip processed MO when validating receipt.
Fixes: #560