### PR TITLE
[16.0] [FIX] quality_control_oca add colspan attribute

### DIFF
--- a/quality_control_oca/views/product_template_view.xml
+++ b/quality_control_oca/views/product_template_view.xml
@@ -14,7 +14,7 @@
             <page name="inventory" position="inside">
                 <t groups="quality_control_oca.group_quality_control_user">
                     <group name="qc" string="Quality control">
-                        <field name="qc_triggers" nolabel="1">
+                        <field name="qc_triggers" nolabel="1" colspan="2">
                             <tree editable="bottom">
                                 <field
                                     name="trigger"

--- a/quality_control_oca/views/qc_test_view.xml
+++ b/quality_control_oca/views/qc_test_view.xml
@@ -93,6 +93,7 @@
                     <field
                         name="ql_values"
                         nolabel="1"
+                        colspan="2"
                         attrs="{'required': [('type','=','qualitative')]}"
                     >
                         <tree editable="bottom">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

product_template_form_view and qc_inspection_form_view are not rendered correctly:

![Quality_error1](https://github.com/OCA/manufacture/assets/44226087/cd56113f-f592-42d2-a941-9f802de5aa16)
![Quality_error2](https://github.com/OCA/manufacture/assets/44226087/f1a81bd9-d212-4e10-b839-ef6d86f833e1)



Desired behavior after PR is merged:

product_template_form_view and qc_inspection_form_view are rendered correctly:

![Quality_ok1](https://github.com/OCA/manufacture/assets/44226087/d2862519-1799-46a7-a0a6-be692febd37c)
![Quality_ok2](https://github.com/OCA/manufacture/assets/44226087/00e6cbb4-04b9-4899-a3d9-a2a7e8d31718)

