### PR TITLE
[16.0][FIX] mrp_lot_number_propagation Keyerror stock.production.lot

### DIFF
--- a/mrp_lot_number_propagation/models/mrp_production.py
+++ b/mrp_lot_number_propagation/models/mrp_production.py
@@ -111,7 +111,7 @@ class MrpProduction(models.Model):
                 and m.state not in ("done", "cancel")
             )
             if finish_moves and not finish_moves.quantity_done:
-                lot_model = self.env["stock.production.lot"]
+                lot_model = self.env["stock.lot"]
                 lot = lot_model.search(
                     [
                         ("product_id", "=", order.product_id.id),
@@ -128,7 +128,7 @@ class MrpProduction(models.Model):
                         )
                     )
                 if not lot:
-                    lot = self.env["stock.production.lot"].create(
+                    lot = self.env["stock.lot"].create(
                         {
                             "product_id": order.product_id.id,
                             "company_id": order.company_id.id,

--- a/mrp_lot_number_propagation/tests/__init__.py
+++ b/mrp_lot_number_propagation/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_mrp_bom
+from . import test_mrp_production

--- a/mrp_lot_number_propagation/tests/common.py
+++ b/mrp_lot_number_propagation/tests/common.py
@@ -81,7 +81,7 @@ class Common(common.TransactionCase):
                     "company_id": line.company_id.id,
                     "name": lot_name,
                 }
-                lot = cls.env["stock.production.lot"].create(vals)
+                lot = cls.env["stock.lot"].create(vals)
             cls._update_qty_in_location(
                 location,
                 line.product_id,

--- a/mrp_lot_number_propagation/tests/test_mrp_production.py
+++ b/mrp_lot_number_propagation/tests/test_mrp_production.py
@@ -64,7 +64,7 @@ class TestMrpProduction(Common):
         self.assertEqual(self.order.propagated_lot_producing, self.LOT_NAME)
         # Create a lot with the same number for the finished product
         # without any stock/quants (so not used at all) before validating the MO
-        existing_lot = self.env["stock.production.lot"].create(
+        existing_lot = self.env["stock.lot"].create(
             {
                 "product_id": self.order.product_id.id,
                 "company_id": self.order.company_id.id,
@@ -82,7 +82,7 @@ class TestMrpProduction(Common):
         # Create a lot with the same number for the finished product
         # with some stock/quants (so it is considered as used) before
         # validating the MO
-        existing_lot = self.env["stock.production.lot"].create(
+        existing_lot = self.env["stock.lot"].create(
             {
                 "product_id": self.order.product_id.id,
                 "company_id": self.order.company_id.id,

--- a/mrp_lot_number_propagation/tests/test_mrp_production.py
+++ b/mrp_lot_number_propagation/tests/test_mrp_production.py
@@ -34,7 +34,7 @@ class TestMrpProduction(Common):
 
     def _set_qty_done(self, order):
         for line in order.move_raw_ids.move_line_ids:
-            line.qty_done = line.product_uom_qty
+            line.qty_done = line.reserved_uom_qty
         order.qty_producing = order.product_qty
 
     def test_order_propagated_lot_producing(self):


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 1653, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1680, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 1884, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 46, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/addons/mrp/models/mrp_production.py", line 1885, in button_mark_done
    productions_not_to_backorder._post_inventory(cancel_backorder=True)
  File "/mnt/data/odoo-addons-dir/quality_control_mrp_oca/models/mrp_production.py", line 33, in _post_inventory
    res = super()._post_inventory(cancel_backorder=cancel_backorder)
  File "/mnt/data/odoo-addons-dir/mrp_lot_production_date/models/mrp_production.py", line 11, in _post_inventory
    res = super()._post_inventory(cancel_backorder=cancel_backorder)
  File "/mnt/data/odoo-addons-dir/mrp_lot_number_propagation/models/mrp_production.py", line 102, in _post_inventory
    self._create_and_assign_propagated_lot_number()
  File "/mnt/data/odoo-addons-dir/mrp_lot_number_propagation/models/mrp_production.py", line 114, in _create_and_assign_propagated_lot_number
    lot_model = self.env["stock.production.lot"]
  File "/opt/odoo/odoo/api.py", line 550, in __getitem__
    return self.registry[model_name](self, (), ())
  File "/opt/odoo/odoo/modules/registry.py", line 186, in __getitem__
    return self.models[model_name]
KeyError: 'stock.production.lot'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (http://oca-manufacture-16-0-3271ae22e786.runboat.odoo-community.org/web/assets/608-565ca3b/web.assets_backend.min.js:1001:163)
        at XMLHttpRequest.<anonymous> (http://oca-manufacture-16-0-3271ae22e786.runboat.odoo-community.org/web/assets/608-565ca3b/web.assets_backend.min.js:1009:13)

```