### PR TITLE
[15.0][add] new module mrp_workorder_blocking_time

### DIFF
--- a/mrp_workorder_blocking_time/__init__.py
+++ b/mrp_workorder_blocking_time/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizards

--- a/mrp_workorder_blocking_time/__manifest__.py
+++ b/mrp_workorder_blocking_time/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "MRP Work Order Blocking Time",
+    "category": "Manufacturing",
+    "version": "15.0.0.1.0",
+    "summary": "Allow to block time on work orders",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/manufacture",
+    "license": "AGPL-3",
+    "depends": ["mrp"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/mrp_routing_workcenter.xml",
+        "views/mrp_workorder.xml",
+        "wizards/wizard_open_blocking_popup.xml",
+    ],
+    "installable": True,
+    "maintainers": ["imlopes"],
+}

--- a/mrp_workorder_blocking_time/models/__init__.py
+++ b/mrp_workorder_blocking_time/models/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import mrp_routing_workcenter
+from . import mrp_workorder

--- a/mrp_workorder_blocking_time/models/mrp_routing_workcenter.py
+++ b/mrp_workorder_blocking_time/models/mrp_routing_workcenter.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class MrpRoutingWorkcenter(models.Model):
+    _inherit = "mrp.routing.workcenter"
+
+    blocking_stage = fields.Boolean(default=False, copy=False)
+    recommended_blocking_time = fields.Float(copy=False)

--- a/mrp_workorder_blocking_time/models/mrp_workorder.py
+++ b/mrp_workorder_blocking_time/models/mrp_workorder.py
@@ -1,0 +1,90 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
+from odoo import fields, models
+
+
+class MrpWorkorder(models.Model):
+    _inherit = "mrp.workorder"
+
+    blocking_stage_end = fields.Datetime(copy=False)
+    blocking_period_interrupted = fields.Boolean(copy=False)
+    interruption_reason = fields.Text(copy=False)
+
+    def button_start(self):
+        res = super().button_start()
+        if self.operation_id and self.operation_id.blocking_stage is True:
+            # calculate the end of the blocking stage based on :
+            # the recommended_blocking_time from operation_id + the start date of the work order
+            blocking_stage_end = self.date_start + timedelta(
+                hours=self.operation_id.recommended_blocking_time
+            )
+            self.blocking_stage_end = blocking_stage_end
+        return res
+
+    def _open_blocking_reason_popup(self, action_to_do):
+        action = self.env.ref(
+            "mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_act_window"
+        ).read()[0]
+        action["context"] = {"active_id": self.id, "action_to_do": action_to_do}
+        return action
+
+    def _check_blocking_time_done(self):
+        """
+        This method check if the blocking stage is done
+        """
+        if self.operation_id and self.operation_id.blocking_stage is True:
+            if self.blocking_stage_end:
+                if self.blocking_stage_end > fields.Datetime.now():
+                    self.blocking_period_interrupted = True
+                    return True
+        return False
+
+    def button_pending(self):
+        bypass_check_blocking_time = self.env.context.get(
+            "bypass_check_blocking_time", False
+        )
+        if bypass_check_blocking_time is True:
+            return super().button_pending()
+        show_warning_popup = self._check_blocking_time_done()
+        if show_warning_popup is True:
+            return self._open_blocking_reason_popup("button_pending")
+        return super().button_pending()
+
+    def button_finish(self):
+        bypass_check_blocking_time = self.env.context.get(
+            "bypass_check_blocking_time", False
+        )
+        if bypass_check_blocking_time is True:
+            return super().button_finish()
+        show_warning_popup = self._check_blocking_time_done()
+        if show_warning_popup is True:
+            return self._open_blocking_reason_popup("button_finish")
+        res = super().button_finish()
+        return res
+
+    def do_finish(self):
+        bypass_check_blocking_time = self.env.context.get(
+            "bypass_check_blocking_time", False
+        )
+        if bypass_check_blocking_time is True:
+            return super().do_finish()
+        show_warning_popup = self._check_blocking_time_done()
+        if show_warning_popup is True:
+            return self._open_blocking_reason_popup("do_finish")
+        res = super().do_finish()
+        return res
+
+    def action_open_manufacturing_order(self):
+        bypass_check_blocking_time = self.env.context.get(
+            "bypass_check_blocking_time", False
+        )
+        if bypass_check_blocking_time is True:
+            return super().action_open_manufacturing_order()
+        show_warning_popup = self._check_blocking_time_done()
+        if show_warning_popup is True:
+            return self._open_blocking_reason_popup("action_open_manufacturing_order")
+        res = super().action_open_manufacturing_order()
+        return res

--- a/mrp_workorder_blocking_time/readme/CONTRIBUTORS.rst
+++ b/mrp_workorder_blocking_time/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Italo LOPES <contact@ilopes.me>

--- a/mrp_workorder_blocking_time/readme/DESCRIPTION.rst
+++ b/mrp_workorder_blocking_time/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+On some Manufacturing orders, we need to block them in "progress" on a work operation for some time
+before being able to continue the process or close the MO.
+
+This module allow to set a delay on a work order operation and to block changes on the MO until
+the delay is over.

--- a/mrp_workorder_blocking_time/readme/USAGE.rst
+++ b/mrp_workorder_blocking_time/readme/USAGE.rst
@@ -1,0 +1,5 @@
+To use this module, you need to:
+
+#. Go to *Manufacturing* and create an Operation.
+#. Check the case blocking stage on the Operation to use blocking time.
+#. Set the time (in hours) to block the stage.

--- a/mrp_workorder_blocking_time/security/ir.model.access.csv
+++ b/mrp_workorder_blocking_time/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mrp_workorder_blocking_reason_wizard_user,mrp.workorder.blocking.wizard user,model_mrp_workorder_blocking_reason_wizard,mrp.group_mrp_user,1,1,1,1

--- a/mrp_workorder_blocking_time/tests/__init__.py
+++ b/mrp_workorder_blocking_time/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_workorder_blocking_time

--- a/mrp_workorder_blocking_time/tests/test_mrp_workorder_blocking_time.py
+++ b/mrp_workorder_blocking_time/tests/test_mrp_workorder_blocking_time.py
@@ -1,0 +1,158 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from datetime import timedelta
+
+from odoo.tests import Form, TransactionCase, tagged
+
+
+# use "tagged" based on https://github.com/odoo/odoo/issues/18002
+@tagged("post_install", "-at_install")
+class TestMrpWorkorderBlockingTime(TransactionCase):
+    def create_production_to_test(self):
+        # create new production order
+        mrp_order_form = Form(self.env["mrp.production"])
+        mrp_order_form.product_id = self.product_to_build
+        mrp_order_form.product_qty = 1
+        production = mrp_order_form.save()
+
+        return production
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.product_to_build = cls.env["product.product"].create(
+            {
+                "name": "Young Tom",
+                "type": "product",
+            }
+        )
+        cls.product_to_use_1 = cls.env["product.product"].create(
+            {
+                "name": "Botox",
+                "type": "product",
+            }
+        )
+        cls.bom_1 = cls.env["mrp.bom"].create(
+            {
+                "product_id": cls.product_to_build.id,
+                "product_tmpl_id": cls.product_to_build.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "consumption": "flexible",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": cls.product_to_use_1.id, "product_qty": 1})
+                ],
+            }
+        )
+
+        cls.workcenter_1 = cls.env["mrp.workcenter"].create(
+            {
+                "name": "Workcenter 1",
+            }
+        )
+
+        cls.operationWithBlockingTime = cls.env["mrp.routing.workcenter"].create(
+            {
+                "name": "Operation 1",
+                "bom_id": cls.bom_1.id,
+                "workcenter_id": cls.workcenter_1.id,
+                "time_cycle": 1,
+                "time_mode": "manual",
+                "time_cycle_manual": 60.0,
+                "blocking_stage": True,
+                "recommended_blocking_time": 1.5,
+                "sequence": 1,
+            }
+        )
+
+    def test_bom_has_operations(self):
+        bom_1 = self.bom_1
+        # check if bom work has some work orders
+        self.assertNotEqual(len(bom_1.operation_ids), 0)
+
+    def test_production_create(self):
+        production = self.create_production_to_test()
+
+        production.action_confirm()
+        self.assertNotEqual(len(production.workorder_ids), 0)
+
+    def test_start_workorder_with_blocking_time(self):
+        production = self.create_production_to_test()
+
+        production.action_confirm()
+
+        # start workorder
+        workorder = production.workorder_ids[0]
+        workorder.button_start()
+
+        # check if work order has blocking stage date set
+        # and check if the blocking state date is correct
+        # (date_start + recommended_blocking_time)
+        self.assertNotEqual(workorder.blocking_stage_end, False)
+        self.assertEqual(
+            workorder.blocking_stage_end,
+            workorder.date_start
+            + timedelta(hours=workorder.operation_id.recommended_blocking_time),
+        )
+
+    def test_pause_workorder_with_blocking_message(self):
+        production = self.create_production_to_test()
+
+        production.action_confirm()
+
+        # start workorder
+        workorder = production.workorder_ids[0]
+        workorder.button_start()
+        self.assertEqual(workorder.is_user_working, True)
+
+        # check if the popup opens when workorder button_pending method is called
+        # and the blocking state date is not over
+        # (blocking_stage_end > fields.Datetime.now())
+        is_popup = workorder.button_pending()
+        self.assertIsInstance(is_popup, dict)
+
+        wizard_obj = self.env["mrp.workorder.blocking.reason.wizard"].with_context(
+            active_id=workorder.id, action_to_do="button_pending"
+        )
+        wizard_id = wizard_obj.create(
+            {"interruption_reason": "Test reason button_pending"}
+        )
+
+        wizard_id.action_confirm()
+
+        # check if work order has blocking_period_interrupted
+        # set and a reason
+        self.assertNotEqual(workorder.blocking_period_interrupted, False)
+        self.assertEqual(workorder.interruption_reason, "Test reason button_pending")
+
+    def test_finish_workorder_with_blocking_message(self):
+        production = self.create_production_to_test()
+
+        production.action_confirm()
+
+        # start workorder
+        workorder = production.workorder_ids[0]
+        workorder.button_start()
+
+        # check if the popup opens when workorder button_finish method is called
+        # and the blocking state date is not over
+        # (blocking_stage_end > fields.Datetime.now())
+        is_popup = workorder.button_finish()
+        self.assertIsInstance(is_popup, dict)
+
+        wizard_obj = self.env["mrp.workorder.blocking.reason.wizard"].with_context(
+            active_id=workorder.id, action_to_do="button_finish"
+        )
+        wizard_id = wizard_obj.create(
+            {"interruption_reason": "Test reason button_finish"}
+        )
+
+        wizard_id.action_confirm()
+
+        # check if work order has blocking_period_interrupted
+        # set and a reason
+        self.assertNotEqual(workorder.blocking_period_interrupted, False)
+        self.assertEqual(workorder.interruption_reason, "Test reason button_finish")
+        self.assertEqual(workorder.state, "done")

--- a/mrp_workorder_blocking_time/views/mrp_routing_workcenter.xml
+++ b/mrp_workorder_blocking_time/views/mrp_routing_workcenter.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="mrp_routing_workcenter_blocking_time_form_inherit" model="ir.ui.view">
+        <field name="name">mrp.routing.workcenter.blocking_time.form.inherit</field>
+        <field name="model">mrp.routing.workcenter</field>
+        <field name="inherit_id" ref="mrp.mrp_routing_workcenter_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='time_cycle']" position="after">
+                <field name="blocking_stage" />
+                <label
+                    for="recommended_blocking_time"
+                    attrs="{'invisible': [('blocking_stage', '=', False)]}"
+                    string="Rec. Blocking Time"
+                />
+                <div attrs="{'invisible': [('blocking_stage', '=', False)]}">
+                    <field
+                        name="recommended_blocking_time"
+                        widget="float_time"
+                        class="oe_inline"
+                    /> hours
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+
+    <record id="mrp_routing_workcenter_blocking_time_tree_inherit" model="ir.ui.view">
+        <field name="name">mrp.routing.workcenter.blocking_time.tree.inherit</field>
+        <field name="model">mrp.routing.workcenter</field>
+        <field name="inherit_id" ref="mrp.mrp_routing_workcenter_tree_view" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='time_cycle']" position="after">
+                <field name="blocking_stage" optional="show" />
+                <field
+                    name="recommended_blocking_time"
+                    widget="float_time"
+                    string="Rec. Blocking Time (hours)"
+                    width="1.5"
+                    optional="show"
+                />
+            </xpath>
+
+        </field>
+    </record>
+
+
+    <record
+        id="mrp_routing_workcenter_bom_blocking_time_tree_inherit"
+        model="ir.ui.view"
+    >
+        <field name="name">mrp.routing.workcenter.bom.blocking_time.tree.inherit</field>
+        <field name="model">mrp.routing.workcenter</field>
+        <field name="inherit_id" ref="mrp.mrp_routing_workcenter_bom_tree_view" />
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='time_cycle']" position="after">
+                <field name="blocking_stage" optional="show" />
+                <field
+                    name="recommended_blocking_time"
+                    widget="float_time"
+                    string="Rec. Blocking Time (hours)"
+                    width="1.5"
+                    optional="show"
+                />
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/mrp_workorder_blocking_time/views/mrp_workorder.xml
+++ b/mrp_workorder_blocking_time/views/mrp_workorder.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+
+    <record id="mrp_workorder_blocking_time_tree_inherit" model="ir.ui.view">
+            <field name="name">mrp.workorder.blocking_time.tree.inherit</field>
+            <field name="model">mrp.workorder</field>
+            <field
+            name="inherit_id"
+            ref="mrp.mrp_production_workorder_tree_editable_view"
+        />
+            <field name="arch" type="xml">
+
+                <xpath expr="//field[@name='date_finished']" position="after">
+                    <field name="blocking_stage_end" optional="show" readonly="1" />
+                </xpath>
+                <xpath expr="//field[@name='json_popover']" position="after">
+                    <field
+                    name="blocking_period_interrupted"
+                    optional="hide"
+                    readonly="1"
+                />
+                    <field name="interruption_reason" optional="hide" readonly="1" />
+                </xpath>
+
+            </field>
+        </record>
+
+
+
+</odoo>

--- a/mrp_workorder_blocking_time/wizards/__init__.py
+++ b/mrp_workorder_blocking_time/wizards/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import wizard_open_blocking_popup

--- a/mrp_workorder_blocking_time/wizards/wizard_open_blocking_popup.py
+++ b/mrp_workorder_blocking_time/wizards/wizard_open_blocking_popup.py
@@ -1,0 +1,27 @@
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class WizardBlockingReason(models.TransientModel):
+    _name = "mrp.workorder.blocking.reason.wizard"
+    _description = "Wizard to open a blocking reason popup for a workorder"
+
+    interruption_reason = fields.Text(copy=False)
+
+    def action_confirm(self):
+        """
+        This method allow to set the interruption reason on the workorder
+        """
+        self.ensure_one()
+        action_to_do = self.env.context.get("action_to_do")
+        if not action_to_do:
+            raise UserError(_("No action to do"))
+        workorder_obj = self.env["mrp.workorder"]
+        workorder = workorder_obj.browse(self.env.context.get("active_id"))
+        workorder.interruption_reason = self.interruption_reason
+        workorder.blocking_period_interrupted = bool(self.interruption_reason)
+        if hasattr(workorder, action_to_do):
+            getattr(
+                workorder.with_context(bypass_check_blocking_time=True), action_to_do
+            )()
+        return {"type": "ir.actions.act_window_close"}

--- a/mrp_workorder_blocking_time/wizards/wizard_open_blocking_popup.xml
+++ b/mrp_workorder_blocking_time/wizards/wizard_open_blocking_popup.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="mrp_workorder_blocking_reason_wizard_form_view" model="ir.ui.view">
+            <field name="name">mrp.workorder.blocking.reason.wizard.form</field>
+            <field name="model">mrp.workorder.blocking.reason.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Warning">
+                    <sheet>
+                        <div class="oe_title">
+                            <h3>
+                                You are trying to pause/finish a workorder, but the blocking period is not over.
+                                Are you sure you want to continue?
+                            </h3>
+                        </div>
+                        <group colspan="4">
+                            <field name="interruption_reason" required="1" />
+                        </group>
+                    </sheet>
+                    <footer>
+                        <button
+                        string="Cancel and continue WO"
+                        class="btn-default"
+                        special="cancel"
+                    />
+                        <button
+                        name="action_confirm"
+                        string="Accept and stop WO"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+
+    <record
+        id="mrp_workorder_blocking_reason_wizard_act_window"
+        model="ir.actions.act_window"
+    >
+            <field name="name">WorkOrder Blocking Reason Popup</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">mrp.workorder.blocking.reason.wizard</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+
+</odoo>

--- a/setup/mrp_workorder_blocking_time/odoo/addons/mrp_workorder_blocking_time
+++ b/setup/mrp_workorder_blocking_time/odoo/addons/mrp_workorder_blocking_time
@@ -1,0 +1,1 @@
+../../../../mrp_workorder_blocking_time

--- a/setup/mrp_workorder_blocking_time/setup.py
+++ b/setup/mrp_workorder_blocking_time/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
On some Manufacturing orders, we need to block them in "progress" on a work operation for some time before being able to continue the process or close the MO.

This module allow to set a delay on a work order operation and to block changes on the MO until the delay is over.

If the delay is not over and we try to pause or finish the MO, a popup opens to allow to set the reason to stop the MO.