### PR TITLE
[15.0][IMP] mrp_multi_level: access action

### DIFF
--- a/mrp_multi_level/models/product_product.py
+++ b/mrp_multi_level/models/product_product.py
@@ -50,8 +50,9 @@ class Product(models.Model):
 
     def action_view_mrp_area_parameters(self):
         self.ensure_one()
-        action = self.env.ref("mrp_multi_level.product_mrp_area_action")
-        result = action.read()[0]
+        result = self.env["ir.actions.actions"]._for_xml_id(
+            "mrp_multi_level.product_mrp_area_action"
+        )
         ctx = ast.literal_eval(result.get("context"))
         if not ctx:
             ctx = {}

--- a/mrp_multi_level/models/product_template.py
+++ b/mrp_multi_level/models/product_template.py
@@ -26,8 +26,9 @@ class ProductTemplate(models.Model):
 
     def action_view_mrp_area_parameters(self):
         self.ensure_one()
-        action = self.env.ref("mrp_multi_level.product_mrp_area_action")
-        result = action.read()[0]
+        result = self.env["ir.actions.actions"]._for_xml_id(
+            "mrp_multi_level.product_mrp_area_action"
+        )
         ctx = ast.literal_eval(result.get("context"))
         mrp_areas = self.env["mrp.area"].search([])
         if "context" not in result:


### PR DESCRIPTION
Steps to reproduce. User with access to stock and manufacture goes to a product and clicks on the MRP Areas smart button. Result:
![image](https://github.com/OCA/manufacture/assets/19620251/93537e59-0036-43b5-b19e-913800dadd6e)


cc @ForgeFlow