### PR TITLE
[FIX] account_move_line_mrp_info: add migration script

### DIFF
--- a/account_move_line_mrp_info/migrations/14.0.1.0.0/pre-migration.py
+++ b/account_move_line_mrp_info/migrations/14.0.1.0.0/pre-migration.py
@@ -1,0 +1,28 @@
+# Copyright 2024 ForgeFlow, S.L.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(
+        env,
+        [
+            (
+                "account.move.line",
+                "account_move_line",
+                "manufacture_order_id",
+                "mrp_production_id",
+            ),
+            (
+                "account.move.line",
+                "account_move_line",
+                "unbuild_order_id",
+                "unbuild_id",
+            ),
+        ],
+    )


### PR DESCRIPTION
Migration from https://github.com/OCA/manufacture/tree/13.0/account_move_line_manufacture_info.

Please, use `merge nobump`.