### PR TITLE
[16.0][REF] mrp_multi_level: location management

### DIFF
--- a/mrp_multi_level/models/mrp_area.py
+++ b/mrp_multi_level/models/mrp_area.py
@@ -39,6 +39,4 @@ class MrpArea(models.Model):
 
     def _get_locations(self):
         self.ensure_one()
-        return self.env["stock.location"].search(
-            [("id", "child_of", self.location_id.id)]
-        )
+        return self.location_id

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -27,7 +27,7 @@ class MultiLevelMrp(models.TransientModel):
     def _prepare_product_mrp_area_data(self, product_mrp_area):
         qty_available = 0.0
         product_obj = self.env["product.product"]
-        location_ids = product_mrp_area.mrp_area_id._get_locations()
+        location_ids = product_mrp_area._get_locations()
         for location in location_ids:
             product_l = product_obj.with_context(location=location.id).browse(
                 product_mrp_area.product_id.id
@@ -462,9 +462,9 @@ class MultiLevelMrp(models.TransientModel):
 
     @api.model
     def _init_mrp_move_from_purchase_order(self, product_mrp_area):
-        location_ids = product_mrp_area.mrp_area_id._get_locations()
+        location_ids = product_mrp_area._get_locations()
         picking_types = self.env["stock.picking.type"].search(
-            [("default_location_dest_id", "in", location_ids.ids)]
+            [("default_location_dest_id", "child_of", location_ids.ids)]
         )
         picking_type_ids = [ptype.id for ptype in picking_types]
         orders = self.env["purchase.order"].search(
@@ -781,7 +781,7 @@ class MultiLevelMrp(models.TransientModel):
         ).mapped("due_date")
         mrp_dates = set(moves_dates + action_dates)
         on_hand_qty = product_mrp_area.product_id.with_context(
-            location=product_mrp_area.mrp_area_id.location_id.id
+            location=product_mrp_area._get_locations().ids,
         )._compute_quantities_dict(False, False, False)[product_mrp_area.product_id.id][
             "qty_available"
         ]


### PR DESCRIPTION
Small refactoring adding a _get_locations method on product.mrp.area which by defaults delegates the computation to the related mrp.area.

This enables extending a few things related to locations at the product.mrp.area level.

Change the way `_get_locations()` work: don't return the list of child locations, only the top-most locations, and then use the `child_of` operator in the code that looks for locations.

Forward port of #1150
