### PR TITLE
[14.0][FIX] mrp_subcontracting_purchase_link: link to PO line, not PO

### DIFF
--- a/mrp_subcontracting_purchase_link/__manifest__.py
+++ b/mrp_subcontracting_purchase_link/__manifest__.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
-    "name": "Link Purchase Order to Subcontract Productions",
+    "name": "Link Purchase Order Line to Subcontract Productions",
     "version": "14.0.1.0.1",
     "category": "Manufacturing",
     "license": "LGPL-3",

--- a/mrp_subcontracting_purchase_link/migrations/14.0.2.0.0/post-migration.py
+++ b/mrp_subcontracting_purchase_link/migrations/14.0.2.0.0/post-migration.py
@@ -1,0 +1,38 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def update_po_line_in_mrp_production(cr):
+    """ """
+    _logger.info("Updating PO line in MRP production")
+    cr.execute(
+        """
+        UPDATE mrp_production
+        SET
+        purchase_line_id = Q.purchase_line_id,
+        purchase_order_id = Q.purchase_id
+        FROM (
+            SELECT po_sm.purchase_line_id, mo_sm.production_id, po.id as purchase_id
+            FROM stock_move as po_sm
+            INNER JOIN stock_move_move_rel as rel
+            ON rel.move_dest_id = po_sm.id
+            INNER JOIN stock_move as mo_sm
+            ON mo_sm.id = rel.move_orig_id
+            INNER JOIN purchase_order_line as pol
+            ON pol.id = po_sm.purchase_line_id
+            INNER JOIN purchase_order as po
+            ON po.id = pol.order_id
+            where po_sm.is_subcontract = true
+            AND po_sm.purchase_line_id is not null
+            AND mo_sm.production_id is not null
+            ) AS Q
+        WHERE mrp_production.id = Q.production_id
+        """
+    )
+
+
+def migrate(cr, version=None):
+    if not version:
+        return
+    update_po_line_in_mrp_production(cr)

--- a/mrp_subcontracting_purchase_link/models/mrp_production.py
+++ b/mrp_subcontracting_purchase_link/models/mrp_production.py
@@ -8,5 +8,13 @@ class MrpProduction(models.Model):
     _inherit = "mrp.production"
 
     purchase_order_id = fields.Many2one(
-        "purchase.order", "Subcontract Purchase Order", readonly=True
+        "purchase.order",
+        "Subcontract Purchase Order",
+        readonly=True,
+        related="purchase_line_id.order_id",
+        store=True,
+    )
+
+    purchase_line_id = fields.Many2one(
+        "purchase.order.line", "Subcontract Purchase Order Line", readonly=True
     )

--- a/mrp_subcontracting_purchase_link/models/purchase_order.py
+++ b/mrp_subcontracting_purchase_link/models/purchase_order.py
@@ -7,14 +7,15 @@ from odoo import fields, models
 class PurchaseOrder(models.Model):
     _inherit = "purchase.order"
 
+    subcontract_production_count = fields.Integer(
+        compute="_compute_subcontract_production_count"
+    )
+
     subcontract_production_ids = fields.One2many(
         "mrp.production",
         "purchase_order_id",
         "Subcontract Production Orders",
         readonly=True,
-    )
-    subcontract_production_count = fields.Integer(
-        compute="_compute_subcontract_production_count"
     )
 
     def action_view_mrp(self):

--- a/mrp_subcontracting_purchase_link/models/stock_picking.py
+++ b/mrp_subcontracting_purchase_link/models/stock_picking.py
@@ -10,5 +10,5 @@ class StockPicking(models.Model):
     def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
         vals = super()._prepare_subcontract_mo_vals(subcontract_move, bom)
         if subcontract_move.purchase_line_id:
-            vals["purchase_order_id"] = subcontract_move.purchase_line_id.order_id.id
+            vals["purchase_line_id"] = subcontract_move.purchase_line_id.id
         return vals

--- a/mrp_subcontracting_purchase_link/readme/DESCRIPTION.rst
+++ b/mrp_subcontracting_purchase_link/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
 This module does the following:
 
-- Extends _prepare_subcontract_mo_vals() and adds the purchase order reference to the subcontracted manufacturing orders.
+- Extends _prepare_subcontract_mo_vals() and adds the purchase order line reference to the subcontracted manufacturing orders.
 - Adds an action button in the purchase order form view to open related subcontracted manufacturing orders.

--- a/mrp_subcontracting_purchase_link/tests/test_mrp_subcontracting_purchase_link.py
+++ b/mrp_subcontracting_purchase_link/tests/test_mrp_subcontracting_purchase_link.py
@@ -44,8 +44,8 @@ class TestMrpSubcontractingPurchaseLink(TestMrpSubcontractingCommon):
                 self.assertEqual(
                     picking._prepare_subcontract_mo_vals(
                         move, move._get_subcontract_bom()
-                    )["purchase_order_id"],
-                    purchase_order.id,
+                    )["purchase_line_id"],
+                    purchase_order.order_line.id,
                 )
 
     def test_02_compute_subcontract_production_count(self):
@@ -62,7 +62,8 @@ class TestMrpSubcontractingPurchaseLink(TestMrpSubcontractingCommon):
             action["views"], [(self.env.ref("mrp.mrp_production_form_view").id, "form")]
         )
         self.assertEqual(
-            action["res_id"], purchase_order1.subcontract_production_ids[0].id
+            action["res_id"],
+            purchase_order1.subcontract_production_ids[0].id,
         )
         action = purchase_order2.action_view_mrp()
         self.assertEqual(

--- a/mrp_subcontracting_purchase_link/views/mrp_production_views.xml
+++ b/mrp_subcontracting_purchase_link/views/mrp_production_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="purchase_order_id" groups="purchase.group_purchase_user" />
+                <field name="purchase_line_id" groups="purchase.group_purchase_user" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The mrps related with a subcontracting process, there are linked to the purchase line associated, not the purchase order



@ForgeFlow