### PR TITLE
[14.0][FIX] quality_control_stock_oca create trigger with a complete name

### DIFF
--- a/quality_control_stock_oca/models/stock_picking_type.py
+++ b/quality_control_stock_oca/models/stock_picking_type.py
@@ -11,7 +11,7 @@ class StockPickingType(models.Model):
     def _create_qc_trigger(self):
         for picking_type in self:
             qc_trigger = {
-                "name": picking_type.name,
+                "name": picking_type.display_name,
                 "company_id": picking_type.warehouse_id.company_id.id,
                 "picking_type_id": picking_type.id,
                 "partner_selectable": True,

--- a/quality_control_stock_oca/tests/test_quality_control_stock.py
+++ b/quality_control_stock_oca/tests/test_quality_control_stock.py
@@ -313,14 +313,14 @@ class TestQualityControl(TransactionCase):
         self.assertEqual(len(trigger), 1, "One trigger must have been created.")
         self.assertEqual(
             trigger.name,
-            picking_type.name,
-            "Trigger name must match picking type name.",
+            picking_type.display_name,
+            "Trigger name must match picking type display name.",
         )
         picking_type.write({"name": "Test Name Change"})
         self.assertEqual(
             trigger.name,
-            picking_type.name,
-            "Trigger name must match picking type name.",
+            picking_type.display_name,
+            "Trigger name must match picking type display name.",
         )
 
     def test_qc_inspection_picking(self):


### PR DESCRIPTION
With the current code and in case of multi-warehouse, it creates many trigger with the same name.

With this PR, triggers are created with the complete name of the picking type.