### PR TITLE
[14.0][REF] repair_picking: move stock_rule._get_custom_move_fields to repair_stock_move

### DIFF
--- a/repair_picking/models/stock_rule.py
+++ b/repair_picking/models/stock_rule.py
@@ -4,16 +4,6 @@
 from odoo import api, models
 
 
-class StockRule(models.Model):
-    _inherit = "stock.rule"
-
-    def _get_custom_move_fields(self):
-        fields = super(StockRule, self)._get_custom_move_fields()
-        # Fields is added on `repair_stock_move` module.
-        fields += ["repair_line_id"]
-        return fields
-
-
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 


### PR DESCRIPTION
As the method will be used by modules that does not need to depend on this module and the method is added to implement the connection with a field that is added in repair_stock_move, I think it makes sense to move the method to that module.

Depends on #1375 

@ForgeFlow