### PR TITLE
[14.0] [FIX] mrp_bom_attribute_match_semifinished_product: access error

### DIFF
--- a/mrp_bom_attribute_match_semifinished_product/models/product_template.py
+++ b/mrp_bom_attribute_match_semifinished_product/models/product_template.py
@@ -8,6 +8,7 @@ class ProductTemplate(models.Model):
     semi_finished_product_tmpl_ids = fields.One2many(
         comodel_name="semi.finished.product.template.line",
         inverse_name="product_tmpl_id",
+        groups="mrp.group_mrp_user",
     )
     semi_finished_mrp_bom_ids = fields.Many2many(
         comodel_name="mrp.bom", string="MRP BoM"


### PR DESCRIPTION
Trying to access a single product without being at least a **Manufacturing/User** would raise an `AccessError`