### PR TITLE
[15.0][FIX] mrp_multi_level: fix main supplier computation

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -231,11 +231,18 @@ class ProductMRPArea(models.Model):
                 rec.supply_bom_id = False
 
     @api.depends(
-        "mrp_area_id", "supply_method", "product_id.route_ids", "product_id.seller_ids"
+        "mrp_area_id",
+        "product_id.route_ids",
+        "product_id.seller_ids",
+        "location_proc_id",
     )
     def _compute_main_supplier(self):
         """Simplified and similar to procurement.rule logic."""
-        for rec in self.filtered(lambda r: r.supply_method == "buy"):
+        for rec in self:
+            if rec.supply_method != "buy":
+                rec.main_supplierinfo_id = False
+                rec.main_supplier_id = False
+                continue
             suppliers = rec.product_id.seller_ids.filtered(
                 lambda r: (not r.product_id or r.product_id == rec.product_id)
                 and (not r.company_id or r.company_id == rec.company_id)
@@ -246,9 +253,6 @@ class ProductMRPArea(models.Model):
                 continue
             rec.main_supplierinfo_id = suppliers[0]
             rec.main_supplier_id = suppliers[0].name
-        for rec in self.filtered(lambda r: r.supply_method != "buy"):
-            rec.main_supplierinfo_id = False
-            rec.main_supplier_id = False
 
     def _adjust_qty_to_order(self, qty_to_order):
         self.ensure_one()


### PR DESCRIPTION
Backport of #1448 

* api.depends

supply_method is not stored and therefore not reliable in the api.depends, including procure location in the api.depends cover changes in the supply method due to procure location change.

* remove usages of filtered

it was iterating the recordset more than 2 times when it could be done in a single interation.