### PR TITLE
[17.0][FIX] mrp_multi_level: properly handle UserError in procurement.

### DIFF
--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -97,7 +97,7 @@ class MrpInventoryProcure(models.TransientModel):
             for item in self.item_ids:
                 item.planned_order_id.qty_released += item.qty
         except UserError as error:
-            errors.append(error.name)
+            errors.append(str(error))
         if errors:
             raise UserError("\n".join(errors))
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Small fix
AttributeError: 'UserError' object has no attribute 'name'.

Example:
![error_example](https://github.com/user-attachments/assets/a6d4afae-e977-4f5b-b121-01c7fa7ec071)

After the fix:
![image](https://github.com/user-attachments/assets/f75b082d-6dd2-47a1-83bc-86d3f6861306)
