### PR TITLE
[14.0][FIX] repair_type: remove destination location for finished product

### DIFF
--- a/repair_type/models/repair_type.py
+++ b/repair_type/models/repair_type.py
@@ -14,11 +14,6 @@ class RepairType(models.Model):
         "Source Location",
         help="This is the location where the product to repair is located.",
     )
-    destination_location_id = fields.Many2one(
-        "stock.location",
-        "Destination Location",
-        help="This is the location where the product repaired will be located.",
-    )
     source_location_add_part_id = fields.Many2one(
         "stock.location",
         "Source Location Add Component",

--- a/repair_type/tests/test_repair_type.py
+++ b/repair_type/tests/test_repair_type.py
@@ -29,9 +29,6 @@ class TestRepairType(TransactionCase):
             {
                 "name": "Repairings Office 1",
                 "source_location_id": self.env.ref("stock.stock_location_stock").id,
-                "destination_location_id": self.env.ref(
-                    "stock.stock_location_customers"
-                ).id,
                 "source_location_add_part_id": self.env.ref(
                     "stock.stock_location_components"
                 ).id,
@@ -49,9 +46,6 @@ class TestRepairType(TransactionCase):
                 "name": "Repairings Office 2",
                 "source_location_id": self.env.ref(
                     "stock.stock_location_components"
-                ).id,
-                "destination_location_id": self.env.ref(
-                    "stock.stock_location_stock"
                 ).id,
                 "source_location_add_part_id": self.env.ref(
                     "stock.location_refrigerator_small"

--- a/repair_type/views/repair_type.xml
+++ b/repair_type/views/repair_type.xml
@@ -27,7 +27,6 @@
                     <group>
                         <group>
                             <field name="source_location_id" />
-                            <field name="destination_location_id" />
                         </group>
                         <group>
                             <field name="source_location_add_part_id" />
@@ -48,7 +47,6 @@
             <tree>
                 <field name="name" />
                 <field name="source_location_id" />
-                <field name="destination_location_id" invisible="1" />
                 <field name="source_location_add_part_id" />
                 <field name="destination_location_add_part_id" />
                 <field name="source_location_remove_part_id" />


### PR DESCRIPTION
The destination location was removed from the repair since 12.0.

cc @ForgeFlow