### PR TITLE
[14.0][IMP] account_move_line_mrp_info: journal items are now accessed from a smart button

### DIFF
--- a/account_move_line_mrp_info/models/mrp_production.py
+++ b/account_move_line_mrp_info/models/mrp_production.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from ast import literal_eval
 
 from odoo import fields, models
 
@@ -11,6 +12,24 @@ class MrpProduction(models.Model):
         comodel_name="account.move.line", inverse_name="mrp_production_id", copy=False
     )
 
+    def view_journal_items(self):
+        self.ensure_one()
+        domain = [
+            (
+                "id",
+                "in",
+                (self.account_move_line_ids).ids,
+            )
+        ]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_move_line_mrp_info.action_view_journal_items"
+        )
+        context = literal_eval(action["context"])
+        context.update(self.env.context)
+        context["no_at_date"] = True
+        context["search_default_group_by_product_id"] = False
+        return dict(action, domain=domain, context=context)
+
 
 class MrpUnbuild(models.Model):
     _inherit = "mrp.unbuild"
@@ -18,3 +37,21 @@ class MrpUnbuild(models.Model):
     account_move_line_ids = fields.One2many(
         comodel_name="account.move.line", inverse_name="unbuild_id", copy=False
     )
+
+    def view_journal_items(self):
+        self.ensure_one()
+        domain = [
+            (
+                "id",
+                "in",
+                (self.account_move_line_ids).ids,
+            )
+        ]
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "account_move_line_mrp_info.action_view_journal_items"
+        )
+        context = literal_eval(action["context"])
+        context.update(self.env.context)
+        context["no_at_date"] = True
+        context["search_default_group_by_product_id"] = False
+        return dict(action, domain=domain, context=context)

--- a/account_move_line_mrp_info/readme/USAGE.rst
+++ b/account_move_line_mrp_info/readme/USAGE.rst
@@ -1,5 +1,6 @@
 * The stock manager can check the journal items by accessing to 'Manufacturing >
-  Operations > Manufacturing Orders> Miscellaneous page'.
+  Operations > Manufacturing Orders> Journal Items' and 'Manufacturing >
+  Operations > Unbuild Orders> Journal Items.
 
 * A user belonging to the group 'Show Full Accounting Features' can review the
   details of a move that is associated to a journal item through

--- a/account_move_line_mrp_info/tests/__init__.py
+++ b/account_move_line_mrp_info/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_journal_items

--- a/account_move_line_mrp_info/tests/test_mrp_journal_items.py
+++ b/account_move_line_mrp_info/tests/test_mrp_journal_items.py
@@ -1,0 +1,159 @@
+from odoo.tests import Form
+
+from odoo.addons.mrp.tests.common import TestMrpCommon
+
+
+class TestMrpOrder(TestMrpCommon):
+    def setUp(self):
+        super(TestMrpOrder, self).setUp()
+        self.stock_location = self.env.ref("stock.stock_location_stock")
+        self.env.ref("base.group_user").write(
+            {"implied_ids": [(4, self.env.ref("stock.group_production_lot").id)]}
+        )
+
+    def test_mrp_with_journal_items(self):
+        """This test creates a Manufacturing orderand then check if the
+        Journal Items button links to the journal items of the order.
+        """
+        journal_items_before_production = self.env["account.move.line"].search([]).ids
+
+        mo, bom, p_final, p1, p2 = self.generate_mo()
+        account = self.env["account.account"].create(
+            {
+                "name": "Test Account",
+                "code": "TestAccount1",
+                "user_type_id": self.env.ref("account.data_account_type_payable").id,
+                "reconcile": True,
+            }
+        )
+        location = self.env["stock.location"].search([("usage", "=", "production")])
+        location.valuation_in_account_id = account.id
+        location.valuation_out_account_id = account.id
+        pc = self.env["product.category"].create(
+            {
+                "name": "Category test",
+                "property_valuation": "real_time",
+                "property_cost_method": "fifo",
+            }
+        )
+        p1.categ_id = pc.id
+        p1.standard_price = 10
+        p2.categ_id = pc.id
+        p2.standard_price = 5
+        p_final.categ_id = pc.id
+
+        self.env["stock.quant"]._update_available_quantity(p1, self.stock_location, 100)
+        self.env["stock.quant"]._update_available_quantity(p2, self.stock_location, 5)
+        mo.action_assign()
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5.0
+        mo = mo_form.save()
+        mo.button_mark_done()
+
+        journal_items_after_production = self.env["account.move.line"].search([]).ids
+
+        result = mo.view_journal_items()
+        domain = result["domain"]
+        mo_journal_items = list(domain[0][2])
+        difference_journal_items = list(
+            set(journal_items_after_production) - set(journal_items_before_production)
+        )
+        mo_journal_items.sort()
+        difference_journal_items.sort()
+
+        self.assertTrue(
+            difference_journal_items,
+            "There should be new journal items after doing the manufacturing order",
+        )
+        self.assertEqual(
+            result["res_model"],
+            "account.move.line",
+            "You should access to the model account.move.line",
+        )
+        self.assertEqual(
+            difference_journal_items,
+            mo_journal_items,
+            "You should have as domain the ids of the journal items",
+        )
+
+
+class TestUnbuild(TestMrpCommon):
+    def setUp(self):
+        super(TestUnbuild, self).setUp()
+        self.stock_location = self.env.ref("stock.stock_location_stock")
+        self.env.ref("base.group_user").write(
+            {"implied_ids": [(4, self.env.ref("stock.group_production_lot").id)]}
+        )
+
+    def test_unbuild_with_journal_items(self):
+        """This test creates an Unbuild order from a Manufacturing order and then check if the
+        Journal Items button links to the journal items of the order.
+        """
+
+        mo, bom, p_final, p1, p2 = self.generate_mo()
+        account = self.env["account.account"].create(
+            {
+                "name": "Test Account",
+                "code": "TestAccount2",
+                "user_type_id": self.env.ref("account.data_account_type_payable").id,
+                "reconcile": True,
+            }
+        )
+        location = self.env["stock.location"].search([("usage", "=", "production")])
+        location.valuation_in_account_id = account.id
+        location.valuation_out_account_id = account.id
+        pc = self.env["product.category"].create(
+            {
+                "name": "Category test",
+                "property_valuation": "real_time",
+                "property_cost_method": "fifo",
+            }
+        )
+        p1.categ_id = pc.id
+        p1.standard_price = 10
+        p2.categ_id = pc.id
+        p2.standard_price = 5
+        p_final.categ_id = pc.id
+
+        self.env["stock.quant"]._update_available_quantity(p1, self.stock_location, 100)
+        self.env["stock.quant"]._update_available_quantity(p2, self.stock_location, 5)
+        mo.action_assign()
+
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5.0
+        mo = mo_form.save()
+        mo.button_mark_done()
+        journal_items_before_unbuild = self.env["account.move.line"].search([]).ids
+
+        x = Form(self.env["mrp.unbuild"])
+        x.product_id = p_final
+        x.bom_id = bom
+        x.product_qty = 5
+        unbuild = x.save()
+        unbuild.action_unbuild()
+        journal_items_after_unbuild = self.env["account.move.line"].search([]).ids
+
+        result = unbuild.view_journal_items()
+        domain = result["domain"]
+        unbuild_journal_items = domain[0][2]
+        difference_journal_items = list(
+            set(journal_items_after_unbuild) - set(journal_items_before_unbuild)
+        )
+        unbuild_journal_items.sort()
+        difference_journal_items.sort()
+
+        self.assertTrue(
+            difference_journal_items,
+            "There should be new journal items after doing the unbuild",
+        )
+        self.assertEqual(
+            result["res_model"],
+            "account.move.line",
+            "You should access to the model account.move.line",
+        )
+        self.assertEqual(
+            difference_journal_items,
+            unbuild_journal_items,
+            "You should have as domain the ids of the journal items",
+        )

--- a/account_move_line_mrp_info/views/mrp_production_view.xml
+++ b/account_move_line_mrp_info/views/mrp_production_view.xml
@@ -1,14 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+       <record id="action_view_journal_items" model="ir.actions.act_window">
+        <field name="name">Journal Items</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">account.move.line</field>
+        <field name="view_mode">tree,form</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_empty_folder">
+                There's no journal item yet
+            </p>
+        </field>
+    </record>
+
     <record id="mrp_production_form_view" model="ir.ui.view">
         <field name="model">mrp.production</field>
         <field name="inherit_id" ref="mrp.mrp_production_form_view" />
         <field name="arch" type="xml">
-            <page name="miscellaneous" position="inside">
-                <group name="account_move_lines_grp" string="Journal Items" colspan="4">
-                    <field name="account_move_line_ids" readonly="1" nolabel="1" />
-                </group>
-            </page>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    string="Journal Items"
+                    type="object"
+                    name="view_journal_items"
+                    class="oe_stat_button"
+                    icon="fa-th-list"
+                    groups="base.group_no_one"
+                    attrs="{'invisible': [('state', '!=', 'done')]}"
+                />
+            </xpath>
         </field>
     </record>
 
@@ -16,9 +34,17 @@
         <field name="model">mrp.unbuild</field>
         <field name="inherit_id" ref="mrp.mrp_unbuild_form_view" />
         <field name="arch" type="xml">
-            <field name="location_dest_id" position="after">
-                    <field name="account_move_line_ids" readonly="1" nolabel="1" />
-            </field>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    string="Journal Items"
+                    type="object"
+                    name="view_journal_items"
+                    class="oe_stat_button"
+                    icon="fa-th-list"
+                    groups="base.group_no_one"
+                    attrs="{'invisible': [('state', '=', 'draft')]}"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
journal items of a manufacturing order or an unbuild order are now accessed from a "Journal Items" smart button.


@ForgeFlow 