### PR TITLE
[FIX]quality_control_oca: Added digits to valid values to avoid round…

### DIFF
--- a/quality_control_oca/models/qc_inspection.py
+++ b/quality_control_oca/models/qc_inspection.py
@@ -284,8 +284,8 @@ class QcInspectionLine(models.Model):
                 )
             else:
                 insp_line.valid_values = "{} ~ {}".format(
-                    formatLang(self.env, insp_line.min_value),
-                    formatLang(self.env, insp_line.max_value),
+                    formatLang(self.env, insp_line.min_value, digits=5),
+                    formatLang(self.env, insp_line.max_value, digits=5),
                 )
                 if self.env.ref("uom.group_uom") in self.env.user.groups_id:
                     insp_line.valid_values += " %s" % insp_line.test_uom_id.name


### PR DESCRIPTION
 Added digits to valid values to avoid rounding problems,

When the maximum value in test is 0,03500, and you load the test into an inspection, in the valid values char field the original method rounds to 0,04 so if you put 0,038 as counted value the quality point fails, but you see that the value is correct.