### PR TITLE
[15.0][IMP] mrp_multi_level: mrp cleanup performance

### DIFF
--- a/mrp_multi_level/models/mrp_production.py
+++ b/mrp_multi_level/models/mrp_production.py
@@ -9,4 +9,7 @@ class MrpProduction(models.Model):
 
     _inherit = "mrp.production"
 
-    planned_order_id = fields.Many2one(comodel_name="mrp.planned.order")
+    planned_order_id = fields.Many2one(
+        comodel_name="mrp.planned.order",
+        index=True,
+    )

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -306,9 +306,10 @@ class MultiLevelMrp(models.TransientModel):
             domain += [("mrp_area_id", "in", mrp_areas.ids)]
         with mute_logger("odoo.models.unlink"):
             self.env["mrp.move"].search(domain).unlink()
+            self.env["mrp.planned.order"].search(
+                domain + [("fixed", "=", False)]
+            ).unlink()
             self.env["mrp.inventory"].search(domain).unlink()
-            domain += [("fixed", "=", False)]
-            self.env["mrp.planned.order"].search(domain).unlink()
         logger.info("End MRP Cleanup")
         return True
 


### PR DESCRIPTION
- Index the planned_order_id column on mrp.production model
- Delete from mrp.planned.order before deleting from mrp.inventory

Backport of https://github.com/OCA/manufacture/pull/1370