### PR TITLE
[FIX] mrp_packaging_default: multiply packagings per products manufactured

### DIFF
--- a/mrp_packaging_default/models/__init__.py
+++ b/mrp_packaging_default/models/__init__.py
@@ -1,2 +1,3 @@
 from . import mrp_bom_line
+from . import mrp_production
 from . import stock_move

--- a/mrp_packaging_default/models/mrp_production.py
+++ b/mrp_packaging_default/models/mrp_production.py
@@ -1,0 +1,27 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+from odoo import models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    def _get_move_raw_values(
+        self,
+        product_id,
+        product_uom_qty,
+        product_uom,
+        operation_id=False,
+        bom_line=False,
+    ):
+        """Include packaging in new move values."""
+        result = super()._get_move_raw_values(
+            product_id,
+            product_uom_qty,
+            product_uom,
+            operation_id=operation_id,
+            bom_line=bom_line,
+        )
+        if bom_line and bom_line.product_packaging_id:
+            result["product_packaging_id"] = bom_line.product_packaging_id.id
+        return result

--- a/mrp_packaging_default/models/stock_move.py
+++ b/mrp_packaging_default/models/stock_move.py
@@ -22,7 +22,6 @@ class StockMove(models.Model):
         vals.update(
             {
                 "product_packaging_id": bom_line.product_packaging_id.id,
-                "product_packaging_qty": bom_line.product_packaging_qty,
             }
         )
 


### PR DESCRIPTION

Before this patch, the amount of packagings was the same in an `mrp.production`, no matter the ordered quantity.

@moduon MT-8145