### PR TITLE
FIX - If product for subcontracting have track serial/lot and have co…

### DIFF
--- a/mrp_subcontracting/models/stock_move.py
+++ b/mrp_subcontracting/models/stock_move.py
@@ -73,12 +73,11 @@ class StockMove(models.Model):
         if self.is_subcontract:
             rounding = self.product_uom.rounding
             production = self.move_orig_ids.mapped("production_id")
-            if self._has_tracked_subcontract_components() and\
-                    float_compare(production.qty_produced,
-                                  production.product_uom_qty,
-                                  precision_rounding=rounding) < 0 and\
-                    float_compare(self.quantity_done, self.product_uom_qty,
-                                  precision_rounding=rounding) < 0:
+            if float_compare(production.qty_produced,
+                             production.product_uom_qty,
+                             precision_rounding=rounding) < 0 and \
+                float_compare(self.quantity_done, self.product_uom_qty,
+                              precision_rounding=rounding) < 0:
                 return self._action_record_components()
         action = super().action_show_details()
         if self.is_subcontract and self._has_tracked_subcontract_components():
@@ -136,7 +135,7 @@ class StockMove(models.Model):
                     force_company=move.company_id.id)
                 .property_stock_subcontractor.id
             })
-        for picking, subcontract_details in\
+        for picking, subcontract_details in \
                 subcontract_details_per_picking.items():
             picking._subcontracted_produce(subcontract_details)
 

--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -30,7 +30,9 @@ class StockPicking(models.Model):
             subcontracted_moves = subcontracted_productions.mapped(
                 'move_raw_ids')
             if all(subcontracted_move.has_tracking == 'none'
-                   for subcontracted_move in subcontracted_moves):
+                   for subcontracted_move in subcontracted_moves) and \
+                all(subcontracted_production.product_id.tracking == 'none'
+                    for subcontracted_production in subcontracted_productions):
                 picking.display_action_record_components = False
                 continue
             # Hide if the production is to close
@@ -108,8 +110,6 @@ class StockPicking(models.Model):
     def action_record_components(self):
         self.ensure_one()
         for move in self.move_lines:
-            if not move._has_tracked_subcontract_components():
-                continue
             production = move.move_orig_ids.mapped("production_id")
             if not production or production.state in ('done', 'to_close'):
                 continue


### PR DESCRIPTION
…mponent with no track, now the button 'Record Components' is displayed and also if click on stock move of picking, is displayed wizard for record production of product(also field serial/lot)