### PR TITLE
[13.0][FIX] mrp_multi_level: Use running on hand quantity in mrp.inventory

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -657,7 +657,7 @@ class MultiLevelMrp(models.TransientModel):
             supply_qty + demand_qty + planned_qty_by_date.get(mdt, 0.0)
         )
         mrp_inventory_data["running_availability"] = running_availability
-        return mrp_inventory_data, running_availability
+        return mrp_inventory_data, running_availability, on_hand_qty
 
     @api.model
     def _init_mrp_inventory(self, product_mrp_area):
@@ -694,7 +694,11 @@ class MultiLevelMrp(models.TransientModel):
         )._product_available()[product_mrp_area.product_id.id]["qty_available"]
         running_availability = on_hand_qty
         for mdt in sorted(mrp_dates):
-            mrp_inventory_data, running_availability = self._prepare_mrp_inventory_data(
+            (
+                mrp_inventory_data,
+                running_availability,
+                on_hand_qty,
+            ) = self._prepare_mrp_inventory_data(
                 product_mrp_area,
                 mdt,
                 on_hand_qty,


### PR DESCRIPTION
We need to show the projected on hand as it evolves over time.

Backport of #743 