### PR TITLE
[16.0][FIX] quality_control_oca: notes width in QC inspection form

### DIFF
--- a/quality_control_oca/views/qc_inspection_view.xml
+++ b/quality_control_oca/views/qc_inspection_view.xml
@@ -113,10 +113,10 @@
                         </page>
                         <page string="Notes">
                             <group string="Internal notes">
-                                <field name="internal_notes" nolabel="1" />
+                                <field name="internal_notes" nolabel="1" colspan="2" />
                             </group>
                             <group string="External notes">
-                                <field name="external_notes" nolabel="1" />
+                                <field name="external_notes" nolabel="1" colspan="2" />
                             </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
Make the Internal and External notes fields in QC Inspections wider in the form view.

Before this fix:

![image](https://github.com/user-attachments/assets/af220b37-68c0-4e21-b9c4-c392d538a160)

After this fix:

![image](https://github.com/user-attachments/assets/605d7a11-184e-4bd0-89a0-6cd925b48131)