### PR TITLE
[14.0][FIX] mrp_multi_level: Get MRParea company_id for supply method

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -179,7 +179,7 @@ class ProductMRPArea(models.Model):
             proc_loc = rec.location_proc_id or rec.mrp_area_id.location_id
             values = {
                 "warehouse_id": rec.mrp_area_id.warehouse_id,
-                "company_id": self.env.company,
+                "company_id": rec.mrp_area_id.company_id,
             }
             rule = group_obj._get_rule(rec.product_id, proc_loc, values)
             rec.supply_method = rule.action if rule else "none"


### PR DESCRIPTION
Change from self.env.company to mrp_area_id.company_id to compute the supply method correctly in the area currently working.