### PR TITLE
[17.0] [IMP] mrp_production_back_to_draft: Workorders back to draft

### DIFF
--- a/mrp_production_back_to_draft/README.rst
+++ b/mrp_production_back_to_draft/README.rst
@@ -57,6 +57,7 @@ Contributors
 ------------
 
 - David Jiménez <david.jimenez@forgeflow.com>
+- Meritxell Abellan <meritxell.abellan@forgeflow.com>
 
 Maintainers
 -----------

--- a/mrp_production_back_to_draft/models/mrp_production.py
+++ b/mrp_production_back_to_draft/models/mrp_production.py
@@ -22,6 +22,7 @@ class MrpProduction(models.Model):
             else:
                 (rec.move_raw_ids + rec.move_finished_ids)._action_cancel()
                 (rec.move_raw_ids + rec.move_finished_ids).write({"state": "draft"})
+                rec.workorder_ids.write({"state": "waiting"})
                 if rec.state != "draft":
                     raise UserError(
                         _("Could not set the production order back to draft")

--- a/mrp_production_back_to_draft/readme/CONTRIBUTORS.md
+++ b/mrp_production_back_to_draft/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - David Jiménez \<<david.jimenez@forgeflow.com>\>
+- Meritxell Abellan \<<meritxell.abellan@forgeflow.com>\>

--- a/mrp_production_back_to_draft/static/description/index.html
+++ b/mrp_production_back_to_draft/static/description/index.html
@@ -402,6 +402,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
 <li>David Jiménez &lt;<a class="reference external" href="mailto:david.jimenez&#64;forgeflow.com">david.jimenez&#64;forgeflow.com</a>&gt;</li>
+<li>Meritxell Abellan &lt;<a class="reference external" href="mailto:meritxell.abellan&#64;forgeflow.com">meritxell.abellan&#64;forgeflow.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Workorders are now reset when a MO gets back to draft.

@ForgeFlow