### PR TITLE
[15.0][FIX] mrp_multi_level: delete params on cascade when deleting product.

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -22,7 +22,10 @@ class ProductMRPArea(models.Model):
         store=True,
     )
     product_id = fields.Many2one(
-        comodel_name="product.product", required=True, string="Product"
+        comodel_name="product.product",
+        required=True,
+        string="Product",
+        ondelete="cascade",
     )
     product_tmpl_id = fields.Many2one(
         comodel_name="product.template",


### PR DESCRIPTION
Backport of https://github.com/OCA/manufacture/pull/1404