### PR TITLE
[13.0][IMP] mrp_multi_level: Consider fixed planned orders

### DIFF
--- a/mrp_multi_level/models/mrp_move.py
+++ b/mrp_multi_level/models/mrp_move.py
@@ -39,6 +39,9 @@ class MrpMove(models.Model):
     current_date = fields.Date(string="Current Date")
     current_qty = fields.Float(string="Current Qty")
     mrp_date = fields.Date(string="MRP Date")
+    planned_order_id = fields.Many2one(
+        comodel_name="mrp.planned.order", string="Planned Order", index=True
+    )
     planned_order_up_ids = fields.Many2many(
         comodel_name="mrp.planned.order",
         relation="mrp_move_planned_order_rel",
@@ -54,12 +57,13 @@ class MrpMove(models.Model):
             ("mv", "Move"),
             ("fc", "Forecast"),
             ("mrp", "MRP"),
+            ("plan", "Planned Order"),
         ],
         string="Origin",
     )
     mrp_qty = fields.Float(string="MRP Quantity")
     mrp_type = fields.Selection(
-        selection=[("s", "Supply"), ("d", "Demand")], string="Type"
+        selection=[("s", "Supply"), ("d", "Demand"), ("p", "Plan")], string="Type"
     )
     name = fields.Char(string="Description")
     origin = fields.Char(string="Source Document")


### PR DESCRIPTION
Example case:
- On hand = 12
- Safety Stock = 10
- Demand = 5
- Fixed planned order = 3

**Before**: It would recommend to procure 6 units. 3 from the fixed planned order and 3 more from the calculation of qty_to_procure.
![image](https://github.com/OCA/manufacture/assets/90243017/bd62494e-2cca-48db-a301-8afb33a58915)

**After**: It would recommend to procure 3 units. Since we have a fixed planned order, we consider it.
![image](https://github.com/OCA/manufacture/assets/90243017/9b7661e3-0706-4be4-a0c0-cc374e02879d)
