### PR TITLE
[15.0][FIX] mrp_multi_level: demo data was failing on installation.

### DIFF
--- a/mrp_multi_level/demo/initial_on_hand_demo.xml
+++ b/mrp_multi_level/demo/initial_on_hand_demo.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo noupdate="1">
+
     <record id="stock_inventory_1" model="stock.quant">
         <field name="product_id" ref="product_product_pp_1" />
-        <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="inventory_quantity">10</field>
         <field
             name="location_id"
@@ -12,7 +12,6 @@
     </record>
     <record id="stock_inventory_2" model="stock.quant">
         <field name="product_id" ref="product_product_pp_2" />
-        <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="inventory_quantity">20</field>
         <field
             name="location_id"
@@ -22,7 +21,6 @@
     </record>
     <record id="stock_inventory_3" model="stock.quant">
         <field name="product_id" ref="product_product_sf_2" />
-        <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="inventory_quantity">15</field>
         <field
             name="location_id"
@@ -39,4 +37,6 @@
             model="stock.quant"
             name="search"
         />
-        </function></odoo>
+        </function>
+
+</odoo>


### PR DESCRIPTION
`product_uom_id` is not in the allowed fields for stock.quant when in inventory mode. See `_get_inventory_fields_create` method in stock.quant for more details.

This was making some test fail.