### PR TITLE
[14.0][FIX] mrp_component_operation_scrap_reason: incorrect key in manifest

### DIFF
--- a/mrp_component_operation_scrap_reason/__manifest__.py
+++ b/mrp_component_operation_scrap_reason/__manifest__.py
@@ -14,5 +14,5 @@
         "wizards/mrp_component_operate_wizard.xml",
     ],
     "installable": True,
-    "auto-install": True,
+    "auto_install": True,
 }


### PR DESCRIPTION
Module was not being autoinstalled.

@DavidJForgeFlow 