### PR TITLE
[12.0] FIX  mrp_subcontracting: action_done in case of multiple production orders linked to stock moves

### DIFF
--- a/mrp_subcontracting/models/stock_picking.py
+++ b/mrp_subcontracting/models/stock_picking.py
@@ -51,6 +51,9 @@ class StockPicking(models.Model):
         for picking in self:
             for move in picking.move_lines:
                 production = move.move_orig_ids.mapped('production_id')
+                if len(production) > 1:
+                    production = production.filtered(
+                        lambda p: p.state not in ('done', 'cancel'))[-1:]
                 if not move.is_subcontract or production.state in ('done', 'cancel'):
                     continue
                 if move._has_tracked_subcontract_components():


### PR DESCRIPTION
Adapting from https://github.com/odoo/odoo/blob/c71af144a8ef8faefb2cf6846c32a8432d633430/addons/mrp_subcontracting/models/stock_picking.py#L41C26-L41C117

Otherwise:

```
  File "mrp_subcontracting/models/stock_picking.py", line 54, in action_done
    if not move.is_subcontract or production.state in ('done', 'cancel'):
  File "odoo/odoo/fields.py", line 1062, in __get__
    record.ensure_one()
  File "odoo/odoo/models.py", line 4770, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: mrp.production(ID1, ID2)
```