### PR TITLE
[16.0][FIX] quality_control_mrp_oca: mrp.production Inspections smart button error

### DIFF
--- a/quality_control_mrp_oca/views/mrp_production_view.xml
+++ b/quality_control_mrp_oca/views/mrp_production_view.xml
@@ -9,7 +9,7 @@
         <field name="domain">[('production_id', '=', active_id)]</field>
         <field
             name="context"
-        >{'default_object_id': 'mrp.production,' + str(active_id)}</field>
+        >{'default_object_id': 'mrp.production,' + active_id}</field>
     </record>
     <record model="ir.ui.view" id="mrp_production_qc_view">
         <field name="name">mrp.production.form.qc</field>


### PR DESCRIPTION
When clicking Inspections smart button in a MO we get an error says EvaluationError: Name 'str' is not defined

![Ekran görüntüsü_2024-09-12_15-10-10](https://github.com/user-attachments/assets/9ff1682b-0f89-4b30-ae87-51189fc9d8ae)
