### PR TITLE
[15.0][FIX] Fix edge case date bug in addon `mrp_production_grouped_by_product`

### DIFF
--- a/mrp_production_grouped_by_product/models/mrp_production.py
+++ b/mrp_production_grouped_by_product/models/mrp_production.py
@@ -65,8 +65,9 @@ class MrpProduction(models.Model):
         if date.hour < pt.mo_grouping_max_hour:
             date_end = date.replace(hour=pt.mo_grouping_max_hour, minute=0, second=0)
         else:
-            date_end = date.replace(
-                day=date.day + 1, hour=pt.mo_grouping_max_hour, minute=0, second=0
+            date_end = date + relativedelta(days=1)
+            date_end = date_end.replace(
+                hour=pt.mo_grouping_max_hour, minute=0, second=0
             )
         date_start = date_end - relativedelta(days=pt.mo_grouping_interval)
         domain += [


### PR DESCRIPTION
Edge case: If `date` is on the last day of a month, `date.replace(day=date.day +1)` obviously fails.