### PR TITLE
[16.0][FIX] mrp_packaging_default: Propagate packaging in stock move

### DIFF
--- a/mrp_packaging_default/models/stock_move.py
+++ b/mrp_packaging_default/models/stock_move.py
@@ -16,6 +16,9 @@ class StockMove(models.Model):
         except KeyError:
             # No BoM line, nothing to do
             return
+        # If bom_line_id is False in vals
+        if not bom_line:
+            return
         vals.update(
             {
                 "product_packaging_id": bom_line.product_packaging_id.id,


### PR DESCRIPTION
Before fix,If you confirm a sales order with multi-step delivery, there will be movements where packaging is not assigned. It is because in those moves in the creation dictionary the key bom_line_id is set to False.

@yajo please review.

MT-5356 @moduon