### PR TITLE
[14.0][FIX] mrp_component_operation: manufacturing users to use wizard.

### DIFF
--- a/mrp_component_operation/security/ir.model.access.csv
+++ b/mrp_component_operation/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mrp_component_operation_user,mrp.component.operation.user,model_mrp_component_operation,mrp.group_mrp_user,1,0,0,0
 access_mrp_component_operation_manager,mrp.component.operation.manager,model_mrp_component_operation,mrp.group_mrp_manager,1,1,1,1
-access_mrp_component_operate_user,mrp.component.operate.user,model_mrp_component_operate,mrp.group_mrp_user,1,0,0,0
+access_mrp_component_operate_user,mrp.component.operate.user,model_mrp_component_operate,mrp.group_mrp_user,1,1,1,0
 access_mrp_component_operate_manager,mrp.component.operate.manager,model_mrp_component_operate,mrp.group_mrp_manager,1,1,1,1


### PR DESCRIPTION
Manufacturing users should be allowed to operate components and therefore they need to be able to create and write the wizard model.

cc @DavidJForgeFlow 