### PR TITLE
[14.0] [FIX] mrp_bom_attribute_match: modify permission error

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_bom.py
+++ b/mrp_bom_attribute_match/models/mrp_bom.py
@@ -260,7 +260,7 @@ class MrpBom(models.Model):
             )
             if component_template_product:
                 # need to set product_id temporary
-                current_line.product_id = component_template_product
+                current_line.sudo().product_id = component_template_product
             else:
                 # component_template_id is set, but no attribute value match.
                 continue


### PR DESCRIPTION
Trying to access a product list with a user that is not **Manufacturing/Administrator** would raise an `AccessError`