### PR TITLE
[15.0][FIX] mrp_bom_attribute_match: cyclic references in bom

### DIFF
--- a/mrp_bom_attribute_match/tests/common.py
+++ b/mrp_bom_attribute_match/tests/common.py
@@ -143,7 +143,7 @@ class TestMrpBomAttributeMatchBase(TransactionCase):
             cls.p3,
             [
                 dict(
-                    product_id=cls.p1.product_variant_ids[0],
+                    product_id=cls.product_sword.product_variant_ids[1],
                     product_qty=1,
                 ),
             ],


### PR DESCRIPTION
Setup 'test common' is changed because have cyclic references in bom.
issue: https://github.com/OCA/manufacture/issues/1088