### PR TITLE
[14.0][FIX] mrp_component_operation: fix test and small issues

### DIFF
--- a/mrp_component_operation/wizards/mrp_component_operate.py
+++ b/mrp_component_operation/wizards/mrp_component_operate.py
@@ -53,9 +53,7 @@ class MrpComponentOperate(models.Model):
             filtered_pickings = self.mo_id.picking_ids.filtered(
                 lambda x: x.location_dest_id == self.operation_id.source_location_id
             )
-            move.move_orig_ids |= filtered_pickings[
-                len(filtered_pickings) - 1
-            ].move_ids_without_package
+            move.move_orig_ids |= filtered_pickings[-1].move_ids_without_package
         elif self.incoming_operation == "no":
             res = []
         return res


### PR DESCRIPTION
The test were not passing when also installing mrp_multi_level, the pickings weren't in the desired order. 
Also there was a problem when only 1 picking was in the system.

@BernatPForgeFlow @LoisRForgeFlow 