### PR TITLE
[FIX] quality_control_stock_oca security: enable stock user to validate a picking with done check

### DIFF
--- a/quality_control_stock_oca/__manifest__.py
+++ b/quality_control_stock_oca/__manifest__.py
@@ -13,6 +13,7 @@
     "website": "https://github.com/OCA/manufacture",
     "depends": ["quality_control_oca", "stock"],
     "data": [
+        "security/ir.model.access.csv",
         "views/qc_inspection_view.xml",
         "views/stock_picking_view.xml",
         "views/stock_production_lot_view.xml",

--- a/quality_control_stock_oca/security/ir.model.access.csv
+++ b/quality_control_stock_oca/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_user_qc_inspection,qc_inspection stock_user,quality_control_oca.model_qc_inspection,stock.group_stock_user,1,0,0,0
+access_stock_user_qc_inspection_line,qc_inspection_line stock_user,quality_control_oca.model_qc_inspection_line,stock.group_stock_user,1,0,0,0
+access_stock_user_qc_test,qc_test stock_user,quality_control_oca.model_qc_test,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
How to replicate:

1. create a stock picking with a quality control
2. a quality user executes the check
3. a stock user validates the stock picking -> an error is shown without this PR

With this PR the user can validate the picking, or he receives a warning to request the quality control execution by a quality user/manager.