### PR TITLE
[14.0][FIX] mrp_bom_attribute_match: Do not empty bom line uom when creating

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_bom.py
+++ b/mrp_bom_attribute_match/models/mrp_bom.py
@@ -85,7 +85,11 @@ class MrpBomLine(models.Model):
             if self.product_backup_id:
                 self.product_id = self.product_backup_id
                 self.product_backup_id = False
-            if self.product_uom_id.category_id != self.product_id.uom_id.category_id:
+            if (
+                self.product_id.uom_id
+                and self.product_uom_id.category_id
+                != self.product_id.uom_id.category_id
+            ):
                 self.product_uom_id = self.product_id.uom_id
 
     @api.depends("component_template_id")


### PR DESCRIPTION
When creating a new line, an onchange is played before the user selects the product. With the previous code, since no product was selected, this was emptying the default value. This was in turn breaking any other function that relied on this value being set.