### PR TITLE
[FIX] missing dep from mrp_warehouse_calendar

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
 
 account-analytic
+stock-logistics-warehouse


### PR DESCRIPTION
A dependency is missing for stock_warehouse_calendar in oca_dependencies.txt, causing other PR with OCA PR dependecies to fail (#659 ).
This PR fixes it.