### PR TITLE
[12.0][IMP] mrp_production_auto_post_inventory, add cron job

### DIFF
--- a/mrp_production_auto_post_inventory/__manifest__.py
+++ b/mrp_production_auto_post_inventory/__manifest__.py
@@ -14,6 +14,7 @@
         'mrp',
     ],
     'data': [
+        'data/cron.xml',
         'views/res_config_settings.xml',
     ],
     'installable': True,

--- a/mrp_production_auto_post_inventory/data/cron.xml
+++ b/mrp_production_auto_post_inventory/data/cron.xml
@@ -1,0 +1,12 @@
+<odoo noupdate="1">
+    <record id="ir_cron_mrp_production_post_inventory" model="ir.cron">
+        <field name="name">MRP Production Post Inventory</field>
+        <field name="model_id" ref="mrp.model_mrp_production"/>
+        <field name="state">code</field>
+        <field name="code">model._cron_post_inventory()</field>
+        <field name="interval_number">30</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+    </record>
+</odoo>

--- a/mrp_production_auto_post_inventory/models/__init__.py
+++ b/mrp_production_auto_post_inventory/models/__init__.py
@@ -1,2 +1,3 @@
 from . import company
 from . import res_config_settings
+from . import mrp_production

--- a/mrp_production_auto_post_inventory/models/company.py
+++ b/mrp_production_auto_post_inventory/models/company.py
@@ -12,3 +12,7 @@ class ResCompany(models.Model):
         help="Sets to automatic the post-inventory step in a manufacturing"
              "order. The inventory will be automatically posted after some "
              "quantity has been produced")
+
+    mrp_production_auto_post_inventory_cron = fields.Boolean(
+        string="Auto Post-Inventory by Scheduler",
+        help="Defer auto post-inventory by scheduled job")

--- a/mrp_production_auto_post_inventory/models/mrp_production.py
+++ b/mrp_production_auto_post_inventory/models/mrp_production.py
@@ -1,0 +1,29 @@
+# © 2017 Ecosoft (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+from odoo import models, fields, api
+
+_logger = logging.getLogger(__name__)
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    to_post_inventory_cron = fields.Boolean(
+        string="To Post-Inventory by Job",
+        track_visibility="onchange",
+        help="Checked if configured in settings to auto post-inventory by scheduler. "
+        "Unchecked when post-inventory is done",
+    )
+
+    @api.multi
+    def post_inventory(self):
+        res = super().post_inventory()
+        self.write({"to_post_inventory_cron": False})
+        return res
+
+    @api.model
+    def _cron_post_inventory(self, limit=1000):
+        """ This method is called from a cron job. """
+        records = self.search([("to_post_inventory_cron", "=", True)], limit=limit)
+        records.post_inventory()

--- a/mrp_production_auto_post_inventory/models/res_config_settings.py
+++ b/mrp_production_auto_post_inventory/models/res_config_settings.py
@@ -11,3 +11,7 @@ class ResConfigSettings(models.TransientModel):
     mrp_production_auto_post_inventory = fields.Boolean(
         related='company_id.mrp_production_auto_post_inventory',
         readonly=False)
+
+    mrp_production_auto_post_inventory_cron = fields.Boolean(
+        related='company_id.mrp_production_auto_post_inventory_cron',
+        readonly=False)

--- a/mrp_production_auto_post_inventory/readme/CONTRIBUTORS.rst
+++ b/mrp_production_auto_post_inventory/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Adria Gil Sorribes <adria.gil@eficent.com>
 * Lorenzo Battistini <lb@takobi.online>
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/mrp_production_auto_post_inventory/readme/DESCRIPTION.rst
+++ b/mrp_production_auto_post_inventory/readme/DESCRIPTION.rst
@@ -2,3 +2,6 @@ This module allows the user to set to automatic the post inventory step
 in a manufacturing order. Having this option activated, the inventory will
 be automatically posted after some quantity has been produced without the
 need of completing the whole manufacturing order.
+
+There is also to post inventory by cron job.
+This is useful when posting inventory immediatelly take long time to process.

--- a/mrp_production_auto_post_inventory/views/res_config_settings.xml
+++ b/mrp_production_auto_post_inventory/views/res_config_settings.xml
@@ -22,6 +22,12 @@
                             Sets to automatic the post-inventory step in a manufacturing order.
                             The inventory will be automatically posted after some quantity has been produced.
                         </div>
+                        <div class="content-group" attrs="{'invisible': [('mrp_production_auto_post_inventory','=',False)]}">
+                            <div id="mrp_production_auto_post_inventory_cron" class="mt16">
+                                <field name="mrp_production_auto_post_inventory_cron" class="oe_inline"/>
+                                <label string="Use scheduled job to post-inventory" class="o_light_label" for="mrp_production_auto_post_inventory_cron"/>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/mrp_production_auto_post_inventory/wizard/mrp_product_produce.py
+++ b/mrp_production_auto_post_inventory/wizard/mrp_product_produce.py
@@ -11,5 +11,8 @@ class MrpProductProduce(models.TransientModel):
     def do_produce(self):
         res = super(MrpProductProduce, self).do_produce()
         if self.production_id.company_id.mrp_production_auto_post_inventory:
-            self.production_id.post_inventory()
+            if self.production_id.company_id.mrp_production_auto_post_inventory_cron:
+                self.production_id.to_post_inventory_cron = True
+            else:
+                self.production_id.post_inventory()
         return res


### PR DESCRIPTION
This extend the module by option to post inventory by scheduled job.

![image](https://user-images.githubusercontent.com/1973598/102966963-873c9b00-4523-11eb-8144-66bd760c4638.png)

**Note:** We add this option because our post-inventory take very long time (caused by use of S/N and multi level BOM).