### PR TITLE
[13.0][IMP] mrp_multi_level: Archiving a product should archive related MRP parameters

### DIFF
--- a/mrp_multi_level/models/product_product.py
+++ b/mrp_multi_level/models/product_product.py
@@ -37,6 +37,17 @@ class Product(models.Model):
         for rec in self:
             rec.mrp_area_count = len(rec.mrp_area_ids)
 
+    def write(self, values):
+        res = super().write(values)
+        if values.get("active") is False:
+            parameters = (
+                self.env["product.mrp.area"]
+                .sudo()
+                .search([("product_id", "in", self.ids)])
+            )
+            parameters.write({"active": False})
+        return res
+
     def action_view_mrp_area_parameters(self):
         self.ensure_one()
         action = self.env.ref("mrp_multi_level.product_mrp_area_action")

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -32,6 +32,10 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         self.assertEqual(product_mrp_area.supply_method, "manufacture")
         self.assertFalse(product_mrp_area.main_supplier_id)
         self.assertFalse(product_mrp_area.main_supplierinfo_id)
+        # Archiving the product should archive parameters:
+        self.assertTrue(product_mrp_area.active)
+        self.sf_1.active = False
+        self.assertFalse(product_mrp_area.active)
 
     def test_03_mrp_moves(self):
         """Tests for mrp moves generated."""


### PR DESCRIPTION
Unarchiving the product will need manual unarchivation of parameters.

@ForgeFlow