### PR TITLE
[16.0][IMP] mrp_produt_characterisation Add groups mrp_user

### DIFF
--- a/mrp_product_characterisation/views/view_product_product.xml
+++ b/mrp_product_characterisation/views/view_product_product.xml
@@ -15,6 +15,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     string="Intermediates Products"
                     name="filter_is_intermediate"
                     domain="[('is_intermediate', '=', True)]"
+                    groups="mrp.group_mrp_user"
                 />
             </xpath>
             <xpath expr="//filter[@name='filter_is_intermediate']" position="after">
@@ -22,6 +23,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     string="Components Products"
                     name="filter_is_component"
                     domain="[('is_component', '=', True)]"
+                    groups="mrp.group_mrp_user"
                 />
             </xpath>
             <xpath expr="//filter[@name='components']" position="attributes">

--- a/mrp_product_characterisation/views/view_product_template.xml
+++ b/mrp_product_characterisation/views/view_product_template.xml
@@ -11,16 +11,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
 
-            <xpath
-                expr="//field[@name='purchase_ok']/.."
-                position="after"
-                groups="mrp.group_mrp_user"
-            >
-                <span class="d-inline-block">
+            <xpath expr="//field[@name='purchase_ok']/.." position="after">
+                <span class="d-inline-block" groups="base.group_no_one">
                     <field name="is_component" />
                     <label for="is_component" />
                 </span>
-                <span class="d-inline-block">
+                <span class="d-inline-block" groups="base.group_no_one">
                     <field name="is_intermediate" />
                     <label for="is_intermediate" />
                 </span>
@@ -38,6 +34,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     string="Intermediates Products"
                     name="filter_is_intermediate"
                     domain="[('is_intermediate', '=', True)]"
+                    groups="mrp.group_mrp_user"
                 />
             </xpath>
             <xpath expr="//filter[@name='filter_is_intermediate']" position="after">
@@ -45,6 +42,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     string="Components Products"
                     name="filter_is_component"
                     domain="[('is_component', '=', True)]"
+                    groups="mrp.group_mrp_user"
                 />
             </xpath>
             <xpath expr="//filter[@name='components']" position="attributes">


### PR DESCRIPTION
Two improvements : 
- Theses fields are used for filtering so we hide field on product form and display them only for admin
- And for filter, this PR add groups to show them only for MRP user