### PR TITLE
[16][mrp_sale_info] Allow new fields to be shown or hidden by user

### DIFF
--- a/mrp_sale_info/views/mrp_production.xml
+++ b/mrp_sale_info/views/mrp_production.xml
@@ -22,10 +22,10 @@
         <field name="inherit_id" ref="mrp.mrp_production_tree_view" />
         <field name="arch" type="xml">
             <field name="date_planned_start" position="after">
-                <field name="sale_id" />
-                <field name="partner_id" />
-                <field name="commitment_date" />
-                <field name="client_order_ref" />
+                <field name="sale_id" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="commitment_date" optional="hide" />
+                <field name="client_order_ref" optional="hide" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
In v16 manufacture order tree view, most of the fields are possible to hide. 
This module add 4 fields and they also should be possible to hide to not over-complicate the view.

@oihane @BenjaHe @thomaspaulb 