### PR TITLE
Revert [FIX] mrp_multi_level: adapt tests to recent upstream changes.

### DIFF
--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -444,18 +444,8 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         self.fp_4.route_ids = [(4, self.env.ref("mrp.route_warehouse0_manufacture").id)]
         product_mrp_area._compute_supply_method()
         self.assertEqual(product_mrp_area.supply_method, "manufacture")
-        # because of the issue discussed here https://github.com/odoo/odoo/pull/188846
-        # we need to apply routes explicitly in the proper order (by sequence)
         self.fp_4.route_ids = [
-            (
-                6,
-                0,
-                (
-                    self.env.ref("stock.route_warehouse0_mto")
-                    + self.env.ref("purchase_stock.route_warehouse0_buy")
-                    + self.env.ref("mrp.route_warehouse0_manufacture")
-                ).ids,
-            )
+            (4, self.env.ref("purchase_stock.route_warehouse0_buy").id)
         ]
         product_mrp_area._compute_supply_method()
         self.assertEqual(product_mrp_area.supply_method, "buy")


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/aaed0ae359e0367aaf4a3f0837f478b0115d2bbf we can revert https://github.com/OCA/manufacture/pull/1403/commits/caeefa6ada15d5e9b2296c8af175c4a3aa9cb200