### PR TITLE
[16.0][IMP] mrp_multi_level: add date to default grouping filters

### DIFF
--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -143,6 +143,11 @@
                         context="{'group_by':'main_supplier_id'}"
                     />
                     <filter
+                        name="group_date"
+                        string="Date"
+                        context="{'group_by':'date'}"
+                    />
+                    <filter
                         name="group_release_date"
                         string="Date to Procure"
                         context="{'group_by':'order_release_date'}"


### PR DESCRIPTION
It is the default colum for pivot view.

Fwport of #1187 