### PR TITLE
[16.0][IMP] mrp_restrict_lot : fills Lot/Serial Number to produce with the …

### DIFF
--- a/mrp_restrict_lot/models/__init__.py
+++ b/mrp_restrict_lot/models/__init__.py
@@ -1,1 +1,2 @@
+from . import mrp_production
 from . import stock_rule

--- a/mrp_restrict_lot/models/mrp_production.py
+++ b/mrp_restrict_lot/models/mrp_production.py
@@ -1,0 +1,20 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    lot_producing_id = fields.Many2one(
+        compute="_compute_lot_producing_id", store=True, readonly=False
+    )
+
+    @api.depends("move_finished_ids.restrict_lot_id")
+    def _compute_lot_producing_id(self):
+        for order in self:
+            finish_move_lot = order.move_finished_ids.filtered(
+                lambda m: m.product_id == order.product_id
+            ).restrict_lot_id
+            if finish_move_lot:
+                order.lot_producing_id = finish_move_lot


### PR DESCRIPTION
…restricted one from finished move

This PR is linked to OCA/stock-logistics-workflow#1560 and OCA/sale-workflow#3057 

If lot/serial number restriction changes on the main product stock move of a manufacturing order, the Lot/Serial Number of the manufacturing order is updated accordingly.