### PR TITLE
[13.0][IMP] mrp_multi_level: Add MRP Planner

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -1,5 +1,5 @@
 # © 2016 Ucamco - Wim Audenaert <wim.audenaert@ucamco.com>
-# Copyright 2016-19 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2016-21 ForgeFlow S.L. (https://www.forgeflow.com)
 # - Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 # - Lois Rilo Antelo <lois.rilo@forgeflow.com>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
@@ -65,6 +65,12 @@ class MrpInventory(models.Model):
     supply_method = fields.Selection(
         string="Supply Method",
         related="product_mrp_area_id.supply_method",
+        readonly=True,
+        store=True,
+    )
+    main_supplier_id = fields.Many2one(
+        string="Main Supplier",
+        related="product_mrp_area_id.main_supplier_id",
         readonly=True,
         store=True,
     )

--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -74,6 +74,9 @@ class MrpInventory(models.Model):
         readonly=True,
         store=True,
     )
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id", readonly=True, store=True,
+    )
 
     def _compute_uom_id(self):
         for rec in self:

--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -76,6 +76,9 @@ class MrpPlannedOrder(models.Model):
         "mrp.production", "planned_order_id", string="Manufacturing Orders"
     )
     mo_count = fields.Integer(compute="_compute_mrp_production_count")
+    mrp_planner_id = fields.Many2one(
+        related="product_mrp_area_id.mrp_planner_id", readonly=True, store=True,
+    )
 
     def _compute_mrp_production_count(self):
         for rec in self:

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -97,6 +97,7 @@ class ProductMRPArea(models.Model):
         inverse_name="product_mrp_area_id",
         readonly=True,
     )
+    mrp_planner_id = fields.Many2one("res.users")
 
     _sql_constraints = [
         (

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -108,6 +108,12 @@
                     <field name="company_id" groups="base.group_multi_company" />
                 </group>
                 <separator />
+                <field name="mrp_planner_id" invisible="1" />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter
                     string="To Procure"
                     name="filter_to_procure"

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -17,6 +17,10 @@
                             <field name="product_id" />
                             <field name="product_mrp_area_id" />
                             <field name="supply_method" />
+                            <field
+                                name="main_supplier_id"
+                                attrs="{'invisible': [('supply_method', '!=', 'buy')]}"
+                            />
                             <field name="date" />
                         </group>
                         <group>
@@ -64,6 +68,7 @@
                 />
                 <field name="planned_order_ids" invisible="1" />
                 <field name="supply_method" />
+                <field name="main_supplier_id" optional="hide" />
                 <field name="running_availability" />
             </tree>
         </field>
@@ -124,6 +129,11 @@
                         name="group_supply_method"
                         string="Supply Method"
                         context="{'group_by':'supply_method'}"
+                    />
+                    <filter
+                        name="group_main_supplier_id"
+                        string="Main Supplier"
+                        context="{'group_by':'main_supplier_id'}"
                     />
                     <filter
                         name="group_release_date"

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -83,6 +83,11 @@
                 <field name="product_id" />
                 <field name="mrp_area_id" />
                 <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
+                />
                 <filter string="Fixed" name="fixed" domain="[('fixed','=',True)]" />
                 <group name='group_by' expand="0" string="Group By...">
                     <filter

--- a/mrp_multi_level/views/product_mrp_area_views.xml
+++ b/mrp_multi_level/views/product_mrp_area_views.xml
@@ -63,6 +63,7 @@
                             />
                             <field name="product_tmpl_id" invisible="1" />
                             <field name="product_id" />
+                            <field name="mrp_planner_id" />
                             <field name="location_id" invisible="1" />
                             <field
                                 name="location_proc_id"
@@ -154,6 +155,12 @@
                     string="Archived"
                     name="inactive"
                     domain="[('active','=',False)]"
+                />
+                <separator />
+                <filter
+                    string="My products"
+                    name="mrp_planner_id"
+                    domain="[('mrp_planner_id', '=', uid)]"
                 />
             </search>
         </field>


### PR DESCRIPTION
For each MRP Parameter or for each Product in a MRP Area, we will be able to add a MRP Planner. Once this planner is set, he can filter himself in the MRP Parameters view, MRP Inventory view or MRP Planned Orders view.

Backport of #956 