### PR TITLE
[16.0][IMP] mrp_multi_level_estimate: Stock moves from MO should always be considered

### DIFF
--- a/mrp_multi_level_estimate/wizards/mrp_multi_level.py
+++ b/mrp_multi_level_estimate/wizards/mrp_multi_level.py
@@ -122,8 +122,11 @@ class MultiLevelMrp(models.TransientModel):
         )
         if direction == "out":
             mrp_date = res.get("mrp_date")
-            if self._exclude_considering_estimate_demand_and_other_sources_strat(
-                product_mrp_area, mrp_date
+            if (
+                self._exclude_considering_estimate_demand_and_other_sources_strat(
+                    product_mrp_area, mrp_date
+                )
+                and not res["production_id"]
             ):
                 return False
         return res


### PR DESCRIPTION
When we consider forecasts as the 'Indirect' demand, we should always keep considering the demand coming from Manufacturing Orders, as they are 'Direct' demand.

Forward port of #1042
