### PR TITLE
[13.0][mrp_kit_drop_ship] Kits behave as normal products when drop shipped

### DIFF
--- a/mrp_kit_drop_ship/__init__.py
+++ b/mrp_kit_drop_ship/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2016 Antiun Ingenieria S.L. - Javier Iniesta
+# Copyright 2019 Rubén Bravo <rubenred18@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/mrp_kit_drop_ship/__manifest__.py
+++ b/mrp_kit_drop_ship/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2021 Forgeflow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+{
+    "name": "MRP Kit Drop Ship",
+    "summary": "Kits behave as normal products when drop shipped",
+    "version": "13.0.1.0.0",
+    "category": "Manufacturing",
+    "website": "https://github.com/oca/manufacture",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["mrp", "stock_dropshipping"],
+}

--- a/mrp_kit_drop_ship/models/__init__.py
+++ b/mrp_kit_drop_ship/models/__init__.py
@@ -1,0 +1,2 @@
+from . import procurement_group
+from . import mrp_bom

--- a/mrp_kit_drop_ship/models/mrp_bom.py
+++ b/mrp_kit_drop_ship/models/mrp_bom.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Forgeflow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, models
+
+
+class MrpBom(models.Model):
+    _inherit = "mrp.bom"
+
+    @api.model
+    def _bom_find(
+        self,
+        product_tmpl=None,
+        product=None,
+        picking_type=None,
+        company_id=False,
+        bom_type=False,
+    ):
+        if self.env.context.get("ignore_kit", False):
+            return False
+        return super(MrpBom, self)._bom_find(
+            product_tmpl=product_tmpl,
+            product=product,
+            picking_type=picking_type,
+            company_id=company_id,
+            bom_type=bom_type,
+        )

--- a/mrp_kit_drop_ship/models/procurement_group.py
+++ b/mrp_kit_drop_ship/models/procurement_group.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Forgeflow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, models
+
+
+class ProcurementGroup(models.Model):
+    _inherit = "procurement.group"
+
+    @api.model
+    def run(self, procurements):
+        other_procurements = []
+        for procurement in procurements:
+            rule = self._get_rule(
+                procurement.product_id, procurement.location_id, procurement.values
+            )
+            if (
+                rule.location_id.usage == "customer"
+                and rule.location_src_id.usage == "supplier"
+            ):
+                return super(ProcurementGroup, self.with_context(ignore_kit=True)).run(
+                    [procurement]
+                )
+            other_procurements.append(procurement)
+        return super(ProcurementGroup, self).run(other_procurements)

--- a/mrp_kit_drop_ship/readme/CONTRIBUTORS.rst
+++ b/mrp_kit_drop_ship/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `ForgeFlow <https://www.forgeflow.com>`_:
+
+  * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>

--- a/mrp_kit_drop_ship/readme/DESCRIPTION.rst
+++ b/mrp_kit_drop_ship/readme/DESCRIPTION.rst
@@ -1,0 +1,11 @@
+Without this module, if a product is being procured and has an existing Bill of
+Materials of type Kit, the components of the product are going to be
+procured, instead of the main product.
+
+This module introduces the capability to ignore the existence of the kit
+during procurement, when the procurement is associated with a dropship. That
+is, when the product is going to be sourced from a third party vendor to the
+customer.
+
+Upon confirmation of the purchase order the system will still explode the
+product into components within the drop ship picking.

--- a/mrp_kit_drop_ship/tests/__init__.py
+++ b/mrp_kit_drop_ship/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_kit_drop_ship

--- a/mrp_kit_drop_ship/tests/test_mrp_kit_drop_ship.py
+++ b/mrp_kit_drop_ship/tests/test_mrp_kit_drop_ship.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Forgeflow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
+
+from odoo.tests import common
+
+
+class TestMrpKitDropShip(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.dropship_route = cls.env.ref("stock_dropshipping.route_drop_shipping")
+        cls.buy_route = cls.env.ref("purchase_stock.route_warehouse0_buy")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test mrp_sale_info product",
+                "type": "product",
+                "route_ids": [(4, cls.dropship_route.id), (4, cls.buy_route.id)],
+            }
+        )
+        cls.product_2 = cls.env["product.product"].create(
+            {"name": "Test kit component 1", "type": "consu"}
+        )
+        cls.product_3 = cls.env["product.product"].create(
+            {"name": "Test kit component 2", "type": "consu"}
+        )
+        cls.bom = cls.env["mrp.bom"].create(
+            {"product_tmpl_id": cls.product.product_tmpl_id.id, "type": "phantom"}
+        )
+        cls.env["mrp.bom.line"].create(
+            {"bom_id": cls.bom.id, "product_id": cls.product_2.id, "product_qty": 2}
+        )
+        cls.env["mrp.bom.line"].create(
+            {"bom_id": cls.bom.id, "product_id": cls.product_3.id, "product_qty": 2}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test client"})
+        cls.vendor = cls.env["res.partner"].create({"name": "Test vendor"})
+
+        cls.env["product.supplierinfo"].create(
+            {
+                "product_tmpl_id": cls.product.product_tmpl_id.id,
+                "product_id": cls.product.id,
+                "name": cls.vendor.id,
+            }
+        )
+
+    def test_procure(self):
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 1,
+                            "route_id": self.dropship_route.id,
+                        },
+                    ),
+                ],
+            }
+        )
+        sale_order.action_confirm()
+        self.assertFalse(
+            sale_order.picking_ids,
+            "No pickings should have been created out of the " "sales order.",
+        )
+        purchase = self.env["purchase.order"].search(
+            [("partner_id", "=", self.vendor.id)]
+        )
+        self.assertTrue(purchase, "an RFQ should have been created by the scheduler")
+        purchase.button_confirm()
+        move_line = self.env["stock.move.line"].search(
+            [
+                (
+                    "location_dest_id",
+                    "=",
+                    self.env.ref("stock.stock_location_customers").id,
+                ),
+                ("product_id", "=", self.product_2.id),
+            ]
+        )
+        # The stock move is created for the components
+        self.assertEquals(len(move_line), 1)
+        self.assertEquals(
+            len(move_line.ids), 1, "There should be exactly one move line"
+        )
+        purchase.picking_ids.move_lines.write({"quantity_done": 2})
+        purchase.picking_ids.button_validate()
+        self.assertEquals(sale_order.order_line[0].qty_delivered, 1)

--- a/setup/mrp_kit_drop_ship/odoo/addons/mrp_kit_drop_ship
+++ b/setup/mrp_kit_drop_ship/odoo/addons/mrp_kit_drop_ship
@@ -1,0 +1,1 @@
+../../../../mrp_kit_drop_ship

--- a/setup/mrp_kit_drop_ship/setup.py
+++ b/setup/mrp_kit_drop_ship/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
MRP Kit Drop Ship
==============
Without this module, if a product is being procured and has an existing Bill of
Materials of type Kit, the components of the product are going to be
procured, instead of the main product.

This module introduces the capability to ignore the existence of the kit
during procurement, when the procurement is associated with a dropship. That
is, when the product is going to be sourced from a third party vendor to the
customer.

Upon confirmation of the purchase order the system will still explode the
product into components within the drop ship picking.

cc @JordiMForgeFlow 