### PR TITLE
[FIX] mrp_multi_level: UnboundLocalError

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -680,9 +680,7 @@ class MultiLevelMrp(models.TransientModel):
                 onhand += move.mrp_qty
         if onhand < product_mrp_area.mrp_minimum_stock:
             mrp_date = self._get_safety_stock_target_date(product_mrp_area)
-            qtytoorder = self._get_qty_to_order(
-                product_mrp_area, move.mrp_date, 0, onhand
-            )
+            qtytoorder = self._get_qty_to_order(product_mrp_area, mrp_date, 0, onhand)
             name = _("Safety Stock")
             cm = self.create_action(
                 product_mrp_area_id=product_mrp_area,


### PR DESCRIPTION
Fix a copy-paste error in the call to _get_qty_to_order which was not using the correct mrp_date. Using the mrp_date of the move outside the loop would generate an UnboundLocalError exception if the there was no mrp_move_ids in the mrp.area.