### PR TITLE
[13.0][FIX] mrp_production_grouped_by product: MO duplicate lines

### DIFF
--- a/mrp_production_grouped_by_product/models/__init__.py
+++ b/mrp_production_grouped_by_product/models/__init__.py
@@ -1,3 +1,4 @@
 from . import mrp_production
 from . import stock_rule
 from . import stock_picking_type
+from . import stock_move

--- a/mrp_production_grouped_by_product/models/stock_move.py
+++ b/mrp_production_grouped_by_product/models/stock_move.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Tecnativa - David Vidal
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        new_vals_list = []
+        for val in vals_list:
+            if (
+                self.env.context.get("group_mo_by_product", False)
+                and "raw_material_production_id" in val
+            ):
+                mo = self.env["mrp.production"].browse(
+                    val["raw_material_production_id"]
+                )
+                # MO already has raw materials
+                if mo.move_raw_ids:
+                    continue
+                else:
+                    new_vals_list.append(val)
+            else:
+                new_vals_list.append(val)
+        return super(StockMove, self).create(new_vals_list)

--- a/mrp_production_grouped_by_product/tests/test_mrp_production_grouped_by_product.py
+++ b/mrp_production_grouped_by_product/tests/test_mrp_production_grouped_by_product.py
@@ -89,6 +89,9 @@ class TestProductionGroupedByProduct(common.SavepointCase):
         mo = self.MrpProduction.search([("product_id", "=", self.product1.id)])
         self.assertEqual(len(mo), 1)
         self.assertEqual(mo.product_qty, 12)
+        mto_prod = mo.move_raw_ids.search([("product_id", "=", self.product2.id)])
+        self.assertEqual(len(mto_prod), 1)
+        self.assertEqual(mto_prod[0].product_qty, 12)
         # Run again the scheduler to see if quantities are altered
         self.ProcurementGroup.with_context(test_group_mo=True).run_scheduler()
         mo = self.MrpProduction.search([("product_id", "=", self.product1.id)])


### PR DESCRIPTION
When merging two MOs, the quantity of the Product lines was updated properly but each line was duplicated.