### PR TITLE
[12.0] [FIX] quality_control_stock: expected singleton when setting multiple stock pickings to Done

### DIFF
--- a/quality_control_stock/models/stock_picking.py
+++ b/quality_control_stock/models/stock_picking.py
@@ -45,18 +45,19 @@ class StockPicking(models.Model):
     def action_done(self):
         res = super(StockPicking, self).action_done()
         inspection_model = self.env['qc.inspection']
-        qc_trigger = self.env['qc.trigger'].search(
-            [('picking_type_id', '=', self.picking_type_id.id)])
-        for operation in self.move_lines:
-            trigger_lines = set()
-            for model in ['qc.trigger.product_category_line',
-                          'qc.trigger.product_template_line',
-                          'qc.trigger.product_line']:
-                partner = (self.partner_id
-                           if qc_trigger.partner_selectable else False)
-                trigger_lines = trigger_lines.union(
-                    self.env[model].get_trigger_line_for_product(
-                        qc_trigger, operation.product_id, partner=partner))
-            for trigger_line in _filter_trigger_lines(trigger_lines):
-                inspection_model._make_inspection(operation, trigger_line)
+        for record in self:
+            qc_trigger = record.env['qc.trigger'].search(
+                [('picking_type_id', '=', record.picking_type_id.id)])
+            for operation in record.move_lines:
+                trigger_lines = set()
+                for model in ['qc.trigger.product_category_line',
+                              'qc.trigger.product_template_line',
+                              'qc.trigger.product_line']:
+                    partner = (record.partner_id
+                               if qc_trigger.partner_selectable else False)
+                    trigger_lines = trigger_lines.union(
+                        record.env[model].get_trigger_line_for_product(
+                            qc_trigger, operation.product_id, partner=partner))
+                for trigger_line in _filter_trigger_lines(trigger_lines):
+                    inspection_model._make_inspection(operation, trigger_line)
         return res


### PR DESCRIPTION
There's an "expected singleton" error when setting multiple stock pickings to _Done_. We found this issue when aplying a mass operation (this can be achieved by means of `stock_picking_mass_action` module) on multiple pickings. Specifically, it was found after transfering the pickings and then setting them to _Done_.
To fix this, we added a for record in self in the `action_done` method in the `stock.picking` model, inside the `quality_control_stock` module.