### PR TITLE
[16.0][IMP] mrp_multi_level: Add MRP Planner

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,10 +1,11 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.12.0
+_commit: v1.14.1
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
 github_check_license: true
+github_ci_extra_env: {}
 github_enable_codecov: true
 github_enable_makepot: true
 github_enable_stale_action: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
               fi
           done
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
       - id: pyupgrade
         args: ["--keep-percent-format"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort except __init__.py

--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -71,6 +71,11 @@ class MrpInventory(models.Model):
         readonly=True,
         store=True,
     )
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id",
+        readonly=True,
+        store=True,
+    )
 
     def _compute_uom_id(self):
         for rec in self:

--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -76,6 +76,11 @@ class MrpPlannedOrder(models.Model):
         "mrp.production", "planned_order_id", string="Manufacturing Orders"
     )
     mo_count = fields.Integer(compute="_compute_mrp_production_count")
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id",
+        readonly=True,
+        store=True,
+    )
 
     def _compute_mrp_production_count(self):
         for rec in self:

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -97,6 +97,7 @@ class ProductMRPArea(models.Model):
         inverse_name="product_mrp_area_id",
         readonly=True,
     )
+    mrp_planner_id = fields.Many2one("res.users")
 
     _sql_constraints = [
         (

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -109,6 +109,12 @@
                     <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <separator />
+                <field name="mrp_planner_id" invisible="1" />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter
                     string="To Procure"
                     name="filter_to_procure"

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -83,6 +83,11 @@
                 <field name="product_id" />
                 <field name="mrp_area_id" />
                 <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter string="Fixed" name="fixed" domain="[('fixed','=',True)]" />
                 <group name='group_by' expand="0" string="Group By...">
                     <filter

--- a/mrp_multi_level/views/product_mrp_area_views.xml
+++ b/mrp_multi_level/views/product_mrp_area_views.xml
@@ -63,6 +63,7 @@
                             />
                             <field name="product_tmpl_id" invisible="1" />
                             <field name="product_id" />
+                            <field name="mrp_planner_id" />
                             <field name="location_id" invisible="1" />
                             <field
                                 name="location_proc_id"
@@ -161,6 +162,12 @@
                     string="Archived"
                     name="inactive"
                     domain="[('active','=',False)]"
+                />
+                <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
                 />
             </search>
         </field>


### PR DESCRIPTION
For each MRP Parameter or for each Product in a MRP Area, we will be able to add a MRP Planner. Once this planner is set, he can filter himself in the MRP Parameters view, MRP Inventory view or MRP Planned Orders view.

Original PR: https://github.com/OCA/manufacture/pull/956