### PR TITLE
[16.0][IMP] quality_control_oca, quality_control_stock_oca

### DIFF
--- a/quality_control_mrp_oca/models/mrp_production.py
+++ b/quality_control_mrp_oca/models/mrp_production.py
@@ -47,7 +47,7 @@ class MrpProduction(models.Model):
             ]:
                 trigger_lines = trigger_lines.union(
                     self.env[model].get_trigger_line_for_product(
-                        qc_trigger, move.product_id
+                        qc_trigger, ["after"], move.product_id
                     )
                 )
             for trigger_line in _filter_trigger_lines(trigger_lines):

--- a/quality_control_oca/models/qc_trigger_line.py
+++ b/quality_control_oca/models/qc_trigger_line.py
@@ -38,8 +38,24 @@ class QcTriggerLine(models.AbstractModel):
         " created.",
         domain="[('parent_id', '=', False)]",
     )
+    timing = fields.Selection(
+        selection=[
+            ("before", "Before"),
+            ("after", "After"),
+            ("plan_ahead", "Plan Ahead"),
+        ],
+        default="after",
+        help="* Before: An executable inspection is generated before the record "
+        "related to the trigger is completed (e.g. when picking is confirmed).\n"
+        "* After: An executable inspection is generated when the record related to the "
+        "trigger is completed (e.g. when picking is done).\n"
+        "* Plan Ahead: A non-executable inspection is generated before the record "
+        "related to the trigger is completed (e.g. when picking is confirmed), and the "
+        "inspection becomes executable when the record related to the trigger is "
+        "completed (e.g. when picking is done).",
+    )
 
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
+    def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         """Overridable method for getting trigger_line associated to a product.
         Each inherited model will complete this module to make the search by
         product, template or category.

--- a/quality_control_oca/models/qc_trigger_product_category_line.py
+++ b/quality_control_oca/models/qc_trigger_product_category_line.py
@@ -15,14 +15,15 @@ class QcTriggerProductCategoryLine(models.Model):
 
     product_category = fields.Many2one(comodel_name="product.category")
 
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
+    def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
+            trigger, timings, product, partner=partner
         )
         category = product.categ_id
         while category:
             for trigger_line in category.qc_triggers.filtered(
                 lambda r: r.trigger == trigger
+                and r.timing in timings
                 and (
                     not r.partners
                     or not partner

--- a/quality_control_oca/models/qc_trigger_product_line.py
+++ b/quality_control_oca/models/qc_trigger_product_line.py
@@ -15,12 +15,13 @@ class QcTriggerProductLine(models.Model):
 
     product = fields.Many2one(comodel_name="product.product")
 
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
+    def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
+            trigger, timings, product, partner=partner
         )
         for trigger_line in product.qc_triggers.filtered(
             lambda r: r.trigger == trigger
+            and r.timing in timings
             and (
                 not r.partners
                 or not partner

--- a/quality_control_oca/models/qc_trigger_product_template_line.py
+++ b/quality_control_oca/models/qc_trigger_product_template_line.py
@@ -15,12 +15,13 @@ class QcTriggerProductTemplateLine(models.Model):
 
     product_template = fields.Many2one(comodel_name="product.template")
 
-    def get_trigger_line_for_product(self, trigger, product, partner=False):
+    def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         trigger_lines = super().get_trigger_line_for_product(
-            trigger, product, partner=partner
+            trigger, timings, product, partner=partner
         )
         for trigger_line in product.product_tmpl_id.qc_triggers.filtered(
             lambda r: r.trigger == trigger
+            and r.timing in timings
             and (
                 not r.partners
                 or not partner

--- a/quality_control_oca/tests/test_quality_control.py
+++ b/quality_control_oca/tests/test_quality_control.py
@@ -67,6 +67,10 @@ class TestQualityControlOca(TestQualityControlOcaBase):
         self.assertEqual(self.inspection1.state, "success")
         self.inspection1.action_approve()
         self.assertEqual(self.inspection1.state, "success")
+        self.assertTrue(bool(self.inspection1.date_done))
+        self.inspection1.action_cancel()
+        self.inspection1.action_draft()
+        self.assertFalse(self.inspection1.date_done)
 
     def test_inspection_incorrect(self):
         for line in self.inspection1.inspection_lines:
@@ -86,6 +90,7 @@ class TestQualityControlOca(TestQualityControlOcaBase):
         self.assertEqual(self.inspection1.state, "waiting")
         self.inspection1.action_approve()
         self.assertEqual(self.inspection1.state, "failed")
+        self.assertTrue(bool(self.inspection1.date_done))
 
     def test_actions_errors(self):
         inspection2 = self.inspection1.copy()
@@ -166,7 +171,7 @@ class TestQualityControlOca(TestQualityControlOcaBase):
         ]:
             trigger_lines = trigger_lines.union(
                 self.env[model].get_trigger_line_for_product(
-                    self.qc_trigger, self.product
+                    self.qc_trigger, ["after"], self.product
                 )
             )
         self.assertEqual(len(trigger_lines), 3)

--- a/quality_control_oca/views/product_template_view.xml
+++ b/quality_control_oca/views/product_template_view.xml
@@ -23,6 +23,7 @@
                                 <field name="test" />
                                 <field name="user" />
                                 <field name="partners" widget="many2many_tags" />
+                                <field name="timing" />
                             </tree>
                         </field>
                     </group>

--- a/quality_control_oca/views/qc_inspection_view.xml
+++ b/quality_control_oca/views/qc_inspection_view.xml
@@ -79,6 +79,7 @@
                         </group>
                         <group>
                             <field name="date" />
+                            <field name="date_done" />
                             <field name="success" />
                             <field name="auto_generated" />
                         </group>
@@ -142,8 +143,18 @@
                 <field name="test" />
                 <field name="qty" />
                 <field name="product_id" />
+                <field name="date" optional="show" />
+                <field name="date_done" optional="show" />
                 <field name="success" />
-                <field name="state" />
+                <field
+                    name="state"
+                    widget="badge"
+                    decoration-info="state == 'ready'"
+                    decoration-warning="state == 'waiting'"
+                    decoration-success="state == 'success'"
+                    decoration-danger="state == 'failed'"
+                    decoration-muted="state == 'canceled'"
+                />
             </tree>
         </field>
     </record>
@@ -171,6 +182,9 @@
                     domain="[('success', '=', False)]"
                 />
                 <newline />
+                <separator />
+                <filter name="plan_date" string="Plan Date" date="date" />
+                <filter name="date_done" string="Completion Date" date="date_done" />
                 <group expand="0" string="Group by...">
                     <filter
                         string="Reference"
@@ -213,6 +227,18 @@
                         name="group_by_auto_generated"
                         domain="[]"
                         context="{'group_by': 'auto_generated'}"
+                    />
+                    <filter
+                        string="Plan Date"
+                        name="groupby_date"
+                        domain="[]"
+                        context="{'group_by': 'date'}"
+                    />
+                    <filter
+                        string="Completion Date"
+                        name="groupby_date_done"
+                        domain="[]"
+                        context="{'group_by': 'date_done'}"
                     />
                 </group>
             </search>

--- a/quality_control_stock_oca/README.rst
+++ b/quality_control_stock_oca/README.rst
@@ -37,6 +37,20 @@ It also adds some shortcuts on picking and lots to these inspections.
 .. contents::
    :local:
 
+Configuration
+=============
+
+Configure a QC trigger in the product, product template, or product category to define the conditions for creating inspections:
+
+* Trigger: Choose the trigger to activate the inspection process.
+* Test: Define a group of questions with valid values for the inspection.
+* Responsible: Assign a user responsible for the QC inspection.
+* Partner: Optionally specify partners to limit the test to actions involving them.
+* Timing: Determine when inspections are generated:
+    * Before: On picking confirmation.
+    * After: On picking completion.
+    * Plan Ahead: On picking confirmation, generating a non-editable plan inspection that becomes executable post-picking completion.
+
 Known issues / Roadmap
 ======================
 
@@ -75,6 +89,11 @@ Contributors
 
   * Pedro M. Baeza
   * Carlos Roca
+
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
+  * Yoshi Tashiro
 
 Maintainers
 ~~~~~~~~~~~

--- a/quality_control_stock_oca/models/__init__.py
+++ b/quality_control_stock_oca/models/__init__.py
@@ -2,6 +2,7 @@
 
 from . import qc_trigger
 from . import qc_inspection
+from . import stock_move
 from . import stock_picking_type
 from . import stock_picking
 from . import stock_production_lot

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -72,6 +72,11 @@ class QcInspection(models.Model):
         # Fill qty when coming from pack operations
         if object_ref and object_ref._name == "stock.move":
             res["qty"] = object_ref.product_uom_qty
+            if object_ref.picking_id.immediate_transfer and trigger_line.timing in [
+                "before",
+                "plan_ahead",
+            ]:
+                res["qty"] = object_ref.quantity_done
         return res
 
 

--- a/quality_control_stock_oca/models/stock_move.py
+++ b/quality_control_stock_oca/models/stock_move.py
@@ -1,0 +1,68 @@
+# Copyright 2014 Serv. Tec. Avanzados - Pedro M. Baeza
+# Copyright 2018 Simone Rubino - Agile Business Group
+# Copyright 2019 Andrii Skrypka
+# Copyright 2024 Quartile
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from functools import lru_cache
+
+from odoo import models
+
+from odoo.addons.quality_control_oca.models.qc_trigger_line import _filter_trigger_lines
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def write(self, vals):
+        if "date" in vals:
+            existing_inspections = self.env["qc.inspection"]._get_existing_inspections(
+                self
+            )
+            existing_inspections.write({"date": vals.get("date")})
+        return super().write(vals)
+
+    def _get_partner_for_trigger_line(self):
+        return self.picking_id.partner_id
+
+    def trigger_inspection(self, timings, partner=False):
+        @lru_cache()
+        def get_qc_trigger(picking_type):
+            return (
+                self.env["qc.trigger"]
+                .sudo()
+                .search([("picking_type_id", "=", picking_type.id)])
+            )
+
+        self.ensure_one()
+        inspection_model = self.env["qc.inspection"].sudo()
+        qc_trigger = get_qc_trigger(self.picking_type_id)
+        if qc_trigger.partner_selectable:
+            partner = partner or self._get_partner_for_trigger_line()
+        else:
+            partner = False
+        trigger_lines = set()
+        for model in [
+            "qc.trigger.product_category_line",
+            "qc.trigger.product_template_line",
+            "qc.trigger.product_line",
+        ]:
+            trigger_lines = trigger_lines.union(
+                self.env[model]
+                .sudo()
+                .get_trigger_line_for_product(
+                    qc_trigger, timings, self.product_id.sudo(), partner=partner
+                )
+            )
+        for trigger_line in _filter_trigger_lines(trigger_lines):
+            date = False
+            if trigger_line.timing in ["before", "plan_ahead"]:
+                # To pass scheduled date to the generated inspection
+                date = self.date
+            inspection_model._make_inspection(self, trigger_line, date=date)
+
+    def _action_confirm(self, merge=True, merge_into=False):
+        moves = super()._action_confirm(merge=merge, merge_into=merge_into)
+        for move in moves:
+            move.trigger_inspection(["before", "plan_ahead"])
+        return moves

--- a/quality_control_stock_oca/readme/CONFIGURE.rst
+++ b/quality_control_stock_oca/readme/CONFIGURE.rst
@@ -1,0 +1,10 @@
+Configure a QC trigger in the product, product template, or product category to define the conditions for creating inspections:
+
+* Trigger: Choose the trigger to activate the inspection process.
+* Test: Define a group of questions with valid values for the inspection.
+* Responsible: Assign a user responsible for the QC inspection.
+* Partner: Optionally specify partners to limit the test to actions involving them.
+* Timing: Determine when inspections are generated:
+    * Before: On picking confirmation.
+    * After: On picking completion.
+    * Plan Ahead: On picking confirmation, generating a non-editable plan inspection that becomes executable post-picking completion.

--- a/quality_control_stock_oca/readme/CONTRIBUTORS.rst
+++ b/quality_control_stock_oca/readme/CONTRIBUTORS.rst
@@ -7,3 +7,8 @@
 
   * Pedro M. Baeza
   * Carlos Roca
+
+* `Quartile <https://www.quartile.co>`_:
+
+  * Aung Ko Ko Lin
+  * Yoshi Tashiro

--- a/quality_control_stock_oca/static/description/index.html
+++ b/quality_control_stock_oca/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -375,24 +374,45 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>Configure a QC trigger in the product, product template, or product category to define the conditions for creating inspections:</p>
+<ul class="simple">
+<li>Trigger: Choose the trigger to activate the inspection process.</li>
+<li>Test: Define a group of questions with valid values for the inspection.</li>
+<li>Responsible: Assign a user responsible for the QC inspection.</li>
+<li>Partner: Optionally specify partners to limit the test to actions involving them.</li>
+<li><dl class="first docutils">
+<dt>Timing: Determine when inspections are generated:</dt>
+<dd><ul class="first last">
+<li>Before: On picking confirmation.</li>
+<li>After: On picking completion.</li>
+<li>Plan Ahead: On picking confirmation, generating a non-editable plan inspection that becomes executable post-picking completion.</li>
+</ul>
+</dd>
+</dl>
+</li>
+</ul>
+</div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Put trigger in all languages.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/manufacture/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -400,9 +420,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>OdooMRP team</li>
 <li>AvanzOSC</li>
@@ -411,7 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Oihane Crucelaegui &lt;<a class="reference external" href="mailto:oihanecrucelaegi&#64;avanzosc.es">oihanecrucelaegi&#64;avanzosc.es</a>&gt;</li>
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;agilebg.com">simone.rubino&#64;agilebg.com</a>&gt;</li>
@@ -423,10 +443,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Carlos Roca</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+<li>Yoshi Tashiro</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Before this commit, the QC inspection was only triggered when the picking was already done. So, users could check the QC inspection only after the done state.

With this commit, the QC inspection can be triggered with three options ("Before", "Plan Ahead", and "After"). This allows the QC inspection to be triggered both when the picking is in progress and when it is done, enabling users to check the quality at any stage.

This PR does following:
- Add date_done field in `qc.inspection`
  - Update date_done when status is success or fail
  - Clear date_done when status is reset to draft
- Update form and list views to show date, and date_done
- Add date and date_done fields in the search filter
- Add the timing field in the QC trigger line to enable
  - When timing is 'After', an inspection is generated when a picking with the trigger is done.
  - When timing is 'Before', an inspection is generated for each related
    move when a picking with the trigger is confirmed.
  - When timing is 'Plan Ahead', a 'Plan' inspection is generated for
    each related move when a picking with the trigger is confirmed. A
    plan inspection is just a plan, and cannot be updated except for the
    date. A plan inspection gets converted into an executable inspection
    once the picking is done.

@qrtl QT4613