### PR TITLE
[14.0] mrp_workcenter_hierarchical : Add possibility to switch workcenter of multiple workorders of a same group

### DIFF
--- a/mrp_workcenter_hierarchical/__init__.py
+++ b/mrp_workcenter_hierarchical/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/mrp_workcenter_hierarchical/__manifest__.py
+++ b/mrp_workcenter_hierarchical/__manifest__.py
@@ -13,7 +13,9 @@
     ],
     "website": "https://github.com/OCA/manufacture",
     "data": [
+        "security/ir.model.access.csv",
         "views/workcenter_view.xml",
+        "wizards/switch_workcenter.xml",
     ],
     "demo": [
         "data/mrp_demo.xml",

--- a/mrp_workcenter_hierarchical/security/ir.model.access.csv
+++ b/mrp_workcenter_hierarchical/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_switch_workcenter,access_switch_workcenter,model_switch_workcenter,mrp.group_mrp_manager,1,1,1,0

--- a/mrp_workcenter_hierarchical/tests/test_compute_level.py
+++ b/mrp_workcenter_hierarchical/tests/test_compute_level.py
@@ -2,17 +2,49 @@
 # David BEAL <david.beal@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo import exceptions
+from odoo.tests.common import SavepointCase
 
 
-class ComputeParentLevel(TransactionCase):
+class ComputeParentLevel(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.workc_12 = cls.env.ref("mrp_workcenter_hierarchical.workc_12")
+        cls.workc_123 = cls.env.ref("mrp_workcenter_hierarchical.workc_123")
+        cls.workc_1234 = cls.env.ref("mrp_workcenter_hierarchical.workc_1234")
+        cls.workc_12345 = cls.env.ref("mrp_workcenter_hierarchical.workc_12345")
+
     def test_compute_low_level_workcenter(self):
         workcenter = self.env["mrp.workcenter"].create({"name": "any"})
 
-        def get_record(string):
-            return self.env.ref("mrp_workcenter_hierarchical.%s" % string)
+        workcenter.write({"parent_id": self.workc_12.id})
+        assert workcenter.parent_level_3_id == self.workc_123
+        assert workcenter.parent_level_2_id == self.workc_1234
+        assert workcenter.parent_level_1_id == self.workc_12345
 
-        workcenter.write({"parent_id": get_record("workc_12").id})
-        assert workcenter.parent_level_3_id == get_record("workc_123")
-        assert workcenter.parent_level_2_id == get_record("workc_1234")
-        assert workcenter.parent_level_1_id == get_record("workc_12345")
+    def test_switch_workcenter(self):
+        # take a MO with an operation
+        mo = self.env.ref("mrp.mrp_production_3")
+        mo2 = mo.copy()
+        mo2.action_confirm()
+        wos = mo.workorder_ids + mo2.workorder_ids
+
+        ctx = {"active_model": "mrp.workorder", "active_ids": wos.ids}
+        # the default wworkcenter does not belong to any group
+        with self.assertRaises(exceptions.UserError):
+            self.env["switch.workcenter"].with_context(ctx).create({})
+
+        # set workcenter with group
+        wos.write({"workcenter_id": self.workc_12345.id})
+        wizard = (
+            self.env["switch.workcenter"]
+            .with_context(ctx)
+            .create({"workcenter_id": self.workc_123.id})
+        )
+        # used in view
+        self.assertEqual(
+            self.workc_12345.parent_level_1_id, wizard.parent_workcenter_id
+        )
+        wizard.switch_workcenter()
+        self.assertEqual(wos.workcenter_id.id, self.workc_123.id)

--- a/mrp_workcenter_hierarchical/wizards/__init__.py
+++ b/mrp_workcenter_hierarchical/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import switch_workcenter

--- a/mrp_workcenter_hierarchical/wizards/switch_workcenter.py
+++ b/mrp_workcenter_hierarchical/wizards/switch_workcenter.py
@@ -1,0 +1,51 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SwitchWorkcenter(models.TransientModel):
+    _name = "switch.workcenter"
+    _description = "Switch Workcenter onf workorders"
+
+    workcenter_id = fields.Many2one("mrp.workcenter", "Workcenter", required=True)
+    parent_workcenter_id = fields.Many2one(
+        "mrp.workcenter", "Parent Workcenter", required=True
+    )
+
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        wos = self.env["mrp.workorder"].browse(self.env.context.get("active_ids", []))
+        if any([wo.state in ("done", "cancel") for wo in wos]):
+            raise UserError(
+                _(
+                    "You can not change the workcenter of an in progress or done "
+                    "operation"
+                )
+            )
+
+        workcenter = wos.workcenter_id
+        if len(workcenter) != 1:
+            raise UserError(
+                _(
+                    "You can only change the workcenter of workorders belonging to the "
+                    "same workcenter"
+                )
+            )
+        parent_level_1_id = workcenter.parent_level_1_id.id
+        if not parent_level_1_id:
+            raise UserError(
+                _(
+                    "The present workcenter of the workorders does not belong to any "
+                    "group of workcenter. It can't be switched"
+                )
+            )
+        res["parent_workcenter_id"] = workcenter.parent_level_1_id.id
+        return res
+
+    def switch_workcenter(self):
+        self.ensure_one()
+        active_ids = self.env.context.get("active_ids", [])
+        vals = {"workcenter_id": self.workcenter_id.id}
+        lines = self.env["mrp.workorder"].browse(active_ids)
+        lines.write(vals)
+        return True

--- a/mrp_workcenter_hierarchical/wizards/switch_workcenter.xml
+++ b/mrp_workcenter_hierarchical/wizards/switch_workcenter.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_wiz_switch_workcenter_form" model="ir.ui.view">
+        <field name="model">switch.workcenter</field>
+        <field name="arch" type="xml">
+            <form string="Switch Workcenter">
+                <group col="4">
+                    <p colspan="4">
+    Replace selected workcenters by another one.
+                    </p>
+                    <field name="parent_workcenter_id" invisible="1" />
+                    <field
+                        name="workcenter_id"
+                        domain="[('parent_level_1_id', '=', parent_workcenter_id)]"
+                    />
+                </group>
+                <footer>
+                    <button
+                        name="switch_workcenter"
+                        string="Apply"
+                        type="object"
+                        class="oe_highlight"
+                    />
+                    or
+                    <button special="cancel" string="Cancel" class="oe_link" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_switch_workcenter" model="ir.actions.act_window">
+        <field name="name">Switch Workcenter</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">switch.workcenter</field>
+        <field name="view_mode">form</field>
+        <field name="binding_view_types">form,list</field>
+        <field name="binding_model_id" ref="mrp.model_mrp_workorder" />
+        <field name="view_id" ref="view_wiz_switch_workcenter_form" />
+        <field name="target">new</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Add a missing functionality of the module. It allows to select some batch of workorders and assign them on any workcenter of their current workcenter's group.
Workorders can be switch from workcenter to workcenter inside a same group of workcenter.

@bealdav 