### PR TITLE
[13.0][mrp_multi_level][imp] improve usage of planned orders.

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -6,7 +6,7 @@
 
 from datetime import date, timedelta
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class MrpInventory(models.Model):
@@ -106,3 +106,18 @@ class MrpInventory(models.Model):
             if order_release_date < today:
                 order_release_date = today
             rec.order_release_date = order_release_date
+
+    def action_open_planned_orders(self):
+        planned_order_ids = []
+        for rec in self:
+            planned_order_ids += rec.planned_order_ids.ids
+
+        domain = [("id", "in", planned_order_ids)]
+
+        return {
+            "name": _("Planned Orders"),
+            "type": "ir.actions.act_window",
+            "res_model": "mrp.planned.order",
+            "view_mode": "tree,form",
+            "domain": domain,
+        }

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -48,6 +48,12 @@
                 <field name="supply_qty" />
                 <field name="final_on_hand_qty" />
                 <field name="to_procure" />
+                <button
+                    attrs="{'invisible': [('planned_order_ids', '=', [])]}"
+                    name="action_open_planned_orders"
+                    type="object"
+                    icon="fa-list"
+                />
                 <field name="order_release_date" />
                 <button
                     string="Create Procurement"
@@ -56,6 +62,7 @@
                     type="action"
                     attrs="{'invisible':[('to_procure','&lt;=',0.0)]}"
                 />
+                <field name="planned_order_ids" invisible="1" />
                 <field name="supply_method" />
                 <field name="running_availability" />
             </tree>

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -7,6 +7,7 @@
         <field name="model">mrp.planned.order</field>
         <field name="arch" type="xml">
             <tree decoration-info="fixed != True">
+                <field name="name" />
                 <field name="product_mrp_area_id" />
                 <field name="product_id" />
                 <field name="mrp_area_id" />

--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -77,8 +77,8 @@ class MrpInventoryProcure(models.TransientModel):
                     item.qty,
                     item.uom_id,
                     item.location_id,
-                    "MRP: " + str(self.env.user.login),  # name?
-                    "MRP: " + str(self.env.user.login),  # origin?
+                    "MRP: " + item.planned_order_id.name or str(self.env.user.login),
+                    "MRP: " + item.planned_order_id.name or str(self.env.user.login),
                     item.mrp_inventory_id.company_id,
                     values,
                 )

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -53,25 +53,28 @@ class MultiLevelMrp(models.TransientModel):
         po = po_line = None
         mo = origin = order_number = parent_product_id = None
         if move.purchase_line_id:
-            order_number = move.purchase_line_id.order_id.name
+            po = move.purchase_line_id.order_id
+            order_number = po.origin or po.name
             origin = "po"
             po = move.purchase_line_id.order_id.id
             po_line = move.purchase_line_id.id
         elif move.production_id or move.raw_material_production_id:
             production = move.production_id or move.raw_material_production_id
-            order_number = production.name
+            order_number = production.origin or production.name
             origin = "mo"
             mo = production.id
         elif move.move_dest_ids:
             for move_dest_id in move.move_dest_ids.filtered("production_id"):
-                order_number = move_dest_id.production_id.name
+                production = move_dest_id.production_id
+                order_number = production.origin or production.name
                 origin = "mo"
                 mo = move_dest_id.production_id.id
                 parent_product_id = (
                     move_dest_id.production_id.product_id or move_dest_id.product_id
                 ).id
-        else:
-            order_number = (move.picking_id or move).name
+        if not order_number:
+            source = (move.picking_id or move).origin
+            order_number = source or (move.picking_id or move).name
             origin = "mv"
         # The date to display is based on the timezone of the warehouse.
         today_tz = area._datetime_to_date_tz()
@@ -110,7 +113,7 @@ class MultiLevelMrp(models.TransientModel):
             "order_release_date": mrp_action_date,
             "mrp_action": product_mrp_area.supply_method,
             "qty_released": 0.0,
-            "name": "Planned supply for: " + name,
+            "name": name,
             "fixed": False,
         }
 
@@ -146,12 +149,7 @@ class MultiLevelMrp(models.TransientModel):
             "mrp_origin": "mrp",
             "mrp_order_number": None,
             "parent_product_id": bom.product_id.id,
-            "name": (
-                "Demand Bom Explosion: %s"
-                % (name or product.product_id.default_code or product.product_id.name)
-            ).replace(
-                "Demand Bom Explosion: Demand Bom Explosion: ", "Demand Bom Explosion: "
-            ),
+            "name": name or product.product_id.default_code or product.product_id.name,
         }
 
     @api.model
@@ -474,6 +472,7 @@ class MultiLevelMrp(models.TransientModel):
         last_qty = 0.00
         onhand = product_mrp_area.qty_available
         grouping_delta = product_mrp_area.mrp_nbr_days
+        demand_origin = []
         for move in product_mrp_area.mrp_move_ids:
             if self._exclude_move(move):
                 continue
@@ -489,7 +488,7 @@ class MultiLevelMrp(models.TransientModel):
                     or (onhand + last_qty) < product_mrp_area.mrp_minimum_stock
                 )
             ):
-                name = "Grouped Demand for %d Days" % grouping_delta
+                name = ",".join(demand_origin)
                 qtytoorder = product_mrp_area.mrp_minimum_stock - onhand - last_qty
                 cm = self.create_action(
                     product_mrp_area_id=product_mrp_area,
@@ -514,9 +513,10 @@ class MultiLevelMrp(models.TransientModel):
             else:
                 last_date = fields.Date.from_string(move.mrp_date)
                 onhand += move.mrp_qty
+            demand_origin.append(move.name)
 
         if last_date and last_qty != 0.00:
-            name = "Grouped Demand for %d Days" % grouping_delta
+            name = ",".join(demand_origin)
             qtytoorder = product_mrp_area.mrp_minimum_stock - onhand - last_qty
             cm = self.create_action(
                 product_mrp_area_id=product_mrp_area,


### PR DESCRIPTION
backport of https://github.com/OCA/manufacture/pull/690
- The description of the planned order includes the topmost requirement that
  caused the planned order. This makes it easier to trace, for example,
  what planned orders has a given sales order generated. The description
  of the planned order is passed on to the Manufacturing Orders / Purchase Orders / Transfers
  as the origin, so it can be possible to search for PO's / MO's that
  were originated as a result of a given sales order, for example.

- The MRP Inventory tree view is improved so as to add a button to allow you to
  jump to the planned orders.