### PR TITLE
[14.0][FIX] mrp_subcontracting_partner 

### DIFF
--- a/mrp_subcontracting_partner_management/__manifest__.py
+++ b/mrp_subcontracting_partner_management/__manifest__.py
@@ -11,6 +11,7 @@
     "demo": [],
     "data": [
         "views/res_partner.xml",
+        "views/stock_picking_type.xml",
     ],
     "qweb": [],
     "installable": True,

--- a/mrp_subcontracting_partner_management/models/__init__.py
+++ b/mrp_subcontracting_partner_management/models/__init__.py
@@ -1,1 +1,2 @@
 from . import res_partner
+from . import stock_picking_type

--- a/mrp_subcontracting_partner_management/models/stock_picking_type.py
+++ b/mrp_subcontracting_partner_management/models/stock_picking_type.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    is_subcontractor = fields.Boolean()

--- a/mrp_subcontracting_partner_management/readme/HISTORY.rst
+++ b/mrp_subcontracting_partner_management/readme/HISTORY.rst
@@ -1,3 +1,9 @@
+14.0.1.0.1
+~~~~~~~~~~
+
+**Bugfixes**
+- Fixed duplicate rules when creating a subcontractor partner
+
 14.0.1.0.0
 ~~~~~~~~~~
 

--- a/mrp_subcontracting_partner_management/tests/test_create_sybcontractor_partner_location.py
+++ b/mrp_subcontracting_partner_management/tests/test_create_sybcontractor_partner_location.py
@@ -168,3 +168,16 @@ class TestSubcontractedPartner(common.SavepointCase):
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
         )
+
+    def test_check_countof_rules(self):
+        partner_id = self.partner_obj.create(
+            {
+                "name": "Test partner",
+                "is_company": True,
+                "is_subcontractor_partner": True,
+            }
+        )
+        rules = self.env["stock.rule"].search(
+            [("name", "=", partner_id.partner_buy_rule_id.name)]
+        )
+        self.assertTrue(len(rules) == 2, "There are must be 2 subcontractor rules")

--- a/mrp_subcontracting_partner_management/views/stock_picking_type.xml
+++ b/mrp_subcontracting_partner_management/views/stock_picking_type.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Add filter for subcontracting operation types -->
+    <record id="view_pickingtype_filter" model="ir.ui.view">
+        <field name="name">stock.picking.type.filter.subcontractor</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_pickingtype_filter" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <filter
+                    string="Subcontractor"
+                    name="subocont"
+                    domain="[('is_subcontractor','=',True)]"
+                />
+            </filter>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR fixes duplicate rules issue when creating a subcontractor partner.

- Enable "Subcontractor" checkbox while creating a new partner
- Save new record
- Edit the record and disable "Subcontractor"
- Edit the record and enable "Suncontractor"

Expected behavior
Previously created entities (routes, rules etc) are used

Current behavior
New entities are created

Replaces https://github.com/OCA/manufacture/pull/805