### PR TITLE
[15.0][IMP]  mrp_lot_number_propagation: Propagate from multiple lines

### DIFF
--- a/mrp_lot_number_propagation/models/mrp_bom_line.py
+++ b/mrp_lot_number_propagation/models/mrp_bom_line.py
@@ -39,16 +39,6 @@ class MrpBomLine(models.Model):
         for line in self:
             if not line.bom_id.lot_number_propagation:
                 continue
-            lines_to_propagate = line.bom_id.bom_line_ids.filtered(
-                lambda o: o.propagate_lot_number
-            )
-            if len(lines_to_propagate) > 1:
-                raise ValidationError(
-                    _(
-                        "Only one BoM line can propagate its lot/serial number "
-                        "to the finished product."
-                    )
-                )
             if line.propagate_lot_number and line.product_id.tracking != "serial":
                 raise ValidationError(
                     _(

--- a/mrp_lot_number_propagation/tests/test_mrp_bom.py
+++ b/mrp_lot_number_propagation/tests/test_mrp_bom.py
@@ -13,17 +13,6 @@ class TestMrpBom(Common):
         self.bom.product_tmpl_id.tracking = "none"
         self.assertFalse(self.bom.display_lot_number_propagation)
 
-    def test_bom_line_check_propagate_lot_number_multi(self):
-        form = Form(self.bom)
-        form.lot_number_propagation = True
-        # Flag more than one line to propagate
-        for i in range(len(form.bom_line_ids)):
-            line_form = form.bom_line_ids.edit(i)
-            line_form.propagate_lot_number = True
-            line_form.save()
-        with self.assertRaisesRegex(ValidationError, "Only one BoM"):
-            form.save()
-
     def test_bom_line_check_propagate_lot_number_not_tracked(self):
         form = Form(self.bom)
         form.lot_number_propagation = True


### PR DESCRIPTION
Allow to propagate lot from multiple BOM lines for variants

When defining a single BOM for a product template having multiple product variants, we can have different components where the lot number must be propagated for different product variants.

Therefore we need to allow to mark multiple BOM line with propagate_lot_number, and to avoid complicating the check function on the BOM lines, we ensure at the manufacturing order confirmation that only a single component is set to propagate its lot number.