### PR TITLE
[FIX] mrp_analytic_cost: the module has to be depend on account_analytic_wip

### DIFF
--- a/mrp_analytic_cost/__manifest__.py
+++ b/mrp_analytic_cost/__manifest__.py
@@ -9,7 +9,11 @@
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/manufacture",
     "license": "AGPL-3",
-    "depends": ["mrp_analytic", "analytic_activity_based_cost"],
+    "depends": [
+        "mrp_analytic",
+        "analytic_activity_based_cost",
+        "account_analytic_wip",
+    ],
     "data": [
         "views/account_analytic_line_view.xml",
         "views/mrp_production_views.xml",


### PR DESCRIPTION
Otherwise, during its installation it raises the following error:
```
2021-08-03 11:41:06,662 169 INFO openerp_test odoo.addons.base.models.ir_ui_view: Unknown field "product.product.is_cost_type" in field analytic_product_id default domain"[('is_cost_type', '=', True)]"

View name: mrp.workcenter.form.custom
Error context:
view: ir.ui.view(1319,)
xmlid: mrp_workcenter_form_view_custom
view.model: mrp.workcenter
view.parent: ir.ui.view(953,)
file: /home/odoo/build/OCA/manufacture/setup/mrp_analytic_cost/odoo/addons/mrp_analytic_cost/views/mrp_workcenter_view.xml
```

Indeed, `is_cost_type` field is added by [account_analytic_wip](https://github.com/OCA/account-analytic/blob/d998d6e59a5a61788e5fddbdbd90a6652470ad3a/account_analytic_wip/models/product_template.py#L11).