### PR TITLE
[14.0][FIX] quality_control_oca: tracking attribute inheritance

### DIFF
--- a/quality_control_oca/models/__init__.py
+++ b/quality_control_oca/models/__init__.py
@@ -8,3 +8,6 @@ from . import qc_inspection
 from . import product_product
 from . import product_template
 from . import product_category
+from . import qc_trigger_product_category_line
+from . import qc_trigger_product_line
+from . import qc_trigger_product_template_line

--- a/quality_control_oca/models/qc_trigger_line.py
+++ b/quality_control_oca/models/qc_trigger_line.py
@@ -20,6 +20,7 @@ def _filter_trigger_lines(trigger_lines):
 
 class QcTriggerLine(models.AbstractModel):
     _name = "qc.trigger.line"
+    _inherit = "mail.thread"
     _description = "Abstract line for defining triggers"
 
     trigger = fields.Many2one(comodel_name="qc.trigger", required=True)
@@ -49,77 +50,3 @@ class QcTriggerLine(models.AbstractModel):
         trigger.
         """
         return set()
-
-
-class QcTriggerProductCategoryLine(models.Model):
-    _inherit = "qc.trigger.line"
-    _name = "qc.trigger.product_category_line"
-    _description = "Quality Control Trigger Product Category Line"
-
-    product_category = fields.Many2one(comodel_name="product.category")
-
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
-        trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
-        )
-        category = product.categ_id
-        while category:
-            for trigger_line in category.qc_triggers.filtered(
-                lambda r: r.trigger == trigger
-                and (
-                    not r.partners
-                    or not partner
-                    or partner.commercial_partner_id in r.partners
-                )
-            ):
-                trigger_lines.add(trigger_line)
-            category = category.parent_id
-        return trigger_lines
-
-
-class QcTriggerProductTemplateLine(models.Model):
-    _inherit = "qc.trigger.line"
-    _name = "qc.trigger.product_template_line"
-    _description = "Quality Control Trigger Product Template Line"
-
-    product_template = fields.Many2one(comodel_name="product.template")
-
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
-        trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
-        )
-        for trigger_line in product.product_tmpl_id.qc_triggers.filtered(
-            lambda r: r.trigger == trigger
-            and (
-                not r.partners
-                or not partner
-                or partner.commercial_partner_id in r.partners
-            )
-            and r.test.active
-        ):
-            trigger_lines.add(trigger_line)
-        return trigger_lines
-
-
-class QcTriggerProductLine(models.Model):
-    _inherit = "qc.trigger.line"
-    _name = "qc.trigger.product_line"
-    _description = "Quality Control Trigger Product Line"
-
-    product = fields.Many2one(comodel_name="product.product")
-
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
-        trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
-        )
-        for trigger_line in product.qc_triggers.filtered(
-            lambda r: r.trigger == trigger
-            and (
-                not r.partners
-                or not partner
-                or partner.commercial_partner_id in r.partners
-            )
-            and r.test.active
-        ):
-            trigger_lines.add(trigger_line)
-        return trigger_lines

--- a/quality_control_oca/models/qc_trigger_product_category_line.py
+++ b/quality_control_oca/models/qc_trigger_product_category_line.py
@@ -1,0 +1,34 @@
+# Copyright 2010 NaN Projectes de Programari Lliure, S.L.
+# Copyright 2014 Serv. Tec. Avanzados - Pedro M. Baeza
+# Copyright 2014 Oihane Crucelaegui - AvanzOSC
+# Copyright 2017 ForgeFlow S.L.
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class QcTriggerProductCategoryLine(models.Model):
+    _inherit = "qc.trigger.line"
+    _name = "qc.trigger.product_category_line"
+    _description = "Quality Control Trigger Product Category Line"
+
+    product_category = fields.Many2one(comodel_name="product.category")
+
+    def get_trigger_line_for_product(self, trigger, product, partner=False):
+        trigger_lines = super().get_trigger_line_for_product(
+            trigger, product, partner=partner
+        )
+        category = product.categ_id
+        while category:
+            for trigger_line in category.qc_triggers.filtered(
+                lambda r: r.trigger == trigger
+                and (
+                    not r.partners
+                    or not partner
+                    or partner.commercial_partner_id in r.partners
+                )
+            ):
+                trigger_lines.add(trigger_line)
+            category = category.parent_id
+        return trigger_lines

--- a/quality_control_oca/models/qc_trigger_product_line.py
+++ b/quality_control_oca/models/qc_trigger_product_line.py
@@ -1,0 +1,32 @@
+# Copyright 2010 NaN Projectes de Programari Lliure, S.L.
+# Copyright 2014 Serv. Tec. Avanzados - Pedro M. Baeza
+# Copyright 2014 Oihane Crucelaegui - AvanzOSC
+# Copyright 2017 ForgeFlow S.L.
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class QcTriggerProductLine(models.Model):
+    _inherit = "qc.trigger.line"
+    _name = "qc.trigger.product_line"
+    _description = "Quality Control Trigger Product Line"
+
+    product = fields.Many2one(comodel_name="product.product")
+
+    def get_trigger_line_for_product(self, trigger, product, partner=False):
+        trigger_lines = super().get_trigger_line_for_product(
+            trigger, product, partner=partner
+        )
+        for trigger_line in product.qc_triggers.filtered(
+            lambda r: r.trigger == trigger
+            and (
+                not r.partners
+                or not partner
+                or partner.commercial_partner_id in r.partners
+            )
+            and r.test.active
+        ):
+            trigger_lines.add(trigger_line)
+        return trigger_lines

--- a/quality_control_oca/models/qc_trigger_product_template_line.py
+++ b/quality_control_oca/models/qc_trigger_product_template_line.py
@@ -1,0 +1,32 @@
+# Copyright 2010 NaN Projectes de Programari Lliure, S.L.
+# Copyright 2014 Serv. Tec. Avanzados - Pedro M. Baeza
+# Copyright 2014 Oihane Crucelaegui - AvanzOSC
+# Copyright 2017 ForgeFlow S.L.
+# Copyright 2017 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class QcTriggerProductTemplateLine(models.Model):
+    _inherit = "qc.trigger.line"
+    _name = "qc.trigger.product_template_line"
+    _description = "Quality Control Trigger Product Template Line"
+
+    product_template = fields.Many2one(comodel_name="product.template")
+
+    def get_trigger_line_for_product(self, trigger, product, partner=False):
+        trigger_lines = super().get_trigger_line_for_product(
+            trigger, product, partner=partner
+        )
+        for trigger_line in product.product_tmpl_id.qc_triggers.filtered(
+            lambda r: r.trigger == trigger
+            and (
+                not r.partners
+                or not partner
+                or partner.commercial_partner_id in r.partners
+            )
+            and r.test.active
+        ):
+            trigger_lines.add(trigger_line)
+        return trigger_lines


### PR DESCRIPTION
Several Pull request in 14.0 are failing because the tracking attribute in the qc.trigger.line model:

```
2021-10-15 17:21:46,448 169 WARNING openerp_test odoo.fields: Field qc.trigger.product_category_line.user: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
2021-10-15 17:21:46,449 169 WARNING openerp_test odoo.fields: Field qc.trigger.product_template_line.user: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
2021-10-15 17:21:46,451 169 WARNING openerp_test odoo.fields: Field qc.trigger.product_line.user: unknown parameter 'tracking', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it
```

For example:
https://github.com/OCA/manufacture/pull/692
and
https://github.com/OCA/manufacture/pull/690

This fix is totally made up. I really don't know why that is not valid. @pedrobaeza if you know how to do a proper fix, I'd appreciate your help :)

cc @ForgeFlow 
cc @BernatPForgeFlow


Edit: I also split the models in different files, to pass the pre-commit that was failing