### PR TITLE
[14.0][IMP][mrp_restrict_lot] increment MO name only if name exist

### DIFF
--- a/mrp_restrict_lot/models/stock_rule.py
+++ b/mrp_restrict_lot/models/stock_rule.py
@@ -35,7 +35,7 @@ class StockRule(models.Model):
             lot = self.env["stock.production.lot"].browse(lot_id)
             mo_name = lot.name
             existing_mo = self.env["mrp.production"].search(
-                [("lot_producing_id", "=", lot_id)]
+                [("lot_producing_id", "=", lot_id), ("name", "=", mo_name)], limit=1
             )
             if existing_mo:
                 mo_name = "%s-%s" % (mo_name, len(existing_mo))


### PR DESCRIPTION
With some modules or custom code, we can change the MO name (if cancelled for exemple). 
So, in this case, we do not need to increment the MO name (lot name). 
