### PR TITLE
[14.0][IMP] mrp_multi_level: Add MRP Planner

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -75,6 +75,11 @@ class MrpInventory(models.Model):
         readonly=True,
         store=True,
     )
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id",
+        readonly=True,
+        store=True,
+    )
 
     def _compute_uom_id(self):
         for rec in self:

--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -77,6 +77,11 @@ class MrpPlannedOrder(models.Model):
         "mrp.production", "planned_order_id", string="Manufacturing Orders"
     )
     mo_count = fields.Integer(compute="_compute_mrp_production_count")
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id",
+        readonly=True,
+        store=True,
+    )
 
     def _compute_mrp_production_count(self):
         for rec in self:

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -97,6 +97,7 @@ class ProductMRPArea(models.Model):
         inverse_name="product_mrp_area_id",
         readonly=True,
     )
+    mrp_planner_id = fields.Many2one("res.users")
 
     _sql_constraints = [
         (

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -108,6 +108,12 @@
                     <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <separator />
+                <field name="mrp_planner_id" invisible="1" />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter
                     string="To Procure"
                     name="filter_to_procure"

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -83,6 +83,11 @@
                 <field name="product_id" />
                 <field name="mrp_area_id" />
                 <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter string="Fixed" name="fixed" domain="[('fixed','=',True)]" />
                 <group name='group_by' expand="0" string="Group By...">
                     <filter

--- a/mrp_multi_level/views/product_mrp_area_views.xml
+++ b/mrp_multi_level/views/product_mrp_area_views.xml
@@ -63,6 +63,7 @@
                             />
                             <field name="product_tmpl_id" invisible="1" />
                             <field name="product_id" />
+                            <field name="mrp_planner_id" />
                             <field name="location_id" invisible="1" />
                             <field
                                 name="location_proc_id"
@@ -154,6 +155,12 @@
                     string="Archived"
                     name="inactive"
                     domain="[('active','=',False)]"
+                />
+                <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
                 />
             </search>
         </field>


### PR DESCRIPTION
For each MRP Parameter or for each Product in a MRP Area, we will be able to add a MRP Planner. Once this planner is set, he can filter himself in the MRP Inventory view to know how is the planning evolving for the products that he is responible of.