### PR TITLE
[14.0][IMP] mrp_workcenter_hierarchical: Parents level identification

### DIFF
--- a/mrp_workcenter_hierarchical/models/mrp_workcenter.py
+++ b/mrp_workcenter_hierarchical/models/mrp_workcenter.py
@@ -45,7 +45,7 @@ class MrpWorkcenter(models.Model):
             ids = []
         return ids
 
-    @api.depends("parent_id.parent_id.parent_id", "child_ids")
+    @api.depends("parent_id.parent_id.parent_id.parent_id", "child_ids")
     def _compute_parent_level(self):
         def get_next_level(parent_ids, workcenter):
             return (
@@ -56,6 +56,22 @@ class MrpWorkcenter(models.Model):
 
         for workcenter in self:
             parent_ids = workcenter._get_parent_ids()
-            workcenter.parent_level_1_id = get_next_level(parent_ids, workcenter)
-            workcenter.parent_level_2_id = get_next_level(parent_ids, workcenter)
-            workcenter.parent_level_3_id = get_next_level(parent_ids, workcenter)
+            exclude_ids = [workcenter.id, workcenter.parent_id.id]
+            l_id = [False, False, False]
+
+            l_id[0] = get_next_level(parent_ids, workcenter)
+            workcenter.parent_level_1_id = (
+                l_id[0] if l_id[0] not in exclude_ids else False
+            )
+            exclude_ids.append(l_id[0])
+
+            l_id[1] = get_next_level(parent_ids, workcenter)
+            workcenter.parent_level_2_id = (
+                l_id[1] if l_id[1] not in exclude_ids else False
+            )
+            exclude_ids.append(l_id[1])
+
+            l_id[2] = get_next_level(parent_ids, workcenter)
+            workcenter.parent_level_3_id = (
+                l_id[2] if l_id[2] not in exclude_ids else False
+            )


### PR DESCRIPTION
Hi all,
I've a suggestion to the mrp_workcenter_hierarchical module.
Now the parents level 1, 2, 3 are filled with same value if there isn't other dependencies and uses its own value as parent.
![before](https://user-images.githubusercontent.com/26981549/193404953-9ccd8719-78ca-4772-ba7c-744e49358c03.png)

With this change references are set to false if they already exist in the hierarchy, as well as by itself.
![after](https://user-images.githubusercontent.com/26981549/193404967-a9381350-6e5e-4771-861d-3f2dc635ae39.png)

It remains a "problem" if the stratification is over 4 levels.
I don't know if is opportune to add an indicator of "there are other levels..."

Surely my code isn't elegant but I'm not a Python Cheff so thanks for review.