### PR TITLE
[13.0][FIX] mrp_multi_level: Recompute main supplier in MRP Parameter

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -184,7 +184,9 @@ class ProductMRPArea(models.Model):
             rule = group_obj._get_rule(rec.product_id, proc_loc, values)
             rec.supply_method = rule.action if rule else "none"
 
-    @api.depends("supply_method", "product_id.route_ids", "product_id.seller_ids")
+    @api.depends(
+        "mrp_area_id", "supply_method", "product_id.route_ids", "product_id.seller_ids"
+    )
     def _compute_main_supplier(self):
         """Simplified and similar to procurement.rule logic."""
         for rec in self.filtered(lambda r: r.supply_method == "buy"):


### PR DESCRIPTION
Recompute main supplier in MRP Parameter if we change MRP Area.

To reproduce the changes
1. Create Product with vendors with a specific company associated.
2. Create MRP Parameter with a MRP Area in a different company and save.
3. Change the MRP Area to the correct one.

Previous behaviour:
- Main supplier will not be recomputed and Lead Time is not set.

Actual behaviour:
- Main supplier recomputed and Lead Time set.