### PR TITLE
[14.0][IMP] mrp_component_operation: filter by picking type

### DIFF
--- a/mrp_component_operation/models/mrp_component_operation.py
+++ b/mrp_component_operation/models/mrp_component_operation.py
@@ -6,6 +6,7 @@ from odoo import fields, models
 class MrpComponentOperation(models.Model):
     _name = "mrp.component.operation"
     _description = "Component Operation"
+    _order = "sequence,id"
 
     name = fields.Char(help="Component Operation Reference", required=True)
 
@@ -57,4 +58,15 @@ class MrpComponentOperation(models.Model):
         ],
         default="no",
         required=True,
+    )
+
+    picking_type_id = fields.Many2one(
+        "stock.picking.type",
+        "Operation Type",
+        domain="[('code', '=', 'mrp_operation')]",
+    )
+
+    sequence = fields.Integer(
+        string="Sequence",
+        help="Gives the sequence order when displaying the list of component operations",
     )

--- a/mrp_component_operation/models/mrp_production.py
+++ b/mrp_component_operation/models/mrp_production.py
@@ -20,6 +20,7 @@ class MrpProduction(models.Model):
                 "default_mo_id": self.id,
                 "product_ids": self.move_raw_ids.move_line_ids.product_id.mapped("id"),
                 "lot_ids": self.move_raw_ids.move_line_ids.lot_id.mapped("id"),
+                "default_picking_type_id": self.picking_type_id.id,
             },
             "target": "new",
         }

--- a/mrp_component_operation/views/mrp_component_operation_views.xml
+++ b/mrp_component_operation/views/mrp_component_operation_views.xml
@@ -9,6 +9,9 @@
                     <h1>
                         <field name="name" string="Reference" />
                     </h1>
+                    <group name="picking_type" string="Operation Type">
+                        <field name="picking_type_id" />
+                    </group>
                     <group name="operations" string="Operations">
                         <field name="outgoing_operation" />
                         <field name="incoming_operation" />
@@ -39,8 +42,23 @@
                             attrs="{'invisible': [('outgoing_operation', '!=', 'scrap')], 'required': [('outgoing_operation', '=', 'scrap')]}"
                         />
                     </group>
+
                 </sheet>
             </form>
+        </field>
+    </record>
+
+    <record id="view_mrp_component_operation_tree" model="ir.ui.view">
+        <field name="name">view_mrp_component_operation_tree</field>
+        <field name="model">mrp.component.operation</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="sequence" widget="handle" />
+                <field name="name" string="Reference" />
+                <field name="picking_type_id" />
+                <field name="outgoing_operation" />
+                <field name="incoming_operation" />
+            </tree>
         </field>
     </record>
 

--- a/mrp_component_operation/wizards/mrp_component_operate.py
+++ b/mrp_component_operation/wizards/mrp_component_operate.py
@@ -23,7 +23,14 @@ class MrpComponentOperate(models.Model):
 
     mo_id = fields.Many2one("mrp.production", ondelete="cascade", required=True)
 
-    operation_id = fields.Many2one("mrp.component.operation", required=True)
+    operation_id = fields.Many2one(
+        "mrp.component.operation",
+        required=True,
+        domain="["
+        "'|',"
+        "('picking_type_id', '=', picking_type_id), "
+        "('picking_type_id', '=', False)]",
+    )
 
     incoming_operation = fields.Selection(
         related="operation_id.incoming_operation",
@@ -33,6 +40,11 @@ class MrpComponentOperate(models.Model):
     outgoing_operation = fields.Selection(
         related="operation_id.outgoing_operation",
         required=True,
+    )
+
+    picking_type_id = fields.Many2one(
+        "stock.picking.type",
+        "Operation Type",
     )
 
     @api.onchange("operation_id")

--- a/mrp_component_operation/wizards/mrp_component_operate_wizard.xml
+++ b/mrp_component_operation/wizards/mrp_component_operate_wizard.xml
@@ -23,6 +23,7 @@
                             attrs="{'readonly': ['|',('tracking', '=', 'serial'),('product_id', '=', False)]}"
                         />
                         <field name="operation_id" />
+                        <field name="picking_type_id" invisible="1" />
                         <field name="tracking" invisible="1" />
                     </group>
                     <group


### PR DESCRIPTION
When using the operate component feature, the operations can be settled for specific picking types.

@ForgeFlow