### PR TITLE
[14.0][REF+IMP] mrp_attachment_mgmt: Cleanup + button in production orders

### DIFF
--- a/mrp_attachment_mgmt/__manifest__.py
+++ b/mrp_attachment_mgmt/__manifest__.py
@@ -11,6 +11,7 @@
     "installable": True,
     "data": [
         "views/mrp_bom_view.xml",
+        "views/mrp_production_views.xml",
         "views/product_views.xml",
         "views/workorder_attachments_views.xml",
     ],

--- a/mrp_attachment_mgmt/models/__init__.py
+++ b/mrp_attachment_mgmt/models/__init__.py
@@ -1,3 +1,4 @@
 from . import mrp_bom
+from . import mrp_production
 from . import mrp_workorder
 from . import product

--- a/mrp_attachment_mgmt/models/mrp_production.py
+++ b/mrp_attachment_mgmt/models/mrp_production.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    def action_show_attachments(self):
+        return self.product_id._action_show_attachments()

--- a/mrp_attachment_mgmt/models/mrp_workorder.py
+++ b/mrp_attachment_mgmt/models/mrp_workorder.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, models
 from odoo.exceptions import UserError
@@ -6,20 +7,6 @@ from odoo.exceptions import UserError
 
 class MrpWorkorder(models.Model):
     _inherit = "mrp.workorder"
-
-    def _action_see_workorder_attachments_products(self, products):
-        domain = [
-            "|",
-            "&",
-            ("res_model", "=", "product.product"),
-            ("res_id", "in", products.ids),
-            "&",
-            ("res_model", "=", "product.template"),
-            ("res_id", "in", products.mapped("product_tmpl_id").ids),
-        ]
-        action = self.env.ref("base.action_attachment").read()[0]
-        action.update({"domain": domain})
-        return action
 
     def action_see_workorder_attachments(self):
         error = []
@@ -33,6 +20,4 @@ class MrpWorkorder(models.Model):
             raise UserError(
                 _("%d Product(s) without drawing:\n%s") % (len(error), "\n".join(error))
             )
-        return self._action_see_workorder_attachments_products(
-            self.mapped("product_id")
-        )
+        return self.product_id._action_show_attachments()

--- a/mrp_attachment_mgmt/models/product.py
+++ b/mrp_attachment_mgmt/models/product.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields, models
 
@@ -7,13 +8,28 @@ class ProductTemplate(models.Model):
     _inherit = "product.template"
 
     def action_see_bom_documents(self):
-        first_bom = fields.first(self.bom_ids)
-        return first_bom._action_see_bom_documents(self)
+        return fields.first(self.bom_ids).action_see_bom_documents()
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def action_see_bom_documents(self):
-        first_bom = fields.first(self.bom_ids)
-        return first_bom._action_see_bom_documents(self.product_tmpl_id, self)
+        return fields.first(self.bom_ids).action_see_bom_documents()
+
+    def _action_show_attachments(self):
+        """Returns the action to show the attachments linked to the products
+        recordset or to their templates.
+        """
+        domain = [
+            "|",
+            "&",
+            ("res_model", "=", "product.product"),
+            ("res_id", "in", self.ids),
+            "&",
+            ("res_model", "=", "product.template"),
+            ("res_id", "in", self.product_tmpl_id.ids),
+        ]
+        action = self.env["ir.actions.actions"]._for_xml_id("base.action_attachment")
+        action.update({"domain": domain})
+        return action

--- a/mrp_attachment_mgmt/tests/test_mrp_attachment_mgmt.py
+++ b/mrp_attachment_mgmt/tests/test_mrp_attachment_mgmt.py
@@ -33,3 +33,8 @@ class TestMrpAttachmentMgmt(TestMrpAttachmentMgmtBase):
         attachment = self._create_attachment(self.product)
         action = self.workorder.action_see_workorder_attachments()
         self.assertIn(attachment.id, self.attachment_model.search(action["domain"]).ids)
+
+    def test_mrp_production_attachments(self):
+        attachment = self._create_attachment(self.product)
+        action = self.mrp_production.action_show_attachments()
+        self.assertIn(attachment.id, self.attachment_model.search(action["domain"]).ids)

--- a/mrp_attachment_mgmt/views/mrp_production_views.xml
+++ b/mrp_attachment_mgmt/views/mrp_production_views.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mrp_production_form_view" model="ir.ui.view">
+        <field name="name">mrp.production.form - Add attachments smart-button</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="///button[@name='action_see_move_scrap']" position="after">
+                <button
+                    class="oe_stat_button"
+                    name="action_show_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                    string="Attachments"
+                />
+            </xpath>
+        </field>
+    </record>
+    <record id="action_show_production_attachments" model="ir.actions.server">
+        <field name="name">Attachments</field>
+        <field name="model_id" ref="mrp.model_mrp_production" />
+        <field name="binding_model_id" ref="mrp.model_mrp_production" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.action_show_attachments()
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- [REF] mrp_attachment_mgmt: Avoid code duplication for attachment view
    
  - Put the method on product, and call it from all the places.
  - Remove excessive method fragmentation w/o gain.
  - Replace action read by proper `_for_xml_id` call.

- [IMP] Add smart-button to production orders

@Tecnativa