### PR TITLE
[14.0][IMP] mrp_sale_info: Smartlink on sale order

### DIFF
--- a/mrp_sale_info/__manifest__.py
+++ b/mrp_sale_info/__manifest__.py
@@ -14,10 +14,12 @@
     "installable": True,
     "depends": [
         "mrp",
+        "sale",
         "sale_stock",
     ],
     "data": [
         "views/mrp_production.xml",
         "views/mrp_workorder.xml",
+        "views/sale_order.xml",
     ],
 }

--- a/mrp_sale_info/models/__init__.py
+++ b/mrp_sale_info/models/__init__.py
@@ -3,3 +3,4 @@
 from . import mrp_production
 from . import mrp_workorder
 from . import stock_rule
+from . import sale_order

--- a/mrp_sale_info/models/sale_order.py
+++ b/mrp_sale_info/models/sale_order.py
@@ -1,0 +1,27 @@
+# Copyright 2018 Alex Comba - Agile Business Group
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    production_ids = fields.One2many("mrp.production", "sale_id")
+    production_count = fields.Integer(compute="_compute_production_count", store=True)
+
+    @api.depends("production_ids")
+    def _compute_production_count(self):
+        for sale in self:
+            sale.production_count = len(sale.production_ids)
+
+    def action_view_production(self):
+        action = self.env.ref("mrp.mrp_production_action").read()[0]
+        if self.production_count > 1:
+            action["domain"] = [("id", "in", self.production_ids.ids)]
+        else:
+            action["views"] = [
+                (self.env.ref("mrp.mrp_production_form_view").id, "form")
+            ]
+            action["res_id"] = self.production_ids.id
+        return action

--- a/mrp_sale_info/tests/test_mrp_sale_info.py
+++ b/mrp_sale_info/tests/test_mrp_sale_info.py
@@ -52,3 +52,6 @@ class TestMrpSaleInfo(common.SavepointCase):
         self.assertEqual(production.sale_id, self.sale_order)
         self.assertEqual(production.partner_id, self.partner)
         self.assertEqual(production.client_order_ref, self.sale_order.client_order_ref)
+        self.assertEqual(self.sale_order.production_count, 1)
+        sale_action = self.sale_order.action_view_production()
+        self.assertEqual(sale_action["res_id"], production.id)

--- a/mrp_sale_info/views/sale_order.xml
+++ b/mrp_sale_info/views/sale_order.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2018 Alex Comba - Agile Business Group
+     Copyright 2016-2018 Akretion
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="view_order_form">
+        <field name="name">sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    type="object"
+                    name="action_view_production"
+                    class="oe_stat_button"
+                    icon="fa-gears"
+                    attrs="{'invisible': [('production_count', '=', 0)]}"
+                >
+                    <field
+                        name="production_count"
+                        widget="statinfo"
+                        string="Production"
+                    />
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Forward port of https://github.com/OCA/manufacture/pull/861

Smartlink on sale order to mrp.production related records. A direct copy of the code from sale_mrp_link.

