### PR TITLE
[14.0][FIX] mrp_bom_attribute_match: writing on multiple products

### DIFF
--- a/mrp_bom_attribute_match/models/product.py
+++ b/mrp_bom_attribute_match/models/product.py
@@ -7,8 +7,9 @@ class ProductTemplate(models.Model):
 
     def write(self, vals):
         res = super(ProductTemplate, self).write(vals)
-        self.check_product_with_component_change_allowed()
-        self.check_component_change_allowed()
+        for product in self:
+            product.check_product_with_component_change_allowed()
+            product.check_component_change_allowed()
         return res
 
     def check_product_with_component_change_allowed(self):


### PR DESCRIPTION
When writing on multiple product variants [this module tries to access `self._origin`](https://github.com/OCA/manufacture/blob/cd8ff960c32a77e7341e27579fedd93372d5bb93/mrp_bom_attribute_match/models/product.py#L63) which results in a singleton error.

I think we can simply avoid it by calling these functions for every product.