### PR TITLE
[12.0][FIX] mrp_multi_level: Manage Kits in MRP Multi Level

### DIFF
--- a/mrp_multi_level/demo/mrp_bom_demo.xml
+++ b/mrp_multi_level/demo/mrp_bom_demo.xml
@@ -44,6 +44,28 @@
         <field name="bom_id" ref="mrp_bom_fp_2"/>
     </record>
 
+    <!-- FP-3 -->
+     <record id="mrp_bom_fp_3" model="mrp.bom">
+        <field name="product_tmpl_id"
+               ref="product_product_fp_3_product_template"/>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="sequence">5</field>
+    </record>
+    <record id="mrp_bom_fp_3_line_sf_3" model="mrp.bom.line">
+        <field name="product_id" ref="product_product_sf_3"/>
+        <field name="product_qty">2</field>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="sequence">5</field>
+        <field name="bom_id" ref="mrp_bom_fp_3"/>
+    </record>
+    <record id="mrp_bom_fp_3_line_pp_3" model="mrp.bom.line">
+        <field name="product_id" ref="product_product_pp_3"/>
+        <field name="product_qty">2</field>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="sequence">5</field>
+        <field name="bom_id" ref="mrp_bom_fp_3"/>
+    </record>
+
      <!-- Customizable Desk -->
      <record id="mrp_bom_product_4" model="mrp.bom">
         <field name="product_tmpl_id"
@@ -118,5 +140,27 @@
         <field name="product_uom_id" ref="uom.product_uom_unit"/>
         <field name="sequence">5</field>
         <field name="bom_id" ref="mrp_bom_sf_2"/>
+    </record>
+    <!-- SF-3 -->
+     <record id="mrp_bom_sf_3" model="mrp.bom">
+        <field name="product_tmpl_id"
+               ref="product_product_sf_3_product_template"/>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+         <field name="type">phantom</field>
+        <field name="sequence">5</field>
+    </record>
+    <record id="mrp_bom_sf_3_line_pp_3" model="mrp.bom.line">
+        <field name="product_id" ref="product_product_pp_3"/>
+        <field name="product_qty">1</field>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="sequence">5</field>
+        <field name="bom_id" ref="mrp_bom_sf_3"/>
+    </record>
+    <record id="mrp_bom_sf_3_line_pp_4" model="mrp.bom.line">
+        <field name="product_id" ref="product_product_pp_4"/>
+        <field name="product_qty">3</field>
+        <field name="product_uom_id" ref="uom.product_uom_unit"/>
+        <field name="sequence">5</field>
+        <field name="bom_id" ref="mrp_bom_sf_3"/>
     </record>
 </odoo>

--- a/mrp_multi_level/demo/product_mrp_area_demo.xml
+++ b/mrp_multi_level/demo/product_mrp_area_demo.xml
@@ -8,6 +8,10 @@
         <field name="product_id" ref="product_product_fp_2"/>
         <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
     </record>
+    <record id="product_mrp_area_fp_3" model="product.mrp.area">
+        <field name="product_id" ref="product_product_fp_3"/>
+        <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
+    </record>
     <record id="product_mrp_area_product_4" model="product.mrp.area">
         <field name="product_id" ref="product.product_product_4"/>
         <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
@@ -32,12 +36,24 @@
         <field name="product_id" ref="product_product_sf_2"/>
         <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
     </record>
+    <record id="product_mrp_area_sf_3" model="product.mrp.area">
+        <field name="product_id" ref="product_product_sf_3"/>
+        <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
+    </record>
     <record id="product_mrp_area_pp_1" model="product.mrp.area">
         <field name="product_id" ref="product_product_pp_1"/>
         <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
     </record>
     <record id="product_mrp_area_pp_2" model="product.mrp.area">
         <field name="product_id" ref="product_product_pp_2"/>
+        <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
+    </record>
+    <record id="product_mrp_area_pp_3" model="product.mrp.area">
+        <field name="product_id" ref="product_product_pp_3"/>
+        <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
+    </record>
+    <record id="product_mrp_area_pp_4" model="product.mrp.area">
+        <field name="product_id" ref="product_product_pp_4"/>
         <field name="mrp_area_id" ref="mrp_area_stock_wh0"/>
     </record>
     <record id="product_mrp_area_av_11" model="product.mrp.area">

--- a/mrp_multi_level/demo/product_product_demo.xml
+++ b/mrp_multi_level/demo/product_product_demo.xml
@@ -20,6 +20,16 @@
         <field name="route_ids" eval="[(6, 0, [ref('mrp.route_warehouse0_manufacture')])]"/>
     </record>
 
+    <record id="product_product_fp_3" model="product.product">
+        <field name="name">FP-3</field>
+        <field name="categ_id" ref="product_category_mrp"/>
+        <field name="type">product</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="produce_delay">3</field>
+        <field name="route_ids" eval="[(6, 0, [ref('mrp.route_warehouse0_manufacture')])]"/>
+    </record>
+
      <!-- Customizable Desk -->
     <record id="product.product_product_4_product_template" model="product.template">
         <field name="route_ids" eval="[(6, 0, [ref('mrp.route_warehouse0_manufacture')])]"/>
@@ -43,6 +53,15 @@
         <field name="produce_delay">3</field>
         <field name="route_ids" eval="[(6, 0, [ref('mrp.route_warehouse0_manufacture')])]"/>
     </record>
+    <record id="product_product_sf_3" model="product.product">
+        <field name="name">SF-3</field>
+        <field name="categ_id" ref="product_category_mrp"/>
+        <field name="type">product</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="produce_delay">3</field>
+        <field name="route_ids" eval="[(6, 0, [ref('mrp.route_warehouse0_manufacture')])]"/>
+    </record>
 
     <record id="product_product_pp_1" model="product.product">
         <field name="name">PP-1</field>
@@ -55,6 +74,24 @@
 
     <record id="product_product_pp_2" model="product.product">
         <field name="name">PP-2</field>
+        <field name="categ_id" ref="product_category_mrp"/>
+        <field name="type">product</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="route_ids" eval="[(6, 0, [ref('purchase_stock.route_warehouse0_buy')])]"/>
+    </record>
+
+    <record id="product_product_pp_3" model="product.product">
+        <field name="name">PP-3</field>
+        <field name="categ_id" ref="product_category_mrp"/>
+        <field name="type">product</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="uom_po_id" ref="uom.product_uom_unit"/>
+        <field name="route_ids" eval="[(6, 0, [ref('purchase_stock.route_warehouse0_buy')])]"/>
+    </record>
+
+    <record id="product_product_pp_4" model="product.product">
+        <field name="name">PP-4</field>
         <field name="categ_id" ref="product_category_mrp"/>
         <field name="type">product</field>
         <field name="uom_id" ref="uom.product_uom_unit"/>

--- a/mrp_multi_level/demo/product_supplierinfo_demo.xml
+++ b/mrp_multi_level/demo/product_supplierinfo_demo.xml
@@ -44,4 +44,20 @@
         <field name="min_qty">0</field>
         <field name="price">100</field>
     </record>
+
+    <record id="product_supplierinfo_pp_3" model="product.supplierinfo">
+        <field name="product_tmpl_id" ref="product_product_pp_3_product_template"/>
+        <field name="name" ref="res_partner_lazer_tech"/>
+        <field name="delay">2</field>
+        <field name="min_qty">0</field>
+        <field name="price">10</field>
+    </record>
+
+    <record id="product_supplierinfo_pp_4" model="product.supplierinfo">
+        <field name="product_tmpl_id" ref="product_product_pp_4_product_template"/>
+        <field name="name" ref="res_partner_lazer_tech"/>
+        <field name="delay">3</field>
+        <field name="min_qty">0</field>
+        <field name="price">80</field>
+    </record>
 </odoo>

--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -29,10 +29,14 @@ class TestMrpMultiLevelCommon(SavepointCase):
 
         cls.fp_1 = cls.env.ref('mrp_multi_level.product_product_fp_1')
         cls.fp_2 = cls.env.ref('mrp_multi_level.product_product_fp_2')
+        cls.fp_3 = cls.env.ref('mrp_multi_level.product_product_fp_3')
         cls.sf_1 = cls.env.ref('mrp_multi_level.product_product_sf_1')
         cls.sf_2 = cls.env.ref('mrp_multi_level.product_product_sf_2')
+        cls.sf_3 = cls.env.ref('mrp_multi_level.product_product_sf_3')
         cls.pp_1 = cls.env.ref('mrp_multi_level.product_product_pp_1')
         cls.pp_2 = cls.env.ref('mrp_multi_level.product_product_pp_2')
+        cls.pp_3 = cls.env.ref('mrp_multi_level.product_product_pp_3')
+        cls.pp_4 = cls.env.ref('mrp_multi_level.product_product_pp_4')
         cls.product_4b = cls.env.ref('product.product_product_4b')
         cls.av_11 = cls.env.ref('mrp_multi_level.product_product_av_11')
         cls.av_12 = cls.env.ref('mrp_multi_level.product_product_av_12')
@@ -219,6 +223,16 @@ class TestMrpMultiLevelCommon(SavepointCase):
                     'date': date_move,
                     'product_uom': cls.fp_2.uom_id.id,
                     'product_uom_qty': 15,
+                    'location_id': cls.stock_location.id,
+                    'location_dest_id': cls.customer_location.id
+                }),
+                (0, 0, {
+                    'name': 'Test move fp-3',
+                    'product_id': cls.fp_3.id,
+                    'date_expected': date_move,
+                    'date': date_move,
+                    'product_uom': cls.fp_3.uom_id.id,
+                    'product_uom_qty': 5,
                     'location_id': cls.stock_location.id,
                     'location_dest_id': cls.customer_location.id
                 }),

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -328,3 +328,42 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         )
         self.assertEqual(len(inventory), 1)
         self.assertEqual(inventory.date, date_move.date())
+
+    def test_15_phantom_comp_planning(self):
+        """
+        Phantom components will not appear in MRP Inventory or Planned Orders.
+        MRP Parameter will have 'phantom' supply method.
+        """
+        # SF-3
+        sf_3_line_1 = self.mrp_inventory_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.sf_3.id)
+        ])
+        self.assertEqual(len(sf_3_line_1), 0)
+        sf_3_planned_order_1 = self.planned_order_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.sf_3.id)
+        ])
+        self.assertEqual(len(sf_3_planned_order_1), 0)
+        sf_3_mrp_parameter = self.product_mrp_area_obj.search([
+            ('product_id', '=', self.sf_3.id)
+        ])
+        self.assertEqual(sf_3_mrp_parameter.supply_method, 'phantom')
+        # PP-3
+        pp_3_line_1 = self.mrp_inventory_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.pp_3.id),
+        ])
+        self.assertEqual(len(pp_3_line_1), 1)
+        self.assertEqual(pp_3_line_1.demand_qty, 20.0)
+        pp_3_planned_orders = self.planned_order_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.pp_3.id),
+        ])
+        self.assertEqual(len(pp_3_planned_orders), 2)
+        # PP-4
+        pp_4_line_1 = self.mrp_inventory_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.pp_4.id),
+        ])
+        self.assertEqual(len(pp_4_line_1), 1)
+        self.assertEqual(pp_4_line_1.demand_qty, 30.0)
+        pp_4_planned_orders = self.planned_order_obj.search([
+            ('product_mrp_area_id.product_id', '=', self.pp_4.id),
+        ])
+        self.assertEqual(len(pp_4_planned_orders), 1)


### PR DESCRIPTION
When running MRP Multi Level, if a product BoM Type is _Kit_, it won't create Planned Orders for the product and it won't neither create an MRP Inventory row. It will only create the MRP Moves to continue the explosion down.

For MRP Parameters that are Kits, they will have _Kit_ supply method.