### PR TITLE
[13.0][IMP] mrp_production_grouped_by_product: group confirmed MO and set d…

### DIFF
--- a/mrp_production_grouped_by_product/models/mrp_production.py
+++ b/mrp_production_grouped_by_product/models/mrp_production.py
@@ -33,13 +33,16 @@ class MrpProduction(models.Model):
 
         :return: Odoo domain.
         """
+        if "routing_id" not in vals and "bom_id" in vals:
+            bom = self.env["mrp.bom"].browse(vals["bom_id"])
+            vals["routing_id"] = bom.routing_id.id
         domain = [
             ("product_id", "=", vals["product_id"]),
             ("picking_type_id", "=", vals["picking_type_id"]),
             ("bom_id", "=", vals.get("bom_id", False)),
             ("routing_id", "=", vals.get("routing_id", False)),
             ("company_id", "=", vals.get("company_id", False)),
-            ("state", "=", "draft"),
+            ("state", "in", ["draft", "confirmed"]),
         ]
         if not vals.get("date_planned_finished"):
             return domain


### PR DESCRIPTION
…efault routing

**Before this commit:**
- MO created by MTO route will have state as `confirmed` right after being triggered from procurement, so searching for draft MO to merge will result nothing since the MO has been already confirmed. 
- While being created from MTO, `vals` will not have `routing_id`, so the condition in grouping domain is incorrect `[('routing_id', '=', False)]`

**After this commit:**
- Merge new MO created by MTO with confirmed MO (not planned)
- Set default `routing_id` to the one set on BoM