### PR TITLE
[14.0][FIX] repair_stock_move: fix state in repair lines

### DIFF
--- a/repair_stock_move/models/repair_order.py
+++ b/repair_stock_move/models/repair_order.py
@@ -172,5 +172,6 @@ class RepairOrder(models.Model):
         if self.stock_move_ids:
             # With this module this should always be the case, so this is
             # effectively overriding the method.
+            self.operations.write({"state": "done"})
             return {self.id: self.move_id.id}
         return super().action_repair_done()

--- a/repair_stock_move/tests/test_repair_stock_move.py
+++ b/repair_stock_move/tests/test_repair_stock_move.py
@@ -118,6 +118,11 @@ class TestRepairStockMove(common.SavepointCase):
                 "confirmed",
                 "Generated stock move state should be confirmed",
             )
+            self.assertEqual(
+                operation.state,
+                "confirmed",
+                "Repair line state should be confirmed",
+            )
         # Start Repair
         self.repair1.action_repair_start()
         # End Repair
@@ -132,6 +137,11 @@ class TestRepairStockMove(common.SavepointCase):
                 operation.move_id.state,
                 "done",
                 "Generated stock move state should be done",
+            )
+            self.assertEqual(
+                operation.state,
+                "done",
+                "Repair line state should be done",
             )
 
     def _create_simple_repair_order(self, invoice_method):


### PR DESCRIPTION
When setting the repair to done, the repair lines aren't settled to done, this have some problems when trying to use again lots in manufacturing orders with a lot substituted with another.

@ForgeFlow