### PR TITLE
[17.0][FIX] mrp_multi_level: avoid create warehouse and location in mrp area view

### DIFF
--- a/mrp_multi_level/views/mrp_area_views.xml
+++ b/mrp_multi_level/views/mrp_area_views.xml
@@ -35,8 +35,8 @@
                     <group colspan="4" col="2">
                         <group>
                             <field name="active" invisible="1" />
-                            <field name="warehouse_id" />
-                            <field name="location_id" />
+                            <field name="warehouse_id" options="{'no_create': True}" />
+                            <field name="location_id" options="{'no_create': True}" />
                             <field
                                 name="company_id"
                                 groups="base.group_multi_company"


### PR DESCRIPTION
Avoid bug that occurs when clicking `New` on the `warehouse_id` field if the Storage Locations setting is not active.
Before PR: once you click on `New` you cannot close
![PR-mrp_mulit_level](https://github.com/user-attachments/assets/57c199c4-3c9d-43fd-8543-e9735dd1d6c7)

After PR: `New` button removed
![PR-mrp_mulit_level2](https://github.com/user-attachments/assets/f495d2ae-f434-4d59-9fca-18b15b24cdbe)
