### PR TITLE
[14.0][FIX] mrp_sale_info: move_dest_ids can be None

### DIFF
--- a/mrp_sale_info/models/stock_rule.py
+++ b/mrp_sale_info/models/stock_rule.py
@@ -35,9 +35,10 @@ class StockRule(models.Model):
             values.get("group_id").id if values.get("group_id", False) else False
         )
         moves = values.get("move_dest_ids")
-        line_ids = moves.sale_line_id
-        while moves.move_dest_ids:
-            moves = moves.move_dest_ids
-            line_ids |= moves.sale_line_id
-        res["sale_line_ids"] = line_ids and [(4, x.id) for x in line_ids] or False
+        if moves:
+            line_ids = moves.sale_line_id
+            while moves.move_dest_ids:
+                moves = moves.move_dest_ids
+                line_ids |= moves.sale_line_id
+            res["sale_line_ids"] = line_ids and [(4, x.id) for x in line_ids] or False
         return res


### PR DESCRIPTION
Very simple fix for an error that could sometimes be triggered if `values.get("move_dest_ids")` returns `None` or `False`