### PR TITLE
[14.0] [FIX] mrp_bom_attribute_match: display proper BoM structure

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_bom.py
+++ b/mrp_bom_attribute_match/models/mrp_bom.py
@@ -160,6 +160,18 @@ class MrpBomLine(models.Model):
         if self.bom_product_template_attribute_value_ids:
             self._check_variants_validity()
 
+    def _skip_bom_line(self, product):
+        # Make this method compatible to work with NewIds
+        res = super()._skip_bom_line(product)
+
+        return res and (
+            len(
+                set(product.product_template_attribute_value_ids.ids)
+                & set(self.bom_product_template_attribute_value_ids.ids)
+            )
+            != len(self.bom_product_template_attribute_value_ids.attribute_id)
+        )
+
 
 class MrpBom(models.Model):
     _inherit = "mrp.bom"

--- a/mrp_bom_attribute_match/reports/mrp_report_bom_structure.py
+++ b/mrp_bom_attribute_match/reports/mrp_report_bom_structure.py
@@ -32,9 +32,6 @@ class ReportBomStructure(models.AbstractModel):
             if to_ignore_line_ids:
                 for to_ignore_line_id in to_ignore_line_ids:
                     bom.bom_line_ids = [(3, to_ignore_line_id, 0)]
-            product = bom._get_component_template_product(
-                line, product, line.product_id
-            )
         components, total = super()._get_bom_lines(
             bom, bom_quantity, product, line_id, level
         )


### PR DESCRIPTION
Before this fix the BoM structure was wrong, for example:

A BoM setup like this:
![immagine](https://github.com/OCA/manufacture/assets/42804718/1956664b-4705-41f1-a463-be2618e28a12)

Would have always been showing this structure:
![immagine](https://github.com/OCA/manufacture/assets/42804718/813223f1-e20f-434e-8b0f-e444d954008b)

While instead should be showing the proper structure of the BoM:
![immagine](https://github.com/OCA/manufacture/assets/42804718/20bb3eeb-b36c-492c-8137-a73fd6b887e1)

Only when the right combination of product variant is chosen.