### PR TITLE
[13.0][FIX] mrp_multi_level: Use actual time in procurements

### DIFF
--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -1,6 +1,8 @@
 # Copyright 2018-19 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+from datetime import datetime
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 
@@ -129,10 +131,10 @@ class MrpInventoryProcureItem(models.TransientModel):
     )
 
     def _prepare_procurement_values(self, group=False):
+        current_time = fields.Datetime.now().time()
+        date_planned = datetime.combine(self.date_planned, current_time)
         return {
-            "date_planned": fields.Datetime.to_string(
-                fields.Date.from_string(self.date_planned)
-            ),
+            "date_planned": fields.Datetime.to_string(date_planned),
             "warehouse_id": self.warehouse_id,
             "group_id": group,
             "planned_order_id": self.planned_order_id.id,


### PR DESCRIPTION
If we do not use actual time, then we can face problems in other modules that consider that as the default modus operandi.

For example, if we already have a purchase order for a specific day and then we procure again for that day from the MRP, when we change the price of the products it won't update the pricelist since there is already another order. https://github.com/OCA/purchase-workflow/blob/13.0/purchase_order_supplierinfo_update/models/purchase_order.py#L40