### PR TITLE
[13.0][fix] mrp_multi_level: update supply_method

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -689,6 +689,7 @@ class MultiLevelMrp(models.TransientModel):
             supply_qty + demand_qty + planned_qty_by_date.get(mdt, 0.0)
         )
         mrp_inventory_data["running_availability"] = running_availability
+        mrp_inventory_data["supply_method"] = product_mrp_area.supply_method
         return mrp_inventory_data, running_availability, on_hand_qty
 
     @api.model


### PR DESCRIPTION
Force to update the supply method in mrp.inventory even when is a
computed field.

cc @ForgeFlow @LoisRForgeFlow 