### PR TITLE
[13.0][FIX] mrp_multi_level: Correct main supplier when changing sequence in Vendor Pricelist

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -219,7 +219,7 @@ class ProductMRPArea(models.Model):
             suppliers = rec.product_id.seller_ids.filtered(
                 lambda r: (not r.product_id or r.product_id == rec.product_id)
                 and (not r.company_id or r.company_id == rec.company_id)
-            )
+            ).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
             if not suppliers:
                 rec.main_supplierinfo_id = False
                 rec.main_supplier_id = False


### PR DESCRIPTION


When we change the sequence order of the Vendor Pricelist for a product, we firstly fetch the vendors and then we change the sequence. Then, when changing a sequence we try to get the first supplier but we do not get the desired result. Reordering the suppliers allows to always get the first supplier in the list.