### PR TITLE
[14.0][ADD] mrp_component_operation_scrap_reason

### DIFF
--- a/mrp_component_operation_scrap_reason/__init__.py
+++ b/mrp_component_operation_scrap_reason/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/mrp_component_operation_scrap_reason/__manifest__.py
+++ b/mrp_component_operation_scrap_reason/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+{
+    "name": "MRP Component Operation Scrap Reason",
+    "version": "14.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "summary": "Allows to pass a reason to scrap with MRP component operation",
+    "website": "https://github.com/OCA/manufacture",
+    "category": "Manufacturing/Manufacturing",
+    "license": "AGPL-3",
+    "depends": ["scrap_reason_code", "mrp_component_operation"],
+    "data": [
+        "wizards/mrp_component_operate_wizard.xml",
+    ],
+    "installable": True,
+    "auto-install": True,
+}

--- a/mrp_component_operation_scrap_reason/readme/CONTRIBUTORS.rst
+++ b/mrp_component_operation_scrap_reason/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* David Jiménez <david.jimenez@forgeflow.com>

--- a/mrp_component_operation_scrap_reason/readme/DESCRIPTION.rst
+++ b/mrp_component_operation_scrap_reason/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module allows to pass a reason to scrap with MRP component operation (glue module).

--- a/mrp_component_operation_scrap_reason/wizards/__init__.py
+++ b/mrp_component_operation_scrap_reason/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import mrp_component_operate

--- a/mrp_component_operation_scrap_reason/wizards/mrp_component_operate.py
+++ b/mrp_component_operation_scrap_reason/wizards/mrp_component_operate.py
@@ -1,0 +1,18 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class MrpComponentOperate(models.Model):
+    _inherit = "mrp.component.operate"
+
+    scrap_reason_code_id = fields.Many2one(
+        "scrap.reason.code",
+        string="Scrap Reason Code",
+    )
+
+    def _create_scrap(self):
+        scrap = super()._create_scrap()
+        scrap.reason_code_id = self.scrap_reason_code_id
+        return scrap

--- a/mrp_component_operation_scrap_reason/wizards/mrp_component_operate_wizard.xml
+++ b/mrp_component_operation_scrap_reason/wizards/mrp_component_operate_wizard.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_mrp_component_operate_form_scrap_reason" model="ir.ui.view">
+        <field name="name">view_mrp_component_operate_form_scrap_reason</field>
+        <field name="model">mrp.component.operate</field>
+        <field
+            name="inherit_id"
+            ref="mrp_component_operation.view_mrp_component_operate_form"
+        />
+        <field name="arch" type="xml">
+            <field name="operation_id" position="after">
+                <field
+                    name="scrap_reason_code_id"
+                    attrs="{'invisible': [('outgoing_operation', '!=', 'scrap')], 'required': [('outgoing_operation', '=', 'scrap')]}"
+                />
+            </field>
+
+        </field>
+    </record>
+</odoo>

--- a/setup/mrp_component_operation_scrap_reason/odoo/addons/mrp_component_operation_scrap_reason
+++ b/setup/mrp_component_operation_scrap_reason/odoo/addons/mrp_component_operation_scrap_reason
@@ -1,0 +1,1 @@
+../../../../mrp_component_operation_scrap_reason

--- a/setup/mrp_component_operation_scrap_reason/setup.py
+++ b/setup/mrp_component_operation_scrap_reason/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to pass a reason to scrap with MRP component operation (glue module).

Depends on #917 

@ForgeFlow