### PR TITLE
[16.0][IMP-FIX] mrp_subcontracting_partner_management: Define the correct picking_type (out) in the subcontracting_resupply rule

### DIFF
--- a/mrp_subcontracting_partner_management/models/res_partner.py
+++ b/mrp_subcontracting_partner_management/models/res_partner.py
@@ -207,7 +207,11 @@ class ResPartner(models.Model):
         prop = self.env["ir.property"]._get(
             "property_stock_production", "product.template"
         )
-        picking_type = self.env.ref("stock.picking_type_out", raise_if_not_found=False)
+        company = self.company_id or self.env.company
+        warehouse = self.env["stock.warehouse"].search(
+            [("company_id", "=", company.id)], limit=1
+        )
+        picking_type = warehouse.out_type_id
         route = self.env.ref(
             "mrp_subcontracting.route_resupply_subcontractor_mto",
             raise_if_not_found=False,

--- a/mrp_subcontracting_partner_management/models/res_partner.py
+++ b/mrp_subcontracting_partner_management/models/res_partner.py
@@ -6,7 +6,7 @@ from odoo import api, fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    is_subcontractor_partner = fields.Boolean(string="Subcontractor")
+    is_subcontractor_partner = fields.Boolean(string="Subcontractor partner")
     subcontracted_created_location_id = fields.Many2one(
         comodel_name="stock.location", copy=False
     )

--- a/mrp_subcontracting_partner_management/tests/test_create_subcontractor_partner_location.py
+++ b/mrp_subcontracting_partner_management/tests/test_create_subcontractor_partner_location.py
@@ -1,4 +1,5 @@
 from odoo.tests import tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -16,15 +17,12 @@ class TestSubcontractedPartner(BaseCommon):
         location = self.partner.subcontracted_created_location_id
         self.assertTrue(location, "Location is not created")
         self.assertTrue(location.active, "Location must be active")
-
         partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type, "Picking type is not created")
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
         partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule, "Partner Buy rule is not created")
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
         partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(partner_resupply_rule, "Partner Resupply rule is not created")
         self.assertTrue(
@@ -34,16 +32,12 @@ class TestSubcontractedPartner(BaseCommon):
     def test_is_subcontractor_partner_switch_off(self):
         self.partner.write({"is_subcontractor_partner": True})
         self.partner.update({"is_subcontractor_partner": False})
-
         location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
         partner_picking_type = self.partner.partner_picking_type_id
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
-
         partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
         partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
@@ -51,16 +45,12 @@ class TestSubcontractedPartner(BaseCommon):
 
     def test_is_subcontractor_partner_switch_on(self):
         self.partner.update({"is_subcontractor_partner": True})
-
         location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
         partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
         partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
         partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
@@ -69,16 +59,12 @@ class TestSubcontractedPartner(BaseCommon):
     def test_is_subcontractor_partner_active_switch_off(self):
         self.partner.write({"is_subcontractor_partner": True})
         self.partner.update({"active": False})
-
         location = self.partner.subcontracted_created_location_id
         self.assertFalse(location.active, "Location must be not active")
-
         partner_picking_type = self.partner.partner_picking_type_id
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
-
         partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
-
         partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertFalse(
             partner_resupply_rule.active, "Partner Resupply rule must be not active"
@@ -87,21 +73,18 @@ class TestSubcontractedPartner(BaseCommon):
     def test_is_subcontractor_partner_aсtive_switch_on(self):
         self.partner.write({"is_subcontractor_partner": True})
         self.partner.write({"active": True})
-
         location = self.partner.subcontracted_created_location_id
         self.assertTrue(location.active, "Location must be active")
-
         partner_picking_type = self.partner.partner_picking_type_id
         self.assertTrue(partner_picking_type.active, "Picking type must be active")
-
         partner_buy_rule = self.partner.partner_buy_rule_id
         self.assertTrue(partner_buy_rule.active, "Partner Buy rule must be active")
-
         partner_resupply_rule = self.partner.partner_resupply_rule_id
         self.assertTrue(
             partner_resupply_rule.active, "Partner Resupply rule must be active"
         )
 
+    @mute_logger("odoo.models.unlink")
     def test_is_subcontractor_partner_delete(self):
         partner = self.partner_obj.create(
             {
@@ -110,14 +93,11 @@ class TestSubcontractedPartner(BaseCommon):
                 "is_subcontractor_partner": True,
             }
         )
-
         location = partner.subcontracted_created_location_id
         partner_picking_type = partner.partner_picking_type_id
         partner_buy_rule = partner.partner_buy_rule_id
         partner_resupply_rule = partner.partner_resupply_rule_id
-
         partner.unlink()
-
         self.assertFalse(location.active, "Location must be not active")
         self.assertFalse(partner_picking_type.active, "Picking type must be not active")
         self.assertFalse(partner_buy_rule.active, "Partner Buy rule must be not active")
@@ -153,7 +133,6 @@ class TestSubcontractedPartner(BaseCommon):
             expected_text,
             msg="Location name must be equal to {}".format(expected_text),
         )
-
         fields = [
             "subcontracted_created_location_id",
             "partner_buy_rule_id",
@@ -169,7 +148,6 @@ class TestSubcontractedPartner(BaseCommon):
                 expected_text,
                 msg="Record name must be equal to {}".format(expected_text),
             )
-
         picking = partner.partner_picking_type_id
         expected_text = "%s:  IN" % expected_text
         self.assertEqual(

--- a/mrp_subcontracting_partner_management/views/res_partner_views.xml
+++ b/mrp_subcontracting_partner_management/views/res_partner_views.xml
@@ -9,6 +9,7 @@
             <field name="property_supplier_payment_term_id" position="before">
                 <field
                     name="is_subcontractor_partner"
+                    string="Subcontractor"
                     attrs="{'invisible': [('is_company', '=', False)]}"
                 />
             </field>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/manufacture/pull/1342

Changes done:
- [x] Change the string of the `is_subcontractor_partner` field
- [x] Define the correct picking_type (out) in the subcontracting_resupply rule

Before this change the picking_type_id used to create the subcontracting_resupply rule was "fixed”, which is incorrect if you do not use the main company or multi-company.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT49962