### PR TITLE
[16.0][FIX] mrp_bom_product_price_margin onchange stuck with readonly

### DIFF
--- a/mrp_bom_product_price_margin/views/view_mrp_bom.xml
+++ b/mrp_bom_product_price_margin/views/view_mrp_bom.xml
@@ -77,6 +77,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                   for 1x <field
                         name="product_uom_id"
                         readonly="1"
+                        force_save="1"
                         style="pointer-events:none;"
                     />
               </div>


### PR DESCRIPTION
With several unity of measure context, product_uom_id was stuck because of readonly → it need force_save