### PR TITLE
[17.0][FIX] mrp_multi_level: when a product is a kit do not check rule

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -206,18 +206,19 @@ class ProductMRPArea(models.Model):
         boms_by_product = self.env["mrp.bom"]._bom_find(self.mapped("product_id"))
         for rec in self:
             rule = rec._get_rule()
-            if not rule:
+            bom = boms_by_product.get(rec.product_id, self.env["mrp.bom"])
+            if bom.type == "phantom":
+                rec.supply_method = "phantom"
+                rec.supply_bom_id = bom
+            elif not rule:
                 rec.supply_method = "none"
                 rec.supply_bom_id = False
-                continue
-            # Determine the supply method based on the final rule.
-            bom = boms_by_product.get(rec.product_id, self.env["mrp.bom"])
-            rec.supply_method = (
-                "phantom"
-                if rule.action == "manufacture" and bom.type == "phantom"
-                else rule.action
-            )
-            rec.supply_bom_id = bom
+            elif rule.action == "manufacture":
+                rec.supply_method = rule.action
+                rec.supply_bom_id = bom
+            else:
+                rec.supply_method = rule.action
+                rec.supply_bom_id = False
 
     @api.depends(
         "mrp_area_id", "supply_method", "product_id.route_ids", "product_id.seller_ids"

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -449,6 +449,16 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         ]
         product_mrp_area._compute_supply_method()
         self.assertEqual(product_mrp_area.supply_method, "buy")
+        kit_bom = self.mrp_bom_obj.create(
+            {
+                "product_tmpl_id": self.fp_4.product_tmpl_id.id,
+                "product_id": self.fp_4.id,
+                "type": "phantom",
+            }
+        )
+        product_mrp_area._compute_supply_method()
+        self.assertEqual(product_mrp_area.supply_method, "phantom")
+        self.assertEqual(product_mrp_area.supply_bom_id, kit_bom)
 
     def test_18_priorize_safety_stock(self):
         now = datetime.now()

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -444,8 +444,18 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         self.fp_4.route_ids = [(4, self.env.ref("mrp.route_warehouse0_manufacture").id)]
         product_mrp_area._compute_supply_method()
         self.assertEqual(product_mrp_area.supply_method, "manufacture")
+        # because of the issue discussed here https://github.com/odoo/odoo/pull/188846
+        # we need to apply routes explicitly in the proper order (by sequence)
         self.fp_4.route_ids = [
-            (4, self.env.ref("purchase_stock.route_warehouse0_buy").id)
+            (
+                6,
+                0,
+                (
+                    self.env.ref("stock.route_warehouse0_mto")
+                    + self.env.ref("purchase_stock.route_warehouse0_buy")
+                    + self.env.ref("mrp.route_warehouse0_manufacture")
+                ).ids,
+            )
         ]
         product_mrp_area._compute_supply_method()
         self.assertEqual(product_mrp_area.supply_method, "buy")


### PR DESCRIPTION
When you procure a kit, it doesn't matter what the route configuration is on the product itself but on its children, so it is not needed to check anything else but the BoM to assign the 'phantom' supply method.

Also do not assign a BoM when the supply method is not phantom or manufacture.

Fwport of #1401 