### PR TITLE
[13.0][FIX] quality_control_oca: Protect product category view with group

### DIFF
--- a/quality_control_oca/views/product_category_view.xml
+++ b/quality_control_oca/views/product_category_view.xml
@@ -10,6 +10,7 @@
         <field name="name">product.category.qc</field>
         <field name="model">product.category</field>
         <field name="inherit_id" ref="product.product_category_form_view" />
+        <field name="groups_id" eval="[(4, ref('group_quality_control_user'))]" />
         <field name="arch" type="xml">
             <group name="first" position="after">
                 <group name="qc" string="Quality control">


### PR DESCRIPTION
For avoiding access errors when other users without quality quality permissions wants to open the product category view.

@Tecnativa