### PR TITLE
[14.0][FIX] mrp_unbuild_valuation_layer_link: fix wobbly tests

### DIFF
--- a/mrp_unbuild_valuation_layer_link/tests/test_mrp__unbuild_valuation_layer_link.py
+++ b/mrp_unbuild_valuation_layer_link/tests/test_mrp__unbuild_valuation_layer_link.py
@@ -53,8 +53,8 @@ class TestUnbuild(TestMrpCommon):
             "You should access to the model stock.valuation.layer",
         )
         self.assertEqual(
-            difference_layers,
-            unbuild_valuation_layers,
+            sorted(difference_layers),
+            sorted(unbuild_valuation_layers),
             "You should have as domain the ids of the stock valuation belonging "
             "to the ids of the stock moves of produce_line and consume_line",
         )


### PR DESCRIPTION
Failing test encountered there:
- https://github.com/OCA/manufacture/pull/905
- https://github.com/OCA/manufacture/actions/runs/3581755765/jobs/6025185446#step:8:503