### PR TITLE
[IMP] mrp_subcontracting: Partial subcontracting receptions

### DIFF
--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -50,7 +50,12 @@ class StockPicking(models.Model):
         for picking in self:
             for move in picking.move_lines:
                 production = move.move_orig_ids.mapped('production_id')
-                if not move.is_subcontract or production.state in ('done', 'cancel'):
+                if (
+                    not move.is_subcontract or
+                    not move.quantity_done or
+                    not production or
+                    production.state in ('done', 'cancel')
+                ):
                     continue
                 if move._has_tracked_subcontract_components():
                     move.move_orig_ids.filtered(


### PR DESCRIPTION
We have had some case in which we need to partially receive a subcontracting purchase order, but current code does not allow it because if there is no quantity in the picking line, Odoo blocks the process (https://github.com/odoo/odoo/blob/12.0/addons/mrp/wizard/mrp_product_produce.py#L55). 

Another case, if we, for some reason, cancel the production order and the relations between movements and it are lost, 
it also blocks the process.