### PR TITLE
[ADD][15.0] Add module of mrp_finished_backorder_product

### DIFF
--- a/mrp_finished_backorder_product/__init__.py
+++ b/mrp_finished_backorder_product/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import models

--- a/mrp_finished_backorder_product/__manifest__.py
+++ b/mrp_finished_backorder_product/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "MRP Finished Backorder Product",
+    "version": "15.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "summary": "Be able to see the summary of the finished manufactured orders ",
+    "website": "https://github.com/OCA/manufacture",
+    "category": "Manufacturing",
+    "depends": ["mrp"],
+    "data": ["views/mrp_production_views.xml"],
+    "license": "LGPL-3",
+    "installable": True,
+    "development_status": "Beta",
+}

--- a/mrp_finished_backorder_product/models/__init__.py
+++ b/mrp_finished_backorder_product/models/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from . import mrp_production

--- a/mrp_finished_backorder_product/models/mrp_production.py
+++ b/mrp_finished_backorder_product/models/mrp_production.py
@@ -1,0 +1,25 @@
+# Copyright 2022 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, fields, models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+    finished_move_from_backorder_ids = fields.One2many(
+        "stock.move.line",
+        compute="_compute_finished_backorders",
+        string="Finished Backorders",
+    )
+
+    @api.depends("move_finished_ids.move_line_ids")
+    def _compute_finished_backorders(self):
+        for production in self:
+            production.finished_move_from_backorder_ids = self.env["stock.move.line"]
+            backorders = production.procurement_group_id.mrp_production_ids
+            for backorder in backorders:
+                backorder.mapped("finished_move_line_ids").production_id = backorder
+                production.finished_move_from_backorder_ids |= (
+                    backorder.finished_move_line_ids
+                )

--- a/mrp_finished_backorder_product/readme/CONTRIBUTORS.rst
+++ b/mrp_finished_backorder_product/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Joan Mateu <joan.mateu@forgeflow.com>
+* Maria de Luna <maria.de.luna@forgeflow.com>

--- a/mrp_finished_backorder_product/readme/DESCRIPTION.rst
+++ b/mrp_finished_backorder_product/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module collects the functionality hat was in previous versions and adds a tab to see the finished manufacturing orders.

--- a/mrp_finished_backorder_product/views/mrp_production_views.xml
+++ b/mrp_finished_backorder_product/views/mrp_production_views.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mrp_production_form_view_finished_products" model="ir.ui.view">
+        <field name="name">mrp.production.form.finished</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='miscellaneous']" position='after'>
+                <page
+                    string='Finished products'
+                    name="finished_products"
+                    attrs="{'invisible': [('finished_move_from_backorder_ids', '=', [])]}"
+                >
+                    <field
+                        name="finished_move_from_backorder_ids"
+                        context="{'form_view_ref': 'mrp.view_finisehd_move_line'}"
+                        attrs="{'readonly': [('is_locked', '=', True)], 'invisible': [('finished_move_from_backorder_ids', '=', [])]}"
+                    >
+                         <tree>
+                            <field name="product_id" readonly="1" />
+                             <field name="qty_done" readonly="1" />
+                            <field name="production_id" readonly="1" />
+                             <field
+                                name="lot_id"
+                                groups="stock.group_production_lot"
+                                domain="[('product_id', '=', product_id)]"
+                                context="{'default_product_id': product_id}"
+                            />
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/mrp_finished_backorder_product/odoo/addons/mrp_finished_backorder_product
+++ b/setup/mrp_finished_backorder_product/odoo/addons/mrp_finished_backorder_product
@@ -1,0 +1,1 @@
+../../../../mrp_finished_backorder_product

--- a/setup/mrp_finished_backorder_product/setup.py
+++ b/setup/mrp_finished_backorder_product/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows the users to see the finished products of all the backorders linked to the MO.

This module collects the functionality that was in previous versions and adds a tab to see the finished manufacturing orders.


@ForgeFlow

![Captura de pantalla de 2022-05-13 12-56-52](https://user-images.githubusercontent.com/90242955/168269582-6b7f9a38-fe22-49f4-b478-4bd344accff4.png)

