### PR TITLE
[16.0][IMP] mrp_production_quant_manual_assign: skip _check_qty()

### DIFF
--- a/mrp_production_quant_manual_assign/tests/__init__.py
+++ b/mrp_production_quant_manual_assign/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_mrp_production_quant_manual_assign

--- a/mrp_production_quant_manual_assign/tests/test_mrp_production_quant_manual_assign.py
+++ b/mrp_production_quant_manual_assign/tests/test_mrp_production_quant_manual_assign.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestMrpProductionQuantManualAssign(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env.ref("base.main_company")
+        cls.manufacture_route = cls.env.ref("mrp.route_warehouse0_manufacture")
+        cls.finished_product = cls.env["product.product"].create(
+            {"name": "test product", "type": "product"}
+        )
+        cls.component = cls.env["product.product"].create(
+            {"name": "test component", "type": "product"}
+        )
+        cls.bom = cls.env["mrp.bom"].create(
+            {
+                "product_id": cls.finished_product.id,
+                "product_tmpl_id": cls.finished_product.product_tmpl_id.id,
+                "product_uom_id": cls.finished_product.uom_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+            }
+        )
+        cls.picking_type = cls.env["stock.picking.type"].search(
+            [
+                ("code", "=", "mrp_operation"),
+                ("company_id", "=", cls.company.id),
+            ],
+            limit=1,
+        )
+        cls.env["mrp.bom.line"].create(
+            {"bom_id": cls.bom.id, "product_id": cls.component.id, "product_qty": 1}
+        )
+        cls.finished_product.route_ids = [Command.set(cls.manufacture_route.ids)]
+        quant_vals = {
+            "product_id": cls.component.id,
+            "location_id": cls.picking_type.default_location_src_id.id,
+            "quantity": 10.00,
+        }
+        cls.env["stock.quant"].create(quant_vals)
+        mo = cls.env["mrp.production"].create(
+            {
+                "product_id": cls.finished_product.id,
+                "bom_id": cls.bom.id,
+                "product_qty": 1,
+            }
+        )
+        mo.action_confirm()
+        cls.move = mo.move_raw_ids[0]
+
+    def _create_wizard(self):
+        return (
+            self.env["assign.manual.quants"]
+            .with_context(active_id=self.move.id)
+            .create({})
+        )
+
+    def test_mrp_production_quant_assign_wizard(self):
+        wizard = self._create_wizard()
+        self.assertEqual(len(wizard.quants_lines.ids), 1)
+        self.assertEqual(len(wizard.quants_lines.filtered("selected").ids), 1)
+        self.assertEqual(wizard.lines_qty, 1.0)
+        self.assertEqual(
+            sum(line.qty for line in wizard.quants_lines),
+            self.move.reserved_availability,
+        )
+
+    def test_quant_assign_wizard_constraint(self):
+        wizard = self._create_wizard()
+        # For pickings, this should raise "Quantity is higher than the needed one",
+        # but for manufacturing orders (MO), no error is raised.
+        wizard.write(
+            {
+                "quants_lines": [
+                    (1, wizard.quants_lines[:1].id, {"selected": True, "qty": 2})
+                ]
+            }
+        )

--- a/mrp_production_quant_manual_assign/wizards/assign_manual_quants.py
+++ b/mrp_production_quant_manual_assign/wizards/assign_manual_quants.py
@@ -25,6 +25,14 @@ class AssignManualQuants(models.TransientModel):
         res.update({"is_production_single_lot": self._is_production_single_lot(move)})
         return res
 
+    @api.constrains("quants_lines")
+    def _check_qty(self):
+        # If the move is that of a production component, skip the check and let the
+        # standard check based on Flexible Consumption do the job.
+        if self.move_id.raw_material_production_id:
+            return
+        return super()._check_qty()
+
     @api.model
     def _prepare_wizard_line(self, move, quant):
         line = super()._prepare_wizard_line(move, quant)


### PR DESCRIPTION
Supersedes https://github.com/OCA/manufacture/pull/1237

`assign.manual.quants._check_qty()` would show an error when you tried to consume more than you were supposed to, however this should not be applied in the manufacturing context where component losses/overcomsumption should be added to the cost of produced product.

We let the standard check logic based on the BoM configuration ('Flexible Consumption')' handle the case where discrepancy arises.

@qrtl QT4406