### PR TITLE
[IMP] mrp_bom_attribute_match: Avoid write same product

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_bom.py
+++ b/mrp_bom_attribute_match/models/mrp_bom.py
@@ -200,7 +200,8 @@ class MrpBom(models.Model):
             )
             if component_template_product:
                 # need to set product_id temporary
-                current_line.product_id = component_template_product
+                if current_line.product_id != component_template_product:
+                    current_line.product_id = component_template_product
             else:
                 # component_template_id is set, but no attribute value match.
                 continue


### PR DESCRIPTION
Currently, without this fix, a _product.template_ search takes a long time when we have many products with dynamic BOMs.

These are the times obtained in some cases:

**# 1**:
**Before**: 274.05381894111633 sec.
**After**: 4.87627649307251 sec.

**# 2**:
**Before**: 665.5540463924408 sec.
**After**: 34.8937041759491 sec.

In my case I have used _search_read_ with this domain:
```
[
    "|",
    "|",
    "|",
    ("default_code", "ilike", product_name),
    ("product_variant_ids.default_code", "ilike", product_name),
    ("name", "ilike", product_name),
    ("barcode", "ilike", product_name),
]
```

