### PR TITLE
[14.0][IMP] mrp_production_serial_matrix: handle flexible manufacturing.

### DIFF
--- a/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
@@ -175,6 +175,9 @@ class TestMrpProductionSerialMatrix(SavepointCase):
                 active_id=production_1.id, active_model="mrp.production"
             )
         )
+        expected = 3 * 3  # Only SN products (1 + 2 per finish unit)
+        self.assertEqual(len(wizard_form.line_ids), expected)
+        wizard_form.include_lots = True
         expected = 3 * 4
         self.assertEqual(len(wizard_form.line_ids), expected)
         self.assertEqual(wizard_form.lot_selection_warning_count, 0)

--- a/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix_view.xml
+++ b/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix_view.xml
@@ -5,14 +5,19 @@
         <field name="model">mrp.production.serial.matrix</field>
         <field name="arch" type="xml">
             <form>
-                <group name="info">
-                    <field name="production_id" options='{"no_open": True}' />
-                    <field name="product_id" options='{"no_open": True}' />
-                    <field
-                        name="company_id"
-                        options='{"no_open": True}'
-                        invisible="1"
-                    />
+                <group>
+                    <group name="info">
+                        <field name="production_id" options='{"no_open": True}' />
+                        <field name="product_id" options='{"no_open": True}' />
+                        <field
+                            name="company_id"
+                            options='{"no_open": True}'
+                            invisible="1"
+                        />
+                    </group>
+                    <group name="settings">
+                        <field name="include_lots" widget="boolean_toggle" />
+                    </group>
                 </group>
                 <group name="finished_lots" string="Finished Product Serial Numbers">
                     <p


### PR DESCRIPTION
If the component lines are changed they might differ from what it
is stated in the BoM. It is better to rely on compoent lines to
generate Matrix.

New option to decide whether to add or not products tracked by lots
to the matrix is added. Product tracked by serials are always added.

@ForgeFlow