### PR TITLE
[14.0][FIX] mrp_workorder_sequence: Call method changed on v14

### DIFF
--- a/mrp_workorder_sequence/models/mrp_production.py
+++ b/mrp_workorder_sequence/models/mrp_production.py
@@ -14,7 +14,7 @@ class MrpProduction(models.Model):
                 work.sequence = current_sequence
                 current_sequence += 1
 
-    def _generate_workorders(self, exploded_boms):
-        res = super()._generate_workorders(exploded_boms)
+    def _create_workorder(self):
+        res = super()._create_workorder()
         self._reset_work_order_sequence()
         return res


### PR DESCRIPTION
@ForgeFlow