### PR TITLE
[14.0][IMP] repair_stock_move: If the repaired product has lot/series control, the reservation will be made on the lot informed in the repair order

### DIFF
--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -18,7 +18,7 @@ class RepairOrder(models.Model):
         help="Technical field used to compute whether the button "
         "'Check Availability' should be displayed.",
     )
-    ignore_availability = fields.Boolean()
+    ignore_availability = fields.Boolean(copy=False)
     # Make "Parts" editable in more states.
     operations = fields.One2many(
         states={

--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -74,12 +74,12 @@ class RepairOrder(models.Model):
         res = super().action_repair_confirm()
         for repair in self:
             moves = self.env["stock.move"]
+            move = repair._create_repair_stock_move()
+            repair.move_id = move
             for operation in repair.operations:
                 move = operation.create_stock_move()
                 moves |= move
                 operation.write({"move_id": move.id})
-            move = repair._create_repair_stock_move()
-            repair.move_id = move
         self.mapped("stock_move_ids")._action_confirm()
         return res
 

--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -100,7 +100,10 @@ class RepairOrder(models.Model):
         return res
 
     def action_force_availability(self):
-        self.write({"ignore_availability": True})
+        if self.ignore_availability:
+            self.write({"ignore_availability": False})
+        else:
+            self.write({"ignore_availability": True})
 
     def _force_qty_done_in_repair_lines(self):
         for operation in self.mapped("operations"):

--- a/repair_stock_move/models/stock_move.py
+++ b/repair_stock_move/models/stock_move.py
@@ -12,3 +12,22 @@ class StockMove(models.Model):
         string="Repair Line",
         ondelete="cascade",
     )
+
+    def _update_reserved_quantity(self, need, available_quantity,
+                                  location_id, lot_id=None,
+                                  package_id=None, owner_id=None,
+                                  strict=True):
+        if self.repair_id.lot_id and not self.repair_line_id:
+            lot_id = self.repair_id.lot_id
+        return super()._update_reserved_quantity(
+            need, available_quantity, location_id, lot_id=lot_id,
+            package_id=package_id, owner_id=owner_id, strict=strict)
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        vals = super()._prepare_move_line_vals(
+            quantity=quantity, reserved_quant=reserved_quant)
+        if self.repair_id.lot_id and not self.repair_line_id:
+            lot = self.repair_id.lot_id
+            if reserved_quant and lot:
+                vals['lot_id'] = lot.id
+        return vals

--- a/repair_stock_move/models/stock_move.py
+++ b/repair_stock_move/models/stock_move.py
@@ -13,21 +13,34 @@ class StockMove(models.Model):
         ondelete="cascade",
     )
 
-    def _update_reserved_quantity(self, need, available_quantity,
-                                  location_id, lot_id=None,
-                                  package_id=None, owner_id=None,
-                                  strict=True):
+    def _update_reserved_quantity(
+        self,
+        need,
+        available_quantity,
+        location_id,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=True,
+    ):
         if self.repair_id.lot_id and not self.repair_line_id:
             lot_id = self.repair_id.lot_id
         return super()._update_reserved_quantity(
-            need, available_quantity, location_id, lot_id=lot_id,
-            package_id=package_id, owner_id=owner_id, strict=strict)
+            need,
+            available_quantity,
+            location_id,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
         vals = super()._prepare_move_line_vals(
-            quantity=quantity, reserved_quant=reserved_quant)
+            quantity=quantity, reserved_quant=reserved_quant
+        )
         if self.repair_id.lot_id and not self.repair_line_id:
             lot = self.repair_id.lot_id
             if reserved_quant and lot:
-                vals['lot_id'] = lot.id
+                vals["lot_id"] = lot.id
         return vals

--- a/repair_stock_move/views/repair_order_views.xml
+++ b/repair_stock_move/views/repair_order_views.xml
@@ -22,7 +22,15 @@
                     type="object"
                     groups="base.group_user"
                 />
+                <button
+                    name="action_force_availability"
+                    attrs="{'invisible': [('ignore_availability', '=', False)]}"
+                    string="Enable Check Availability"
+                    type="object"
+                    groups="base.group_user"
+                />
                 <field name="show_check_availability" invisible="1" />
+                <field name="ignore_availability" invisible="1" />
             </header>
             <field name="product_qty" position="attributes">
                 <attribute name="attrs" />


### PR DESCRIPTION
Other improvements:
- [x] add new button to disable ignore_availability
- [x] change create stock_move order (first repaired product)
- [x] add copy=false on ignore_availability field