### PR TITLE
[15.0][FIX] mrp_warehouse_calendar: date_planned_finished calculated with warehouse calendar

### DIFF
--- a/mrp_warehouse_calendar/models/mrp_production.py
+++ b/mrp_warehouse_calendar/models/mrp_production.py
@@ -8,14 +8,25 @@ class MrpProduction(models.Model):
     _inherit = "mrp.production"
 
     @api.onchange("date_planned_start", "product_id")
-    def onchange_date_planned(self):
-        dt_planned = self.date_planned_start
-        warehouse = self.picking_type_id.warehouse_id
-        if warehouse.calendar_id and self.product_id.produce_delay:
-            date_expected_finished = warehouse.calendar_id.plan_days(
-                +1 * self.product_id.produce_delay + 1, dt_planned
-            )
-            self.date_planned_finished = date_expected_finished
+    def _onchange_date_planned_start(self):
+        res = super(MrpProduction, self)._onchange_date_planned_start()
+        if self.date_planned_start and not self.is_planned:
+            warehouse = self.picking_type_id.warehouse_id
+            if warehouse.calendar_id:
+                if self.product_id.produce_delay:
+                    self.date_planned_finished = warehouse.calendar_id.plan_days(
+                        +1 * self.product_id.produce_delay + 1, self.date_planned_start
+                    )
+                if self.company_id.manufacturing_lead:
+                    self.date_planned_finished = warehouse.calendar_id.plan_days(
+                        +1 * self.company_id.manufacturing_lead + 1,
+                        self.date_planned_finished,
+                    )
+                self.move_finished_ids = [
+                    (1, m.id, {"date": self.date_planned_finished})
+                    for m in self.move_finished_ids
+                ]
+        return res
 
     @api.returns("self", lambda value: value.id)
     def copy(self, default=None):

--- a/mrp_warehouse_calendar/tests/test_mrp_warehouse_calendar.py
+++ b/mrp_warehouse_calendar/tests/test_mrp_warehouse_calendar.py
@@ -123,7 +123,7 @@ class TestMrpWarehouseCalendar(TransactionCase):
             }
         )
         mo.date_planned_start = "2097-01-04 09:00:00"
-        mo.onchange_date_planned()
+        mo._onchange_date_planned_start()
         date_plan_finished = fields.Date.to_date(mo.date_planned_finished)
         monday = fields.Date.to_date("2097-01-07 09:00:00")
         self.assertEqual(date_plan_finished, monday)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When creating a MO _date_planned_finished_ is not calculated with warehouse calendar.

Current behavior before PR:
There is not calculation of _date_planned_finished_ taking into account warehouse calendar. 

Desired behavior after PR is merged:
_date_planned_finished_ is calculated taking into account warehouse calendar. 

Steps to reproduce:
1. Add a calendar to the warehouse.
![2022-02-03_15-21](https://user-images.githubusercontent.com/90243017/152361939-9f4aec45-a09a-40ce-b00d-c7464d4efcb9.png)

2. Add to a product a Manufacturing Lead Time
![2022-02-03_12-32](https://user-images.githubusercontent.com/90243017/152362241-4b474f47-d787-400f-a2ae-ee8883fad739.png)


3. Create a MO of the product, and see Scheduled End Date. To see Scheduled End Date you have to edit the form view manually in Edit View: Form option.
![2022-02-03_15-17](https://user-images.githubusercontent.com/90243017/152362588-00b6518f-37e5-404c-94ec-63cb05781080.png)

Calendar:
![Captura de pantalla de 2022-02-03 15-29-46](https://user-images.githubusercontent.com/90243017/152362695-196f53fa-14ca-475a-ad74-d385c370ecbf.png)

**As we can observe, Scheduled End Date falls on Sunday, which is not taking into account the warehouse calendar**

Using the PR fix, the result would be like this:
![2022-02-03_15-22](https://user-images.githubusercontent.com/90243017/152363234-932d677a-600b-4a0a-9725-219501b84c9f.png)


