### PR TITLE
Draft:[14.0][FIX] #10130 mrp_sale_info

### DIFF
--- a/mrp_sale_info/__manifest__.py
+++ b/mrp_sale_info/__manifest__.py
@@ -13,8 +13,7 @@
     "application": False,
     "installable": True,
     "depends": [
-        "mrp",
-        "sale",
+        "sale_mrp",
         "sale_stock",
     ],
     "data": [

--- a/mrp_sale_info/models/stock_rule.py
+++ b/mrp_sale_info/models/stock_rule.py
@@ -41,6 +41,4 @@ class StockRule(models.Model):
                 moves = moves.move_dest_ids
                 line_ids |= moves.sale_line_id
             res["sale_line_ids"] = line_ids and [(4, x.id) for x in line_ids] or False
-            return res  # eg in case of orderpoint generating MO
-        line_ids = moves.sale_line_id
         return res

--- a/mrp_sale_info/models/stock_rule.py
+++ b/mrp_sale_info/models/stock_rule.py
@@ -41,4 +41,6 @@ class StockRule(models.Model):
                 moves = moves.move_dest_ids
                 line_ids |= moves.sale_line_id
             res["sale_line_ids"] = line_ids and [(4, x.id) for x in line_ids] or False
+            return res  # eg in case of orderpoint generating MO
+        line_ids = moves.sale_line_id
         return res


### PR DESCRIPTION
@gjotten @thomaspaulb this should at least fix the error about ```AttributeError: 'NoneType' object has no attribute 'sale_line_id'``` by checking if moves exist in the first place.