### PR TITLE
[15.0][FIX] mrp_multi_level: starting qty on hand wrong when using lots

### DIFF
--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -26,6 +26,8 @@ class TestMrpMultiLevelCommon(TransactionCase):
         cls.mrp_inventory_obj = cls.env["mrp.inventory"]
         cls.mrp_move_obj = cls.env["mrp.move"]
         cls.planned_order_obj = cls.env["mrp.planned.order"]
+        cls.lot_model = cls.env["stock.production.lot"]
+        cls.quant_model = cls.env["stock.quant"]
 
         cls.fp_1 = cls.env.ref("mrp_multi_level.product_product_fp_1")
         cls.fp_2 = cls.env.ref("mrp_multi_level.product_product_fp_2")
@@ -221,6 +223,53 @@ class TestMrpMultiLevelCommon(TransactionCase):
         cls.product_mrp_area_obj.create(
             {"product_id": cls.prod_uom_test.id, "mrp_area_id": cls.mrp_area.id}
         )
+        # Product to test lots
+        cls.product_lots = cls.product_obj.create(
+            {
+                "name": "Product Tracked by Lots",
+                "type": "product",
+                "tracking": "lot",
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "list_price": 100.0,
+                "produce_delay": 5.0,
+                "route_ids": [(6, 0, [route_buy])],
+                "seller_ids": [(0, 0, {"name": vendor1.id, "price": 25.0})],
+            }
+        )
+        cls.product_mrp_area_obj.create(
+            {"product_id": cls.product_lots.id, "mrp_area_id": cls.mrp_area.id}
+        )
+        cls.lot_1 = cls.lot_model.create(
+            {
+                "product_id": cls.product_lots.id,
+                "name": "Lot 1",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.lot_2 = cls.lot_model.create(
+            {
+                "product_id": cls.product_lots.id,
+                "name": "Lot 2",
+                "company_id": cls.company.id,
+            }
+        )
+        cls.quant_model.sudo().create(
+            {
+                "product_id": cls.product_lots.id,
+                "lot_id": cls.lot_1.id,
+                "quantity": 100.0,
+                "location_id": cls.stock_location.id,
+            }
+        )
+        cls.quant_model.sudo().create(
+            {
+                "product_id": cls.product_lots.id,
+                "lot_id": cls.lot_2.id,
+                "quantity": 110.0,
+                "location_id": cls.stock_location.id,
+            }
+        )
+
         # Product MRP Parameter to test supply method computation
         cls.env.ref("stock.route_warehouse0_mto").active = True
         cls.env["stock.rule"].create(
@@ -446,6 +495,9 @@ class TestMrpMultiLevelCommon(TransactionCase):
         cls.create_demand_sec_loc(cls.date_10, 70.0)
         cls.create_demand_sec_loc(cls.date_20, 46.0)
         cls.create_demand_sec_loc(cls.date_22, 33.0)
+
+        # Create pickings:
+        cls._create_picking_out(cls.product_lots, 25, today)
 
         cls.mrp_multi_level_wiz.create({}).run_mrp_multi_level()
 

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -524,3 +524,12 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
                     f"unexpected value for {key}: {inv[key]} "
                     f"(expected {test_vals[key]} on {inv.date}",
                 )
+
+    def test_19_on_hand_with_lots(self):
+        """Check that on-hand is correctly computed when tracking by lots."""
+        lots_line_1 = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.product_lots.id)]
+        )
+        self.assertEqual(len(lots_line_1), 1)
+        self.assertEqual(lots_line_1.initial_on_hand_qty, 210)
+        self.assertEqual(lots_line_1.final_on_hand_qty, 185)

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -24,23 +24,6 @@ class MultiLevelMrp(models.TransientModel):
     )
 
     @api.model
-    def _prepare_product_mrp_area_data(self, product_mrp_area):
-        qty_available = 0.0
-        product_obj = self.env["product.product"]
-        location_ids = product_mrp_area._get_locations()
-        for location in location_ids:
-            product_l = product_obj.with_context(location=location.id).browse(
-                product_mrp_area.product_id.id
-            )
-            qty_available += product_l.qty_available
-
-        return {
-            "product_mrp_area_id": product_mrp_area.id,
-            "mrp_qty_available": qty_available,
-            "mrp_llc": product_mrp_area.product_id.llc,
-        }
-
-    @api.model
     def _prepare_mrp_move_data_from_stock_move(
         self, product_mrp_area, move, direction="in"
     ):
@@ -863,11 +846,7 @@ class MultiLevelMrp(models.TransientModel):
             [("product_mrp_area_id", "=", product_mrp_area.id)], order="due_date"
         ).mapped("due_date")
         mrp_dates = set(moves_dates + action_dates)
-        on_hand_qty = product_mrp_area.product_id.with_context(
-            location=product_mrp_area._get_locations().ids,
-        )._compute_quantities_dict(False, False, False)[product_mrp_area.product_id.id][
-            "qty_available"
-        ]
+        on_hand_qty = product_mrp_area.qty_available
         running_availability = on_hand_qty
         mrp_inventory_vals = []
         for mdt in sorted(mrp_dates):


### PR DESCRIPTION
Unify the way to get the starting on hand whenever needed in MRP calculations.