### PR TITLE
[14.0][IMP-FIX] mrp_subcontracting_partner_management: Define the correct picking_type (out) in the subcontracting_resupply rule

### DIFF
--- a/mrp_subcontracting_partner_management/models/res_partner.py
+++ b/mrp_subcontracting_partner_management/models/res_partner.py
@@ -222,7 +222,11 @@ class ResPartner(models.Model):
         prop = self.env["ir.property"]._get(
             "property_stock_production", "product.template"
         )
-        picking_type = self.env.ref("stock.picking_type_out", raise_if_not_found=False)
+        company = self.company_id or self.env.company
+        warehouse = self.env["stock.warehouse"].search(
+            [("company_id", "=", company.id)], limit=1
+        )
+        picking_type = warehouse.out_type_id
         route = self.env.ref(
             "mrp_subcontracting.route_resupply_subcontractor_mto",
             raise_if_not_found=False,

--- a/mrp_subcontracting_partner_management/models/res_partner.py
+++ b/mrp_subcontracting_partner_management/models/res_partner.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    is_subcontractor_partner = fields.Boolean(string="Subcontractor")
+    is_subcontractor_partner = fields.Boolean(string="Is subcontractor")
     subcontracted_created_location_id = fields.Many2one(
         comodel_name="stock.location", copy=False
     )

--- a/mrp_subcontracting_partner_management/tests/test_create_subcontractor_partner_location.py
+++ b/mrp_subcontracting_partner_management/tests/test_create_subcontractor_partner_location.py
@@ -1,4 +1,5 @@
 from odoo.tests import common, tagged
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -6,149 +7,95 @@ class TestSubcontractedPartner(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.partner_id = cls.env.ref("base.res_partner_12")
         cls.partner_obj = cls.env["res.partner"]
+        cls.partner = cls.partner_obj.create({"name": "Test partner"})
 
     def test_is_subcontractor_partner_first_time(self):
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.update({"is_subcontractor_partner": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location, "Location is not created")
         self.assertTrue(location.active, "Location must be active")
-
-        partner_picking_type = self.partner_id.partner_picking_type_id
+        partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type, "Picking type is not created")
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule, "Partner Buy rule is not created")
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(partner_resupply_rule, "Partner Resupply rule is not created")
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
     def test_is_subcontractor_partner_switch_off(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": False,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.update({"is_subcontractor_partner": False})
+        location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
-        partner_picking_type = self.partner_id.partner_picking_type_id
+        partner_picking_type = self.partner.partner_picking_type_id
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
         )
 
     def test_is_subcontractor_partner_switch_on(self):
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.update({"is_subcontractor_partner": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
-        partner_picking_type = self.partner_id.partner_picking_type_id
+        partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
     def test_is_subcontractor_partner_aсtive_switch_off(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.update(
-            {
-                "active": False,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.update({"active": False})
+        location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
-        partner_picking_type = self.partner_id.partner_picking_type_id
+        partner_picking_type = self.partner.partner_picking_type_id
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
         )
 
     def test_is_subcontractor_partner_aсtive_switch_on(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.write(
-            {
-                "active": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.write({"active": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
-        partner_picking_type = self.partner_id.partner_picking_type_id
+        partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
+    @mute_logger("odoo.models.unlink")
     def test_is_subcontractor_partner_delete(self):
-        partner_id = self.partner_obj.create(
+        partner = self.partner_obj.create(
             {
                 "name": "Test partner",
                 "is_company": True,
                 "is_subcontractor_partner": True,
             }
         )
-
-        location = partner_id.subcontracted_created_location_id
-        partner_picking_type = partner_id.partner_picking_type_id
-        partner_buy_rule = partner_id.partner_buy_rule_id
-        partner_resupply_rule = partner_id.partner_resupply_rule_id
-
-        partner_id.unlink()
-
+        location = partner.subcontracted_created_location_id
+        partner_picking_type = partner.partner_picking_type_id
+        partner_buy_rule = partner.partner_buy_rule_id
+        partner_resupply_rule = partner.partner_resupply_rule_id
+        partner.unlink()
         self.assertFalse(location.active, "Location must be not active")
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
@@ -157,7 +104,7 @@ class TestSubcontractedPartner(common.SavepointCase):
         )
 
     def test_check_countof_rules(self):
-        partner_id = self.partner_obj.create(
+        partner = self.partner_obj.create(
             {
                 "name": "Test partner",
                 "is_company": True,
@@ -165,7 +112,7 @@ class TestSubcontractedPartner(common.SavepointCase):
             }
         )
         rules = self.env["stock.rule"].search(
-            [("name", "=", partner_id.partner_buy_rule_id.name)]
+            [("name", "=", partner.partner_buy_rule_id.name)]
         )
         self.assertTrue(len(rules) == 2, "There are must be 2 subcontractor rules")
 
@@ -184,7 +131,6 @@ class TestSubcontractedPartner(common.SavepointCase):
             expected_text,
             msg="Location name must be equal to {}".format(expected_text),
         )
-
         fields = [
             "subcontracted_created_location_id",
             "partner_buy_rule_id",
@@ -200,7 +146,6 @@ class TestSubcontractedPartner(common.SavepointCase):
                 expected_text,
                 msg="Record name must be equal to {}".format(expected_text),
             )
-
         picking = partner.partner_picking_type_id
         expected_text = "%s:  IN" % expected_text
         self.assertEqual(
@@ -213,15 +158,15 @@ class TestSubcontractedPartner(common.SavepointCase):
         )
 
     def test_action_subcontractor_location_stock(self):
-        self.partner_id.update({"is_subcontractor_partner": True})
-        action = self.partner_id.action_subcontractor_location_stock()
+        self.partner.update({"is_subcontractor_partner": True})
+        action = self.partner.action_subcontractor_location_stock()
         self.assertEqual(
             action.get("domain"),
             [
                 (
                     "location_id",
                     "child_of",
-                    self.partner_id.property_stock_subcontractor.ids,
+                    self.partner.property_stock_subcontractor.ids,
                 )
             ],
             msg="Domains must be the same",

--- a/mrp_subcontracting_partner_management/views/res_partner_views.xml
+++ b/mrp_subcontracting_partner_management/views/res_partner_views.xml
@@ -9,6 +9,7 @@
             <field name="property_supplier_payment_term_id" position="before">
                 <field
                     name="is_subcontractor_partner"
+                    string="Subcontractor"
                     attrs="{'invisible': [('is_company', '=', False)]}"
                 />
             </field>

--- a/mrp_subcontracting_purchase_partner_management/tests/test_create_subcontractor_partner_location.py
+++ b/mrp_subcontracting_purchase_partner_management/tests/test_create_subcontractor_partner_location.py
@@ -16,128 +16,78 @@ class TestSubcontractedPartnerPatch(TestSubcontractedPartner):
         )
 
     def test_is_subcontractor_partner_first_time(self):
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.update({"is_subcontractor_partner": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location, "Location is not created")
         self.assertTrue(location.active, "Location must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule, "Partner Buy rule is not created")
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(partner_resupply_rule, "Partner Resupply rule is not created")
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
     def test_is_subcontractor_partner_switch_off(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": False,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.update({"is_subcontractor_partner": False})
+        location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
         )
 
     def test_is_subcontractor_partner_switch_on(self):
-        self.partner_id.update(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.update({"is_subcontractor_partner": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
     def test_is_subcontractor_partner_active_switch_off(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.update(
-            {
-                "active": False,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.update({"active": False})
+        location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
         )
 
     def test_is_subcontractor_partner_aсtive_switch_on(self):
-        self.partner_id.write(
-            {
-                "is_subcontractor_partner": True,
-            }
-        )
-        self.partner_id.write(
-            {
-                "active": True,
-            }
-        )
-
-        location = self.partner_id.subcontracted_created_location_id
+        self.partner.write({"is_subcontractor_partner": True})
+        self.partner.write({"active": True})
+        location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
-        partner_buy_rule = self.partner_id.partner_buy_rule_id
+        partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
-        partner_resupply_rule = self.partner_id.partner_resupply_rule_id
+        partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
     def test_is_subcontractor_partner_delete(self):
-        partner_id = self.partner_obj.create(
+        partner = self.partner_obj.create(
             {
                 "name": "Test partner",
                 "is_company": True,
                 "is_subcontractor_partner": True,
             }
         )
-
-        location = partner_id.subcontracted_created_location_id
-        partner_buy_rule = partner_id.partner_buy_rule_id
-        partner_resupply_rule = partner_id.partner_resupply_rule_id
-
-        partner_id.unlink()
-
+        location = partner.subcontracted_created_location_id
+        partner_buy_rule = partner.partner_buy_rule_id
+        partner_resupply_rule = partner.partner_resupply_rule_id
+        partner.unlink()
         self.assertFalse(location.active, "Location must be not active")
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
         self.assertFalse(


### PR DESCRIPTION
Changes done:
- [x] Change the string of the `is_subcontractor_partner` field
- [x] Define the correct picking_type (out) in the subcontracting_resupply rule

Before this change the picking_type_id used to create the subcontracting_resupply rule was "fixed”, which is incorrect if you do not use the main company or multi-company.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT49962