### PR TITLE
[14.0][IMP] mrp_subcontracting_purchase_link: add post init hook to populate the PO line on previous manufacturing orders

### DIFF
--- a/mrp_subcontracting_purchase_link/__init__.py
+++ b/mrp_subcontracting_purchase_link/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/mrp_subcontracting_purchase_link/__manifest__.py
+++ b/mrp_subcontracting_purchase_link/__manifest__.py
@@ -5,9 +5,10 @@
     "version": "14.0.2.0.0",
     "category": "Manufacturing",
     "license": "LGPL-3",
-    "author": "Quartile Limited, Odoo Community Association (OCA)",
+    "author": "Quartile Limited, ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/manufacture",
     "depends": ["purchase", "mrp_subcontracting"],
     "data": ["views/purchase_order_views.xml", "views/mrp_production_views.xml"],
+    "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/mrp_subcontracting_purchase_link/hooks.py
+++ b/mrp_subcontracting_purchase_link/hooks.py
@@ -1,5 +1,6 @@
 # Copyright 2023 ForgeFlow, S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
 import logging
 
 _logger = logging.getLogger(__name__)
@@ -34,7 +35,5 @@ def update_po_line_in_mrp_production(cr):
     )
 
 
-def migrate(cr, version=None):
-    if not version:
-        return
+def post_init_hook(cr, registry):
     update_po_line_in_mrp_production(cr)

--- a/mrp_subcontracting_purchase_link/readme/CONTRIBUTORS.rst
+++ b/mrp_subcontracting_purchase_link/readme/CONTRIBUTORS.rst
@@ -2,3 +2,8 @@
 
   * Yoshi Tashiro <tashiro@quartile.co>
   * Tim Lai <tl@quartile.com>
+
+* `ForgeFlow <https://www.forgeflow.com>`__:
+
+  * Thiago Mulero <thuago.mulero@forgeflow.com>
+  * Jordi Ballester <jordi.ballester@forgeflow.com>


### PR DESCRIPTION
Otherwise when you install the module the previous subcontracting MO's will not have the link with the purchase order
cc @ThiagoMForgeFlow 