### PR TITLE
[14.0][IMP] mrp_subcontracting_bom_dual_use: Full compatibility of workorder_ids in subcontracting

### DIFF
--- a/mrp_subcontracting_bom_dual_use/models/__init__.py
+++ b/mrp_subcontracting_bom_dual_use/models/__init__.py
@@ -2,3 +2,4 @@
 
 from . import mrp_bom
 from . import mrp_production
+from . import stock_picking

--- a/mrp_subcontracting_bom_dual_use/models/mrp_production.py
+++ b/mrp_subcontracting_bom_dual_use/models/mrp_production.py
@@ -1,7 +1,7 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MrpProduction(models.Model):
@@ -25,3 +25,23 @@ class MrpProduction(models.Model):
             '&', ('type', '=', 'subcontract'), ('allow_in_regular_production', '=', True)
         ]""",
     )
+
+    @api.model
+    def create(self, values):
+        """We must correctly set the workorder_ids field in subcontratactions.
+        We allow to set workorders in mrp.bom if allow_in_regular_production is checked
+        and it must be compatible.
+        We do not want to use the _prepare_subcontract_mo_vals() method of stock.picking
+        and set the workorder_ids there because mrp already has all the logic by UX in
+        the _create_workorder() method, that is why it is done this way only for
+        subcontractactions.
+        """
+        production = super().create(values)
+        if self.env.context.get("force_subcontract_create_workorder"):
+            warehouse = production.picking_type_id.warehouse_id
+            if (
+                production.picking_type_id == warehouse.subcontracting_type_id
+                and production.bom_id.allow_in_regular_production
+            ):
+                production._onchange_workorder_ids()
+        return production

--- a/mrp_subcontracting_bom_dual_use/models/stock_picking.py
+++ b/mrp_subcontracting_bom_dual_use/models/stock_picking.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    def _subcontracted_produce(self, subcontract_details):
+        """Add a context for the subcontracts created by this method."""
+        self = self.with_context(force_subcontract_create_workorder=True)
+        super()._subcontracted_produce(subcontract_details)


### PR DESCRIPTION
Full compatibility of `workorder_ids` in subcontracting

@Tecnativa TT49962