### PR TITLE
[13.0][FIX] mrp_multi_level: do not include supplies on origin.

### DIFF
--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -43,6 +43,7 @@
                             <field name="product_id" />
                             <field name="mrp_area_id" />
                             <field name="name" />
+                            <field name="origin" />
                             <field name="fixed" />
                         </group>
                         <group>

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -535,7 +535,8 @@ class MultiLevelMrp(models.TransientModel):
             else:
                 last_date = fields.Date.from_string(move.mrp_date)
                 onhand += move.mrp_qty
-            demand_origin.append(move.origin or move.name)
+            if move.mrp_type == "d":
+                demand_origin.append(move.origin or move.name)
 
         if last_date and last_qty != 0.00:
             name = _(


### PR DESCRIPTION
Planned orders' origin when groupping was including supplies which could lead to confusion.

Before:
![image](https://user-images.githubusercontent.com/23449160/190386657-fcb1eea4-8085-44fc-89f8-c1b77eb17b25.png)

After:
![image](https://user-images.githubusercontent.com/23449160/190386771-3e4781c0-4879-4b71-be00-9241128cc940.png)


@ForgeFlow