### PR TITLE
[14.0] [mrp_multi_level][imp] improve traceability

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -6,7 +6,7 @@
 
 from datetime import date, timedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class MrpInventory(models.Model):
@@ -113,3 +113,18 @@ class MrpInventory(models.Model):
             if order_release_date < today:
                 order_release_date = today
             rec.order_release_date = order_release_date
+
+    def action_open_planned_orders(self):
+        planned_order_ids = []
+        for rec in self:
+            planned_order_ids += rec.planned_order_ids.ids
+
+        domain = [("id", "in", planned_order_ids)]
+
+        return {
+            "name": _("Planned Orders"),
+            "type": "ir.actions.act_window",
+            "res_model": "mrp.planned.order",
+            "view_mode": "tree,form",
+            "domain": domain,
+        }

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -52,6 +52,12 @@
                 <field name="supply_qty" />
                 <field name="final_on_hand_qty" />
                 <field name="to_procure" />
+                <button
+                    attrs="{'invisible': [('planned_order_ids', '=', [])]}"
+                    name="action_open_planned_orders"
+                    type="object"
+                    icon="fa-list"
+                />
                 <field name="order_release_date" />
                 <button
                     title="Create Procurement"
@@ -60,6 +66,7 @@
                     type="action"
                     attrs="{'invisible':[('to_procure','&lt;=',0.0)]}"
                 />
+                <field name="planned_order_ids" invisible="1" />
                 <field name="supply_method" />
                 <field name="main_supplier_id" optional="hide" />
                 <field name="running_availability" />

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -7,6 +7,7 @@
         <field name="model">mrp.planned.order</field>
         <field name="arch" type="xml">
             <tree decoration-info="fixed != True">
+                <field name="name" />
                 <field name="product_mrp_area_id" />
                 <field name="product_id" />
                 <field name="mrp_area_id" />

--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -83,8 +83,8 @@ class MrpInventoryProcure(models.TransientModel):
                     item.qty,
                     item.uom_id,
                     item.location_id,
-                    "MRP: " + str(self.env.user.login),  # name?
-                    "MRP: " + str(self.env.user.login),  # origin?
+                    "MRP: " + item.planned_order_id.name or str(self.env.user.login),
+                    "MRP: " + item.planned_order_id.name or str(self.env.user.login),
                     item.mrp_inventory_id.company_id,
                     values,
                 )


### PR DESCRIPTION
 - The description of the planned order includes the topmost requirement that
  caused the planned order. This makes it easier to trace, for example,
  what planned orders has a given sales order generated. The description
  of the planned order is passed on to the Manufacturing Orders / Purchase Orders / Transfers
  as the origin, so it can be possible to search for PO's / MO's that
  were originated as a result of a given sales order, for example.

- The MRP Inventory tree view is improved so as to add a button to allow you to
  jump to the planned orders.

@ForgeFlow @LoisRForgeFlow 