### PR TITLE
[12.0][FIX] mrp_auto_create_lot: be able to force existing lot

### DIFF
--- a/mrp_auto_create_lot/models/mrp_workorder.py
+++ b/mrp_auto_create_lot/models/mrp_workorder.py
@@ -9,7 +9,7 @@ class MrpWorkorder(models.Model):
 
     @api.multi
     def record_production(self):
-        if self.product_id.auto_create_lot:
+        if not self.final_lot_id and self.product_id.auto_create_lot:
             self.final_lot_id = self.env['stock.production.lot'].create({
                 'product_id': self.product_id.id,
             })


### PR DESCRIPTION
To be able to assign an existing lot