### PR TITLE
[13.0][REF] mrp_multi_level: location management

### DIFF
--- a/mrp_multi_level/models/mrp_area.py
+++ b/mrp_multi_level/models/mrp_area.py
@@ -38,6 +38,4 @@ class MrpArea(models.Model):
 
     def _get_locations(self):
         self.ensure_one()
-        return self.env["stock.location"].search(
-            [("id", "child_of", self.location_id.id)]
-        )
+        return self.location_id

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -172,16 +172,16 @@ class ProductMRPArea(models.Model):
     def _compute_qty_available(self):
         for rec in self:
             rec.qty_available = rec.product_id.with_context(
-                {"location": rec.mrp_area_id.location_id.id}
+                location=rec._get_locations().ids
             ).qty_available
 
     def _compute_supply_method(self):
         group_obj = self.env["procurement.group"]
         for rec in self:
-            proc_loc = rec.location_proc_id or rec.mrp_area_id.location_id
+            proc_loc = rec.location_proc_id or rec.location_id
             values = {
                 "warehouse_id": rec.mrp_area_id.warehouse_id,
-                "company_id": rec.mrp_area_id.company_id,
+                "company_id": rec.company_id,
             }
             rule = group_obj._get_rule(rec.product_id, proc_loc, values)
             if not rule:
@@ -255,24 +255,26 @@ class ProductMRPArea(models.Model):
 
     def _in_stock_moves_domain(self):
         self.ensure_one()
-        locations = self.mrp_area_id._get_locations()
+        locations = self._get_locations()
         return [
             ("product_id", "=", self.product_id.id),
             ("state", "not in", ["done", "cancel"]),
             ("product_qty", ">", 0.00),
-            ("location_id", "not in", locations.ids),
-            ("location_dest_id", "in", locations.ids),
+            "!",
+            ("location_id", "child_of", locations.ids),
+            ("location_dest_id", "child_of", locations.ids),
         ]
 
     def _out_stock_moves_domain(self):
         self.ensure_one()
-        locations = self.mrp_area_id._get_locations()
+        locations = self._get_locations()
         return [
             ("product_id", "=", self.product_id.id),
             ("state", "not in", ["done", "cancel"]),
             ("product_qty", ">", 0.00),
-            ("location_id", "in", locations.ids),
-            ("location_dest_id", "not in", locations.ids),
+            ("location_id", "child_of", locations.ids),
+            "!",
+            ("location_dest_id", "child_of", locations.ids),
         ]
 
     def action_view_stock_moves(self, domain):
@@ -291,3 +293,7 @@ class ProductMRPArea(models.Model):
     def _to_be_exploded(self):
         self.ensure_one()
         return self.supply_method in ["manufacture", "phantom"]
+
+    def _get_locations(self):
+        self.ensure_one()
+        return self.mrp_area_id._get_locations()

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -27,7 +27,7 @@ class MultiLevelMrp(models.TransientModel):
     def _prepare_product_mrp_area_data(self, product_mrp_area):
         qty_available = 0.0
         product_obj = self.env["product.product"]
-        location_ids = product_mrp_area.mrp_area_id._get_locations()
+        location_ids = product_mrp_area._get_locations()
         for location in location_ids:
             product_l = product_obj.with_context({"location": location.id}).browse(
                 product_mrp_area.product_id.id
@@ -462,9 +462,9 @@ class MultiLevelMrp(models.TransientModel):
 
     @api.model
     def _init_mrp_move_from_purchase_order(self, product_mrp_area):
-        location_ids = product_mrp_area.mrp_area_id._get_locations()
+        location_ids = product_mrp_area._get_locations()
         picking_types = self.env["stock.picking.type"].search(
-            [("default_location_dest_id", "in", location_ids.ids)]
+            [("default_location_dest_id", "child_of", location_ids.ids)]
         )
         picking_type_ids = [ptype.id for ptype in picking_types]
         orders = self.env["purchase.order"].search(
@@ -780,7 +780,7 @@ class MultiLevelMrp(models.TransientModel):
         ).mapped("due_date")
         mrp_dates = set(moves_dates + action_dates)
         on_hand_qty = product_mrp_area.product_id.with_context(
-            location=product_mrp_area.mrp_area_id.location_id.id
+            location=product_mrp_area._get_locations().ids
         )._product_available()[product_mrp_area.product_id.id]["qty_available"]
         running_availability = on_hand_qty
         mrp_inventory_vals = []


### PR DESCRIPTION
Small refactoring adding a _get_locations method on product.mrp.area which by defaults delegates the computation to the related mrp.area.

This enables extending a few things related to locations at the product.mrp.area level.

Change the way `_get_locations()` work: don't return the list of child locations, only the top-most locations, and then use the `child_of` operator in the code that looks for locations.

Backport of #1150 