### PR TITLE
[13.0][FIX] quality_control_oca: Remove object_id and type fields in Quality control test model because they have no use.

### DIFF
--- a/quality_control_oca/demo/quality_control_demo.xml
+++ b/quality_control_oca/demo/quality_control_demo.xml
@@ -3,7 +3,6 @@
     <data noupdate="1">
         <record model="qc.test" id="qc_test_1">
             <field name="name">Generic Test (demo)</field>
-            <field name="type">generic</field>
             <field name="active" eval="True" />
             <field name="category" ref="qc_test_template_category_generic" />
         </record>

--- a/quality_control_oca/models/qc_test.py
+++ b/quality_control_oca/models/qc_test.py
@@ -16,14 +16,6 @@ class QcTest(models.Model):
     _name = "qc.test"
     _description = "Quality control test"
 
-    def object_selection_values(self):
-        return set()
-
-    @api.onchange("type")
-    def onchange_type(self):
-        if self.type == "generic":
-            self.object_id = False
-
     active = fields.Boolean("Active", default=True)
     name = fields.Char(string="Name", required=True, translate=True)
     test_lines = fields.One2many(
@@ -32,16 +24,7 @@ class QcTest(models.Model):
         string="Questions",
         copy=True,
     )
-    object_id = fields.Reference(
-        string="Reference object", selection="object_selection_values",
-    )
     fill_correct_values = fields.Boolean(string="Pre-fill with correct values")
-    type = fields.Selection(
-        [("generic", "Generic"), ("related", "Related")],
-        string="Type",
-        required=True,
-        default="generic",
-    )
     category = fields.Many2one(comodel_name="qc.test.category", string="Category")
     company_id = fields.Many2one(
         comodel_name="res.company",

--- a/quality_control_oca/views/qc_test_view.xml
+++ b/quality_control_oca/views/qc_test_view.xml
@@ -18,11 +18,6 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="type" />
-                            <field
-                                name="object_id"
-                                attrs="{'invisible': [('type','=','generic')]}"
-                            />
                             <field name="active" />
                         </group>
                         <group>
@@ -56,8 +51,6 @@
             <tree string="Tests">
                 <field name="name" />
                 <field name="category" />
-                <field name="type" />
-                <field name="object_id" />
                 <field name="company_id" groups="base.group_multi_company" />
             </tree>
         </field>


### PR DESCRIPTION
Remove `object_id` and `type` fields in Quality control test model because they have no use.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT31885