### PR TITLE
[16.0][FIX] mrp_restrict_lot: avoid duplicate mo name in case of cancellation qty changes ...

### DIFF
--- a/mrp_restrict_lot/models/stock_rule.py
+++ b/mrp_restrict_lot/models/stock_rule.py
@@ -33,5 +33,11 @@ class StockRule(models.Model):
         if lot_id:
             vals["lot_producing_id"] = lot_id
             lot = self.env["stock.lot"].browse(lot_id)
-            vals["name"] = lot.name
+            mo_name = lot.name
+            existing_mo = self.env["mrp.production"].search(
+                [("lot_producing_id", "=", lot_id)]
+            )
+            if existing_mo:
+                mo_name = "%s-%s" % (mo_name, len(existing_mo))
+            vals["name"] = mo_name
         return vals

--- a/mrp_restrict_lot/tests/test_manufaturing_lot.py
+++ b/mrp_restrict_lot/tests/test_manufaturing_lot.py
@@ -49,3 +49,22 @@ class TestRestrictLot(TransactionCase):
         mo = move.move_orig_ids.production_id
         self.assertEqual(mo.lot_producing_id.id, lot.id)
         self.assertEqual(mo.name, lot.name)
+        group = self.env["procurement.group"].create({"name": "My test delivery 2"})
+        move = self.env["stock.move"].create(
+            {
+                "product_id": self.panel_wood_prd.id,
+                "location_id": self.warehouse.lot_stock_id.id,
+                "location_dest_id": self.customer_loc.id,
+                "product_uom_qty": 1,
+                "product_uom": self.panel_wood_prd.uom_id.id,
+                "name": "test",
+                "procure_method": "make_to_order",
+                "warehouse_id": self.warehouse.id,
+                "restrict_lot_id": lot.id,
+                "picking_type_id": self.out_picking_type.id,
+                "group_id": group.id,
+            }
+        )
+        move._action_confirm()
+        mo = move.move_orig_ids.production_id
+        self.assertEqual(mo.name, "%s-%s" % (lot.name, 1))


### PR DESCRIPTION
Forward port of #1010 

Recreated after #1258 has been closed automatically...