### PR TITLE
[16.0][IMP] mrp_multi_level: mrp cleanup performance

### DIFF
--- a/mrp_multi_level/models/mrp_production.py
+++ b/mrp_multi_level/models/mrp_production.py
@@ -9,4 +9,7 @@ class MrpProduction(models.Model):
 
     _inherit = "mrp.production"
 
-    planned_order_id = fields.Many2one(comodel_name="mrp.planned.order")
+    planned_order_id = fields.Many2one(
+        comodel_name="mrp.planned.order",
+        index=True,
+    )

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -306,9 +306,10 @@ class MultiLevelMrp(models.TransientModel):
             domain += [("mrp_area_id", "in", mrp_areas.ids)]
         with mute_logger("odoo.models.unlink"):
             self.env["mrp.move"].search(domain).unlink()
+            self.env["mrp.planned.order"].search(
+                domain + [("fixed", "=", False)]
+            ).unlink()
             self.env["mrp.inventory"].search(domain).unlink()
-            domain += [("fixed", "=", False)]
-            self.env["mrp.planned.order"].search(domain).unlink()
         logger.info("End MRP Cleanup")
         return True
 


### PR DESCRIPTION
Two simple changes decrease the time spent on MRP Cleanup from over 1 minute to less than 1 second.

- Create an index on the planned_order_id column on mrp.production model (~65 seconds saved)
- Delete from mrp.planned.order before deleting from mrp.inventory (~3 seconds saved)

Performance was tested in a database containing the following number of records:

- mrp.production: 100k
- mrp.move: 13k
- mrp.planned.order: 4k
- mrp.inventory: 9k

Total computation time = 4.3 minutes, down from 5.5 minutes.  A 21% improvement.