### PR TITLE
[ADD] mrp_account_analytic: generate Analytic Items for manufacturing consumptions.

### DIFF
--- a/mrp_account_analytic/README.rst
+++ b/mrp_account_analytic/README.rst
@@ -1,0 +1,1 @@
+To generate

--- a/mrp_account_analytic/__init__.py
+++ b/mrp_account_analytic/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/mrp_account_analytic/__manifest__.py
+++ b/mrp_account_analytic/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Manufacturing Analytic Items",
+    "summary": "Consuming raw materials and operations generated Analytic Items",
+    "version": "14.0.1.0.0",
+    "category": "Manufacturing",
+    "author": "Open Source Integrators, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/manufacture",
+    "license": "AGPL-3",
+    "depends": ["mrp_analytic"],
+    "data": [
+        "views/account_analytic_line_view.xml",
+    ],
+    "installable": True,
+    "maintainers": ["dreispt"],
+    "development_status": "Beta",
+}

--- a/mrp_account_analytic/models/__init__.py
+++ b/mrp_account_analytic/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_analytic_line
+from . import mrp_workorder
+from . import stock_move

--- a/mrp_account_analytic/models/account_analytic_line.py
+++ b/mrp_account_analytic/models/account_analytic_line.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2020 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+
+    manufacturing_order_id = fields.Many2one(
+        "mrp.production",
+        string="Related Manufacturing Order",
+    )
+    stock_move_id = fields.Many2one(
+        "stock.move",
+        string="Related Stock Move",
+    )
+    workorder_id = fields.Many2one(
+        "mrp.workorder",
+        string="Work Order",
+    )

--- a/mrp_account_analytic/models/mrp_workorder.py
+++ b/mrp_account_analytic/models/mrp_workorder.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, fields, models
+
+
+class MRPWorkOrder(models.Model):
+    _inherit = "mrp.workorder"
+
+    def _prepare_mrp_workorder_analytic_item(self):
+        """
+        Prepare additional values for Analytic Items created.
+        For compatibility with analytic_activity_cost
+        """
+        self.ensure_one()
+        return {
+            "name": "{} / {}".format(self.production_id.name, self.name),
+            "account_id": self.production_id.analytic_account_id.id,
+            "date": fields.Date.today(),
+            "company_id": self.company_id.id,
+            "manufacturing_order_id": self.production_id.id,
+            "workorder_id": self.id,
+            "unit_amount": self.duration / 60,  # convert minutes to hours
+            "amount": -self.duration / 60 * self.workcenter_id.costs_hour,
+        }
+
+    def generate_mrp_work_analytic_line(self):
+        """Generate Analytic Lines"""
+        AnalyticLine = self.env["account.analytic.line"].sudo()
+        workorders = self.filtered("production_id.analytic_account_id")
+        existing_items = workorders and AnalyticLine.search(
+            [("workorder_id", "in", self.ids)]
+        )
+        for workorder in workorders:
+            line_vals = self._prepare_mrp_workorder_analytic_item()
+            analytic_lines = existing_items.filtered(
+                lambda x: x.workorder_id == workorder
+            )
+            if analytic_lines:
+                for analytic_line in analytic_lines:
+                    analytic_line.write(line_vals)
+                    analytic_line.on_change_unit_amount()
+            else:
+                analytic_line = AnalyticLine.create(line_vals)
+                analytic_line.on_change_unit_amount()
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        if vals.get("duration"):
+            res.generate_mrp_work_analytic_line()
+        return res
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("duration"):
+            self.generate_mrp_work_analytic_line()
+        return res

--- a/mrp_account_analytic/models/stock_move.py
+++ b/mrp_account_analytic/models/stock_move.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2021 Open Source Integrators
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _prepare_mrp_raw_material_analytic_line(self):
+        """
+        Prepare additional values for Analytic Items created.
+        """
+        self.ensure_one()
+        move = self
+        mrp_order = move.raw_material_production_id
+        return {
+            "date": move.date,
+            "name": "{} / {}".format(mrp_order.name, move.product_id.display_name),
+            "ref": mrp_order.name,
+            "account_id": mrp_order.analytic_account_id.id,
+            "manufacturing_order_id": mrp_order.id,
+            "company_id": mrp_order.company_id.id,
+            "stock_move_id": move.id,
+            "product_id": move.product_id.id,
+            "unit_amount": move.quantity_done,
+        }
+
+    def generate_mrp_raw_analytic_line(self):
+        """
+        Generate Analytic Lines.
+        One Analytic Item for each Stock Move line.
+        If the Stock Move is updated, the existing Analytic Item is updated.
+        """
+        AnalyticLine = self.env["account.analytic.line"].sudo()
+        existing_items = AnalyticLine.search([("stock_move_id", "in", self.ids)])
+        for move in self.filtered("raw_material_production_id.analytic_account_id"):
+            line_vals = move._prepare_mrp_raw_material_analytic_line()
+            if move in existing_items.mapped("stock_move_id"):
+                analytic_line = existing_items.filtered(
+                    lambda x: x.stock_move_id == move
+                )
+                analytic_line.write(line_vals)
+                analytic_line.on_change_unit_amount()
+            elif line_vals.get("unit_amount"):
+                analytic_line = AnalyticLine.create(line_vals)
+                analytic_line.on_change_unit_amount()
+
+    def write(self, vals):
+        """ When material is consumed, generate Analytic Items """
+        res = super().write(vals)
+        if vals.get("quantity_done"):
+            self.generate_mrp_raw_analytic_line()
+        return res
+
+    @api.model
+    def create(self, vals):
+        qty_done = vals.get("quantity_done")
+        res = super().create(vals)
+        if qty_done:
+            res.generate_mrp_raw_analytic_line()
+        return res
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def write(self, vals):
+        qty_done = vals.get("qty_done")
+        res = super().write(vals)
+        if qty_done:
+            self.mapped("move_id").generate_mrp_raw_analytic_line()
+        return res
+
+    @api.model
+    def create(self, vals):
+        qty_done = vals.get("qty_done")
+        res = super().create(vals)
+        if qty_done:
+            res.mapped("move_id").generate_mrp_raw_analytic_line()
+        return res

--- a/mrp_account_analytic/readme/CONTRIBUTORS.rst
+++ b/mrp_account_analytic/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Daniel Reis <dreis@opensourceintegrators.com>

--- a/mrp_account_analytic/readme/DESCRIPTION.rst
+++ b/mrp_account_analytic/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Generates Analytic Items during manufacturing operations.
+
+When raw materials are consumed or work center time is recorded,
+Analytic Items are created, capturing teh corresponsing quantity and cost.

--- a/mrp_account_analytic/readme/USAGE.rst
+++ b/mrp_account_analytic/readme/USAGE.rst
@@ -1,0 +1,14 @@
+To use:
+
+* On the *Manufacturing Order*, *Miscellaneous* tab, set the Analytic Account to use.
+  This may correspond to a Project.
+
+On Manufacturing Orders, Analytic Items are automatically generated when:
+
+  * Raw materials are consumed, or
+  * Time is spent on work order Operation.
+
+To analyze costs:
+
+* Go to *Manufacturing > Reports > Analytic Items*.
+  The cost data is available there and can be used for analysis.

--- a/mrp_account_analytic/tests/__init__.py
+++ b/mrp_account_analytic/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_analytic

--- a/mrp_account_analytic/tests/test_mrp_analytic.py
+++ b/mrp_account_analytic/tests/test_mrp_analytic.py
@@ -1,0 +1,116 @@
+from odoo.tests import Form, common
+
+
+class TestMRP(common.TransactionCase):
+    """
+    Create a Manufacturing Order, with Raw Materials and Operations.
+    Consuming raw materials generates or updates Analytic Items.
+    Working on Operations generates or updates Analytic Items.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Analytic Account
+        self.analytic_1 = self.env["account.analytic.account"].create({"name": "Job 1"})
+        # Work Center
+        self.mrp_workcenter_1 = self.env["mrp.workcenter"].create(
+            {
+                "name": "Assembly Line",
+                "costs_hour": 40,
+            }
+        )
+        # Products
+        self.product_lemonade = self.env["product.product"].create(
+            {
+                "name": "Lemonade",
+                "type": "product",
+                "standard_price": 20,
+            }
+        )
+        self.product_lemon = self.env["product.product"].create(
+            {
+                "name": "Lemon",
+                "type": "product",
+                "standard_price": 1,
+            }
+        )
+        # BOM
+        self.mrp_bom_lemonade = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": self.product_lemonade.product_tmpl_id.id,
+                "operation_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "workcenter_id": self.mrp_workcenter_1.id,
+                            "name": "Squeeze Lemons",
+                            "time_cycle": 15,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.mrp_bom_lemonade.write(
+            {
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_lemon.id,
+                            "product_qty": 4,
+                        },
+                    )
+                ]
+            }
+        )
+        # MO
+        mo_create_form = Form(self.env["mrp.production"])
+        mo_create_form.product_id = self.product_lemonade
+        mo_create_form.bom_id = self.mrp_bom_lemonade
+        mo_create_form.product_qty = 1
+        self.mo_lemonade = mo_create_form.save()
+        self.mo_lemonade.analytic_account_id = self.analytic_1
+        self.mo_lemonade.action_confirm()
+
+    def test_100_one_step_produce(self):
+        # Form edit the MO and Save
+        mo_form = Form(self.mo_lemonade)
+        mo_form.qty_producing = 1
+        mo_lemonade = mo_form.save()
+        # Set 15 minutes to work time and "Mark As Done"
+        mo_lemonade.workorder_ids.duration = 15
+        mo_lemonade.button_mark_done()
+
+        analytic_items = self.env["account.analytic.line"].search(
+            [("manufacturing_order_id", "=", mo_lemonade.id)]
+        )
+        # Expected (4 * 1.00) + (0.25 * 40.00) => 14.00
+        analytic_qty = sum(analytic_items.mapped("unit_amount"))
+        self.assertEqual(analytic_qty, 4.25, "Expected Analytic Items total quantity")
+        analytic_amount = sum(analytic_items.mapped("amount"))
+        self.assertEqual(
+            analytic_amount, -14.00, "Expected Analytic Items total amount"
+        )
+
+    def test_110_two_step_produce(self):
+        # Consume some raw material
+        self.mo_lemonade.move_raw_ids.write({"quantity_done": 1})
+        self.mo_lemonade.move_raw_ids.write({"quantity_done": 2})
+        self.mo_lemonade.move_raw_ids.write({"quantity_done": 4})
+        # Work on operations up to 15 minutes
+        self.mo_lemonade.workorder_ids.write({"duration": 5})
+        self.mo_lemonade.workorder_ids.write({"duration": 10})
+        self.mo_lemonade.workorder_ids.write({"duration": 15})
+
+        analytic_items = self.env["account.analytic.line"].search(
+            [("manufacturing_order_id", "=", self.mo_lemonade.id)]
+        )
+        # Expected (4 * 1.00) + (0.25 * 40.00) => 14.00
+        analytic_qty = sum(analytic_items.mapped("unit_amount"))
+        self.assertEqual(analytic_qty, 4.25, "Expected Analytic Items total quantity")
+        analytic_amount = sum(analytic_items.mapped("amount"))
+        self.assertEqual(
+            analytic_amount, -14.00, "Expected Analytic Items total amount"
+        )

--- a/mrp_account_analytic/views/account_analytic_line_view.xml
+++ b/mrp_account_analytic/views/account_analytic_line_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="custom_account_analytic_line_form_view" model="ir.ui.view">
+        <field name="name">account.analytic.line.custom.form</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_form" />
+        <field name="arch" type="xml">
+            <group name="amount" position="after">
+                <group name="manufacture" string="Manufacture">
+                    <field name="stock_move_id" />
+                    <field name="manufacturing_order_id" />
+                </group>
+            </group>
+        </field>
+    </record>
+    <record id="custom_account_analytic_line_filter_view" model="ir.ui.view">
+        <field name="name">account.analytic.line.custom.filter</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="analytic.view_account_analytic_line_filter" />
+        <field name="arch" type="xml">
+            <filter name="date" position="after">
+                <filter
+                    name="related-mo"
+                    string="Related to MO"
+                    domain="[('manufacturing_order_id','!=',False)]"
+                />
+                <filter
+                    string="Manufacturing Order"
+                    name="group_by_mo"
+                    domain="[]"
+                    context="{'group_by': 'manufacturing_order_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+    <record id="action_new_mrp_analytic_items" model="ir.actions.act_window">
+        <field name="name">Analytic Items</field>
+        <field name="res_model">account.analytic.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_related-mo': True}</field>
+    </record>
+    <menuitem
+        id="custom_account_analytic_line_menu"
+        name="Analytic Items"
+        parent="mrp.menu_mrp_reporting"
+        action="action_new_mrp_analytic_items"
+        sequence="30"
+    />
+</odoo>

--- a/setup/mrp_account_analytic/odoo/addons/mrp_account_analytic
+++ b/setup/mrp_account_analytic/odoo/addons/mrp_account_analytic
@@ -1,0 +1,1 @@
+../../../../mrp_account_analytic

--- a/setup/mrp_account_analytic/setup.py
+++ b/setup/mrp_account_analytic/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Extracted from the original proposed code for mrp_account_analytic_wip.
Has only the essential code for Analytic Item generation. 

Extracted from #608, that should be refactored to depend on this.