### PR TITLE
[13.0][FIX] mrp_multi_level_estimate: do not overstate estimates

### DIFF
--- a/mrp_multi_level_estimate/models/product_mrp_area.py
+++ b/mrp_multi_level_estimate/models/product_mrp_area.py
@@ -12,8 +12,9 @@ class ProductMRPArea(models.Model):
         string="Group Days of Estimates",
         default=1,
         help="The days to group your estimates as demand for the MRP."
-        "It can be different from the lenght of the date ranges you "
-        "use in the estimates.",
+        "It can be different from the length of the date ranges you "
+        "use in the estimates but it should not be greater, in that case"
+        "only grouping until the total lenght of the date range will be done.",
     )
 
     _sql_constraints = [

--- a/mrp_multi_level_estimate/wizards/mrp_multi_level.py
+++ b/mrp_multi_level_estimate/wizards/mrp_multi_level.py
@@ -18,6 +18,7 @@ class MultiLevelMrp(models.TransientModel):
     def _prepare_mrp_move_data_from_estimate(self, estimate, product_mrp_area, date):
         mrp_type = "d"
         origin = "fc"
+        daily_qty_unrounded = estimate.daily_qty
         daily_qty = float_round(
             estimate.daily_qty,
             precision_rounding=product_mrp_area.product_id.uom_id.rounding,
@@ -32,6 +33,11 @@ class MultiLevelMrp(models.TransientModel):
         group_estimate_days = min(
             product_mrp_area.group_estimate_days, estimate.duration - days_consumed
         )
+        mrp_qty = float_round(
+            daily_qty_unrounded * group_estimate_days,
+            precision_rounding=product_mrp_area.product_id.uom_id.rounding,
+            rounding_method="HALF-UP",
+        )
         return {
             "mrp_area_id": product_mrp_area.mrp_area_id.id,
             "product_id": product_mrp_area.product_id.id,
@@ -40,7 +46,7 @@ class MultiLevelMrp(models.TransientModel):
             "purchase_order_id": None,
             "purchase_line_id": None,
             "stock_move_id": None,
-            "mrp_qty": -daily_qty * group_estimate_days,
+            "mrp_qty": -mrp_qty,
             "current_qty": -daily_qty,
             "mrp_date": date,
             "current_date": date,

--- a/mrp_multi_level_estimate/wizards/mrp_multi_level.py
+++ b/mrp_multi_level_estimate/wizards/mrp_multi_level.py
@@ -23,6 +23,15 @@ class MultiLevelMrp(models.TransientModel):
             precision_rounding=product_mrp_area.product_id.uom_id.rounding,
             rounding_method="HALF-UP",
         )
+        today = fields.Date.today()
+        days_consumed = 0
+        if product_mrp_area.group_estimate_days > 1:
+            start = estimate.date_from
+            if start < today:
+                days_consumed = (today - start).days
+        group_estimate_days = min(
+            product_mrp_area.group_estimate_days, estimate.duration - days_consumed
+        )
         return {
             "mrp_area_id": product_mrp_area.mrp_area_id.id,
             "product_id": product_mrp_area.product_id.id,
@@ -31,7 +40,7 @@ class MultiLevelMrp(models.TransientModel):
             "purchase_order_id": None,
             "purchase_line_id": None,
             "stock_move_id": None,
-            "mrp_qty": -daily_qty * product_mrp_area.group_estimate_days,
+            "mrp_qty": -daily_qty * group_estimate_days,
             "current_qty": -daily_qty,
             "mrp_date": date,
             "current_date": date,
@@ -61,11 +70,11 @@ class MultiLevelMrp(models.TransientModel):
         domain = self._estimates_domain(product_mrp_area)
         estimates = self.env["stock.demand.estimate"].search(domain)
         for rec in estimates:
-            start = rec.date_range_id.date_start
+            start = rec.date_from
             if start < today:
                 start = today
             mrp_date = fields.Date.from_string(start)
-            date_end = fields.Date.from_string(rec.date_range_id.date_end)
+            date_end = fields.Date.from_string(rec.date_to)
             delta = timedelta(days=product_mrp_area.group_estimate_days)
             while mrp_date <= date_end:
                 mrp_move_data = self._prepare_mrp_move_data_from_estimate(


### PR DESCRIPTION
Commit 1:

when group days of estimates is greater than the lengh of the date
range in the estimate, the estimate is overstated and can generate
unexpected result. Enhance help message to highligh this and
prevent it from happening.

Commit 2:

Rounding should be done at the end of the calculation, using the daily 
quantity already rounded can lead to errors.

Two new test cases highlight the issue.

@ForgeFlow