### PR TITLE
[14.0][FIX] repair_stock_move: do not change repair line default location. Update moves

### DIFF
--- a/repair_stock_move/models/repair_line.py
+++ b/repair_stock_move/models/repair_line.py
@@ -12,24 +12,63 @@ class RepairLine(models.Model):
         inverse_name="repair_line_id",
     )
 
+    def _prepare_stock_move_vals(self):
+        return {
+            "name": self.repair_id.name,
+            "product_id": self.product_id.id,
+            "product_uom_qty": self.product_uom_qty,
+            "product_uom": self.product_uom.id,
+            "partner_id": self.repair_id.address_id.id,  # TODO: check
+            "location_id": self.location_id.id,
+            "location_dest_id": self.location_dest_id.id,
+            "repair_id": self.repair_id.id,
+            "repair_line_id": self.id,
+            "origin": self.repair_id.name,
+            "company_id": self.company_id.id,
+        }
+
+    def _prepare_update_stock_move_vals(self):
+        return {
+            "name": self.repair_id.name,
+            "product_id": self.product_id.id,
+            "product_uom_qty": self.product_uom_qty,
+            "product_uom": self.product_uom.id,
+            "partner_id": self.repair_id.address_id.id,  # TODO: check
+            "location_id": self.location_id.id,
+            "location_dest_id": self.location_dest_id.id,
+            "repair_id": self.repair_id.id,
+            "repair_line_id": self.id,
+            "origin": self.repair_id.name,
+            "company_id": self.company_id.id,
+        }
+
     def create_stock_move(self):
         self.ensure_one()
-        move = self.env["stock.move"].create(
-            {
-                "name": self.repair_id.name,
-                "product_id": self.product_id.id,
-                "product_uom_qty": self.product_uom_qty,
-                "product_uom": self.product_uom.id,
-                "partner_id": self.repair_id.address_id.id,  # TODO: check
-                "location_id": self.location_id.id,
-                "location_dest_id": self.location_dest_id.id,
-                "repair_id": self.repair_id.id,
-                "repair_line_id": self.id,
-                "origin": self.repair_id.name,
-                "company_id": self.company_id.id,
-            }
-        )
+        move = self.env["stock.move"].create(self._prepare_stock_move_vals())
         return move
+
+    def _requires_new_move(self, move):
+        return (
+            move.location_id != self.location_id
+            or move.location_dest_id != self.location_dest_id
+            or move.company_id != self.company_id
+            or move.product_id != self.product_id
+            or False
+        )
+
+    def update_stock_move(self):
+        self.ensure_one()
+        for move in self.stock_move_ids.filtered(
+            lambda m: m.state not in ["done", "cancel"]
+        ):
+            if self._requires_new_move(move):
+                move._action_cancel()
+                new_move = self.create_stock_move()
+                new_move._action_confirm()
+                new_move._action_assign()
+            else:
+                move.write(self._prepare_update_stock_move_vals())
+                move._action_assign()
 
     @api.model
     def create(self, vals):
@@ -45,10 +84,7 @@ class RepairLine(models.Model):
             res.move_id = move
         return res
 
-    @api.onchange("product_id")
-    def _onchange_location(self):
-        if self.state == "draft":
-            self.location_id = self.repair_id.location_id
-
-    # TODO: write qty - update stock move.
-    # TODO: default repair location in repair lines.
+    def write(self, vals):
+        super(RepairLine, self).write(vals)
+        for rec in self:
+            rec.update_stock_move()

--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -162,7 +162,9 @@ class RepairOrder(models.Model):
 
         self.move_id._set_quantity_done(self.move_id.product_uom_qty)
         self.move_id._action_done()
-        for move in self.mapped("operations.move_id"):
+        for move in self.mapped("operations.move_id").filtered(
+            lambda m: m.state not in ["done", "cancel"]
+        ):
             move._set_quantity_done(move.product_uom_qty)
             move._action_done()
         return super().action_repair_end()


### PR DESCRIPTION
* Do not change repair line default location: because this interferes with other modules and
standard behaviour.
* Update moves: when you change the repair lines the corresponding stock moves should be updated
as well.