### PR TITLE
[16.0] Add module mrp_workorder_lot_display

### DIFF
--- a/mrp_workorder_lot_display/README.rst
+++ b/mrp_workorder_lot_display/README.rst
@@ -1,0 +1,1 @@
+To auto generate

--- a/mrp_workorder_lot_display/__manifest__.py
+++ b/mrp_workorder_lot_display/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "MRP Workorder Lot Display",
+    "summary": "Display lot number on workorders kanban",
+    "version": "16.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Manufacturing",
+    "website": "https://github.com/OCA/manufacture",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["grindtildeath"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "mrp",
+    ],
+    "data": [
+        "views/mrp_workorder.xml",
+    ],
+}

--- a/mrp_workorder_lot_display/readme/CONTRIBUTORS.md
+++ b/mrp_workorder_lot_display/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/mrp_workorder_lot_display/readme/DESCRIPTION.md
+++ b/mrp_workorder_lot_display/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+This module displays the lot number on workorders kanban view
+and adds a quick search option on the finished lot number.

--- a/mrp_workorder_lot_display/views/mrp_workorder.xml
+++ b/mrp_workorder_lot_display/views/mrp_workorder.xml
@@ -14,6 +14,17 @@
         </field>
     </record>
 
+    <record id="view_mrp_production_work_order_search" model="ir.ui.view">
+        <field name="name">mrp.production.work.order.search.inherit</field>
+        <field name="model">mrp.workorder</field>
+        <field name="inherit_id" ref="mrp.view_mrp_production_work_order_search" />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="finished_lot_id" />
+            </field>
+        </field>
+    </record>
+
     <record id="workcenter_line_kanban" model="ir.ui.view">
         <field name="name">mrp.production.work.order.kanban.inherit</field>
         <field name="model">mrp.workorder</field>

--- a/mrp_workorder_lot_display/views/mrp_workorder.xml
+++ b/mrp_workorder_lot_display/views/mrp_workorder.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_mrp_production_workorder_form_view_filter" model="ir.ui.view">
+        <field name="name">mrp.production.work.order.select.inherit</field>
+        <field name="model">mrp.workorder</field>
+        <field
+            name="inherit_id"
+            ref="mrp.view_mrp_production_workorder_form_view_filter"
+        />
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="finished_lot_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="workcenter_line_kanban" model="ir.ui.view">
+        <field name="name">mrp.production.work.order.kanban.inherit</field>
+        <field name="model">mrp.workorder</field>
+        <field name="inherit_id" ref="mrp.workcenter_line_kanban" />
+        <field name="arch" type="xml">
+            <field name="operation_id" position="after">
+                <field name="finished_lot_id" />
+            </field>
+            <xpath
+                expr="//h5[hasclass('oe_kanban_bottom_left')]//t[@t-out='record.product_id.value']"
+                position="after"
+            >
+                <t
+                    t-if="record.product_id.tracking != 'none' and record.finished_lot_id.value"
+                > / <t t-out="record.finished_lot_id.value" /></t>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/mrp_workorder_lot_display/odoo/addons/mrp_workorder_lot_display
+++ b/setup/mrp_workorder_lot_display/odoo/addons/mrp_workorder_lot_display
@@ -1,0 +1,1 @@
+../../../../mrp_workorder_lot_display

--- a/setup/mrp_workorder_lot_display/setup.py
+++ b/setup/mrp_workorder_lot_display/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module displays the lot number on workorders kanban view
and adds a quick search option on the finished lot number.