### PR TITLE
[14.0][IMP] mrp_multi_level: Get BoM to explode 

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -201,11 +201,12 @@ class ProductMRPArea(models.Model):
                     break
                 rule = new_rule
             # Determine the supply method based on the final rule.
+            boms = rec.product_id.product_tmpl_id.bom_ids.filtered(
+                lambda x: x.type in ["normal", "phantom"]
+            )
             rec.supply_method = (
                 "phantom"
-                if rule.action == "manufacture"
-                and rec.product_id.product_tmpl_id.bom_ids
-                and rec.product_id.product_tmpl_id.bom_ids[0].type == "phantom"
+                if rule.action == "manufacture" and boms and boms[0].type == "phantom"
                 else rule.action
             )
 


### PR DESCRIPTION
When exploding requirements or calculating supply method, we will consider the first active BoM taking into account the routes.

If the last supply rule is 'Manufacture' and the first active BoM other than 'Subcontracting' is a 'Kit', the supply method for the  MRP Parameter will be 'Kit'. Otherwise, if the last supply rule is 'Manufacture' and there is no BoMs or the first active BoM other than 'Subcontracting' is 'Manufactured', the supply method for the  MRP Parameter will be 'Produce'.

In the image below we have an example of a product with multiple active BoMs. If the route is 'Manufacture', the 'Kit' BoM is the one that will be considered.
![image](https://user-images.githubusercontent.com/90243017/222114402-a05969fe-5310-48a2-a330-92c348e7b592.png)
