### PR TITLE
[14.0][IMP] mrp_multi_level_estimate: do not require date ranges on stock demand estimates

### DIFF
--- a/mrp_multi_level_estimate/wizards/mrp_multi_level.py
+++ b/mrp_multi_level_estimate/wizards/mrp_multi_level.py
@@ -61,11 +61,11 @@ class MultiLevelMrp(models.TransientModel):
         domain = self._estimates_domain(product_mrp_area)
         estimates = self.env["stock.demand.estimate"].search(domain)
         for rec in estimates:
-            start = rec.date_range_id.date_start
+            start = rec.date_from
             if start < today:
                 start = today
             mrp_date = fields.Date.from_string(start)
-            date_end = fields.Date.from_string(rec.date_range_id.date_end)
+            date_end = fields.Date.from_string(rec.date_to)
             delta = timedelta(days=product_mrp_area.group_estimate_days)
             while mrp_date <= date_end:
                 mrp_move_data = self._prepare_mrp_move_data_from_estimate(


### PR DESCRIPTION
This improvement disassociates date ranges from stock demand estimates when running MRP Inventory. Before, it was compulsory that the Stock Demand Estimate had a Date Range associated to it. With this improvement the MRP takes as start and end date the fields specific of the Stock Demand Estimate. 

@LoisRForgeFlow @ForgeFlow