### PR TITLE
[15.0][FIX] mrp_multi_level: readd extensibility hook

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -313,3 +313,7 @@ class ProductMRPArea(models.Model):
     def _get_locations(self):
         self.ensure_one()
         return self.mrp_area_id._get_locations()
+
+    def _should_create_planned_order(self):
+        self.ensure_one()
+        return True

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -265,7 +265,9 @@ class MultiLevelMrp(models.TransientModel):
             order_data = self._prepare_planned_order_data(
                 product_mrp_area_id, qty, mrp_date_supply, mrp_action_date, name, values
             )
-            planned_order = self.env["mrp.planned.order"].create(order_data)
+            planned_order = False
+            if product_mrp_area_id._should_create_planned_order():
+                planned_order = self.env["mrp.planned.order"].create(order_data)
             qty_ordered = qty_ordered + qty
 
             if product_mrp_area_id._to_be_exploded():


### PR DESCRIPTION
_should_create_planned_order hook was unnoticely removed in 33cf4af1accf415f056dfe497969e5933e40246f as it was not needed anymore in the base module. However it is still an extension point that can be used.

Backport of #1391 