### PR TITLE
[12.0][FIX] mrp_production_request: wrong default values

### DIFF
--- a/mrp_production_request/tests/test_mrp_production_request.py
+++ b/mrp_production_request/tests/test_mrp_production_request.py
@@ -157,3 +157,22 @@ class TestMrpProductionRequest(TransactionCase):
         with self.assertRaises(UserError):
             # No Bill of Materials:
             self.procure(self.test_group, self.product_no_bom)
+
+    def test_05_dest_src_locations(self):
+        """Tests default values for location_src_id and
+         location_dest_id fields."""
+        # set manufacturing in three steps
+        self.warehouse.manufacture_steps = 'pbm_sam'
+        randon_bom_id = self.bom_model.search([], limit=1).id
+        request = self.request_model.create({
+            'assigned_to': self.test_user.id,
+            'product_id': self.product.id,
+            'product_qty': 5.0,
+            'bom_id': randon_bom_id,
+        })
+        self.assertEqual(
+            request.location_src_id, self.warehouse.pbm_loc_id,
+            "Wrong Raw Materials Location.")
+        self.assertEqual(
+            request.location_dest_id, self.warehouse.sam_loc_id,
+            "Wrong Finished Products Location.")


### PR DESCRIPTION
 for location_src_id and location_dest_id fields
 Steps to reproduce:
 1. Set `Manufacture` in the Warehouse 
   `Pick components and then manufacture (2 steps)`
or
 `Pick components, manufacture and then store products (3 steps)`
 2. Create Manufacturing Request

Actual result:
   Raw Materials Location is `WH/Stock`

Expected result:
   Raw Materials Location is `WH/Pre-Production`