### PR TITLE
[16.0][FIX] mrp_multi_level: fix kit/phantom planning

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -89,8 +89,11 @@ class MrpInventory(models.Model):
     @api.depends("planned_order_ids", "planned_order_ids.qty_released")
     def _compute_to_procure(self):
         for rec in self:
-            rec.to_procure = sum(rec.planned_order_ids.mapped("mrp_qty")) - sum(
-                rec.planned_order_ids.mapped("qty_released")
+            rec.to_procure = (
+                0.0
+                if rec.supply_method == "phantom"
+                else sum(rec.planned_order_ids.mapped("mrp_qty"))
+                - sum(rec.planned_order_ids.mapped("qty_released"))
             )
 
     @api.depends(

--- a/mrp_multi_level/models/mrp_planned_order.py
+++ b/mrp_multi_level/models/mrp_planned_order.py
@@ -59,6 +59,7 @@ class MrpPlannedOrder(models.Model):
     mrp_action = fields.Selection(
         selection=[
             ("manufacture", "Manufacturing Order"),
+            ("phantom", "Kit"),
             ("buy", "Purchase Order"),
             ("pull", "Pull From"),
             ("push", "Push To"),

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -307,7 +307,3 @@ class ProductMRPArea(models.Model):
     def _get_locations(self):
         self.ensure_one()
         return self.mrp_area_id._get_locations()
-
-    def _should_create_planned_order(self):
-        self.ensure_one()
-        return not self.supply_method == "phantom"

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -6,7 +6,10 @@
         <field name="name">mrp.planned.order.tree</field>
         <field name="model">mrp.planned.order</field>
         <field name="arch" type="xml">
-            <tree decoration-info="fixed != True">
+            <tree
+                decoration-info="fixed != True and mrp_action != 'phantom'"
+                decoration-muted="mrp_action == 'phantom'"
+            >
                 <field name="name" />
                 <field name="origin" />
                 <field name="product_mrp_area_id" />
@@ -17,6 +20,7 @@
                 <field name="qty_released" />
                 <field name="mrp_qty" />
                 <field name="fixed" />
+                <field name="mrp_action" optional="hide" />
             </tree>
         </field>
     </record>

--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -62,6 +62,8 @@ class MrpInventoryProcure(models.TransientModel):
         elif active_model == "mrp.planned.order":
             mrp_planned_order_obj = self.env[active_model]
             for line in mrp_planned_order_obj.browse(active_ids):
+                if line.mrp_action == "phantom":
+                    continue
                 if line.qty_released < line.mrp_qty:
                     items += item_obj.create(self._prepare_item(line))
         if items:


### PR DESCRIPTION
fixes #1362

Ignoring qty_available for phantom products prevents double counting the qty_available of components.

Creating planned orders for phantom products is simpler than recursively exploding phantom BOMs. This also makes it easier to analyze the planning data generated by the MRP calculation.