### PR TITLE
[16.0][FIX] mrp_subcontracting_skip_no_negative: fix creating backorder

### DIFF
--- a/mrp_subcontracting_skip_no_negative/models/stock_move.py
+++ b/mrp_subcontracting_skip_no_negative/models/stock_move.py
@@ -69,10 +69,10 @@ class StockMove(models.Model):
                             location=location.complete_name,
                         )
                     )
-        res = super(StockMove, self - moves_with_no_check)._action_done(
+        res = super(StockMove, moves_with_no_check)._action_done(
             cancel_backorder=cancel_backorder
         )
-        res += super(StockMove, moves_with_no_check)._action_done(
+        res += super(StockMove, self - moves_with_no_check)._action_done(
             cancel_backorder=cancel_backorder
         )
         return res

--- a/mrp_subcontracting_skip_no_negative/models/stock_picking.py
+++ b/mrp_subcontracting_skip_no_negative/models/stock_picking.py
@@ -20,3 +20,25 @@ class StockPicking(models.Model):
             ]
         )
         quants.check_negative_qty()
+
+    def _get_moves_to_backorder(self):
+        self.ensure_one()
+        moves = super()._get_moves_to_backorder()
+        if self.env.context.get("skip_negative_qty_check"):
+            return moves.filtered(lambda x: x.is_subcontract)
+        return moves
+
+    def _create_backorder_picking(self):
+        self.ensure_one()
+        existing_backorder_picking = self.env["stock.picking"].search(
+            [("backorder_id", "=", self.id)]
+        )
+        existing_subcontract_moves = existing_backorder_picking.move_ids.filtered(
+            lambda x: x.is_subcontract
+        )
+        if (
+            self.move_ids.filtered(lambda x: x.state == "done" and x.is_subcontract)
+            and existing_subcontract_moves
+        ):
+            return existing_backorder_picking
+        return super()._create_backorder_picking()

--- a/mrp_subcontracting_skip_no_negative/tests/test_mrp_subcontracting_skip_no_negative.py
+++ b/mrp_subcontracting_skip_no_negative/tests/test_mrp_subcontracting_skip_no_negative.py
@@ -92,3 +92,40 @@ class TestMrpSubcontractingSkipNoNegative(TestMrpSubcontractingCommon):
         ).save()
         immediate_wizard_form.process()
         self.assertEqual(self.subcontracting_receipt.state, "done")
+
+    def test_mrp_subcontracting_with_normal_product(self):
+        another_product = self.env["product.product"].create(
+            {
+                "name": "Another Product",
+                "type": "product",
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "picking_id": self.subcontracting_receipt.id,
+                "product_id": another_product.id,
+                "name": another_product.name,
+                "product_uom": another_product.uom_id.id,
+                "product_uom_qty": 1,
+                "location_id": self.subcontracting_receipt.location_id.id,
+                "location_dest_id": self.subcontracting_receipt.location_dest_id.id,
+            }
+        )
+        self._create_stock_quant(self.comp1, 10)
+        self._create_stock_quant(self.comp2, 10)
+        self.subcontracting_receipt.action_confirm()
+        self.assertEqual(self.subcontracting_receipt.state, "assigned")
+        immediate_wizard = self.subcontracting_receipt.sudo().button_validate()
+        self.assertEqual(immediate_wizard.get("res_model"), "stock.immediate.transfer")
+        immediate_wizard_form = Form(
+            self.env[immediate_wizard["res_model"]].with_context(
+                **immediate_wizard["context"]
+            )
+        ).save()
+        immediate_wizard_form.process()
+        self.assertEqual(self.subcontracting_receipt.state, "done")
+        products = self.subcontracting_receipt.move_ids.mapped("product_id")
+        self.assertIn(self.finished, products)
+        self.assertIn(another_product, products)
+        for move in self.subcontracting_receipt.move_ids:
+            self.assertEqual(move.quantity_done, 1)


### PR DESCRIPTION
This PR fixes the issue of creating a backorder when a picking contains both subcontracted and normal products and is validated.
Depends on https://github.com/odoo/odoo/pull/195958

@qrtl QT5016