### PR TITLE
[14.0][FIX] mrp_analytic_cost: inform the uom in the creation of the analytic line

### DIFF
--- a/mrp_analytic_cost/models/stock_move.py
+++ b/mrp_analytic_cost/models/stock_move.py
@@ -20,6 +20,7 @@ class StockMove(models.Model):
             "company_id": mrp_order.company_id.id,
             "stock_move_id": move.id,
             "product_id": move.product_id.id,
+            "product_uom_id": move.product_uom.id,
             "unit_amount": move.quantity_done,
         }
 


### PR DESCRIPTION
In case there is a difference in internal uom - purchase uom, that would cause the price_unit be taken for the purchase uom, against the qty in internal uom. E.g. MO with consumed product with 2000kg (internal uom in kg), purchase in t at 1500€/t, without informing the unit we end up with 3.000.000€ of cost. If we inform the unit we avoid the heart attack and it is 3000€