### PR TITLE
[15.0][IMP] account_move_line_mrp_info: filter journal item list by MO/UO

### DIFF
--- a/account_move_line_mrp_info/views/account_move_line_view.xml
+++ b/account_move_line_mrp_info/views/account_move_line_view.xml
@@ -12,4 +12,16 @@
         </field>
     </record>
 
+    <record id="view_account_move_line_filter" model="ir.ui.view">
+        <field name="name">account.move.line.search</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_account_move_line_filter" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="mrp_production_id" />
+                <field name="unbuild_id" />
+            </field>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
This is useful for reporting purposes and it also helps to fix issues in the manufacturing variances account.

cc @ForgeFlow

Example:

![image](https://github.com/user-attachments/assets/997d04bc-96dd-4f54-b80a-0af607637f62)
