### PR TITLE
[13.0][BACKPORT] mrp_multi_level: avoid recursion on LLC calculation.

### DIFF
--- a/mrp_multi_level/__manifest__.py
+++ b/mrp_multi_level/__manifest__.py
@@ -15,6 +15,7 @@
     "data": [
         "security/mrp_multi_level_security.xml",
         "security/ir.model.access.csv",
+        "data/system_parameter.xml",
         "views/mrp_area_views.xml",
         "views/product_product_views.xml",
         "views/product_template_views.xml",

--- a/mrp_multi_level/data/system_parameter.xml
+++ b/mrp_multi_level/data/system_parameter.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="llc_calculation_recursion_limit" model="ir.config_parameter">
+        <field name="key">mrp_multi_level.llc_calculation_recursion_limit</field>
+        <field name="value">1000</field>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport from: https://github.com/OCA/manufacture/pull/876

Introduce a safe and configurable LLC depth limit to avoid infinite recursion.

Also, improve extensibility of BoM finding and fix it to not consider archived BoMs.