### PR TITLE
[15.0][IMP] mrp_multi_level: better group operators

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -48,11 +48,16 @@ class MrpInventory(models.Model):
     date = fields.Date()
     demand_qty = fields.Float(string="Demand")
     supply_qty = fields.Float(string="Supply")
-    initial_on_hand_qty = fields.Float(string="Starting Inventory")
-    final_on_hand_qty = fields.Float(string="Forecasted Inventory")
+    initial_on_hand_qty = fields.Float(
+        string="Starting Inventory", group_operator="avg"
+    )
+    final_on_hand_qty = fields.Float(
+        string="Forecasted Inventory", group_operator="avg"
+    )
     to_procure = fields.Float(compute="_compute_to_procure", store=True)
     running_availability = fields.Float(
         string="Planned Availability",
+        group_operator="avg",
         help="Theoretical inventory level if all planned orders were released.",
     )
     order_release_date = fields.Date(compute="_compute_order_release_date", store=True)


### PR DESCRIPTION
For initial OH, final OH and planned availability grouping with sum does not provide any value, specially when grouping by product. And avg though can be more interesting.

For demand and supply we could have more doubts and the sum can make sense, so we keep it as is.