### PR TITLE
[17.0][IMP]quality_control_stock_oca: inspection per lot/serial

### DIFF
--- a/quality_control_stock_oca/README.rst
+++ b/quality_control_stock_oca/README.rst
@@ -38,10 +38,21 @@ It also adds some shortcuts on picking and lots to these inspections.
 .. contents::
    :local:
 
+Configuration
+=============
+
+To create a quality inspection for each lot/serial number used in a
+stock move you need to:
+
+- Go to Quality Control> Configuration > Triggers.
+- Activate the "Inspection Per Lot" option in those triggers which need
+  to force a different inspection for each lot/serial number used in a
+  stock picking.
+
 Known issues / Roadmap
 ======================
 
--  Put trigger in all languages.
+- Put trigger in all languages.
 
 Bug Tracker
 ===========
@@ -66,19 +77,23 @@ Authors
 Contributors
 ------------
 
--  Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
--  Simone Rubino <simone.rubino@agilebg.com>
--  Andrii Skrypka <andrijskrypa@ukr.net>
--  Ignacio José Alés <ignacio.ales@guadaltech.es>
--  Pimolnat Suntian <pimolnats@ecosoft.co.th>
--  `Tecnativa <https://www.tecnativa.com>`__:
+- Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+- Simone Rubino <simone.rubino@agilebg.com>
+- Andrii Skrypka <andrijskrypa@ukr.net>
+- Ignacio José Alés <ignacio.ales@guadaltech.es>
+- Pimolnat Suntian <pimolnats@ecosoft.co.th>
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Pedro M. Baeza
-   -  Carlos Roca
+  - Pedro M. Baeza
+  - Carlos Roca
 
--  `APSL-Nagarro <https://www.apsl.tech>`__:
+- `APSL-Nagarro <https://www.apsl.tech>`__:
 
-   -  Antoni Marroig <amarroig@apsl.net>
+  - Antoni Marroig <amarroig@apsl.net>
+
+- `Sygel <https://www.sygel.es>`__:
+
+  - Manuel Regidor <manuel.regidor@sygel.es>
 
 Maintainers
 -----------

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -47,8 +47,7 @@ class QcInspection(models.Model):
             if inspection.object_id._name == "stock.move":
                 inspection.lot_id = first(
                     move_lines.filtered(
-                        lambda x, inspection=inspection: x.move_id
-                        == inspection.object_id
+                        lambda x, ins=inspection: x.move_id == ins.object_id
                     )
                 ).lot_id
             elif inspection.object_id._name == "stock.lot":

--- a/quality_control_stock_oca/models/qc_trigger.py
+++ b/quality_control_stock_oca/models/qc_trigger.py
@@ -11,3 +11,7 @@ class QcTrigger(models.Model):
     picking_type_id = fields.Many2one(
         comodel_name="stock.picking.type", ondelete="cascade"
     )
+    inspection_per_lot = fields.Boolean(
+        help="If checked, an inspection per used lot/serial number "
+        "will be created in stock pickings."
+    )

--- a/quality_control_stock_oca/models/stock_picking.py
+++ b/quality_control_stock_oca/models/stock_picking.py
@@ -80,5 +80,20 @@ class StockPicking(models.Model):
                     )
                 )
             for trigger_line in _filter_trigger_lines(trigger_lines):
-                inspection_model._make_inspection(operation, trigger_line)
+                inspection = inspection_model._make_inspection(operation, trigger_line)
+                if operation.product_id.tracking != "none":
+                    move_line = operation.move_line_ids[0]
+                    if trigger_line.trigger.inspection_per_lot:
+                        move_lines = operation.move_line_ids
+                        for move_line in move_lines:
+                            inspection.write(
+                                {
+                                    "lot_id": move_line.lot_id and move_line.lot_id.id,
+                                    "qty": move_line.quantity,
+                                }
+                            )
+                            if move_line != move_lines[-1]:
+                                inspection = inspection.copy()
+                                inspection.set_test(trigger_line)
+                                inspection.action_todo()
         return res

--- a/quality_control_stock_oca/readme/CONFIGURE.md
+++ b/quality_control_stock_oca/readme/CONFIGURE.md
@@ -1,0 +1,8 @@
+To create a quality inspection for each lot/serial number used in a stock
+move you need to:
+
+- Go to Quality Control> Configuration > Triggers.
+- Activate the "Inspection Per Lot" option in those triggers which need
+  to force a different inspection for each lot/serial number used in a 
+  stock picking.
+

--- a/quality_control_stock_oca/readme/CONTRIBUTORS.md
+++ b/quality_control_stock_oca/readme/CONTRIBUTORS.md
@@ -8,3 +8,5 @@
   - Carlos Roca
 - [APSL-Nagarro](https://www.apsl.tech):
   - Antoni Marroig \<<amarroig@apsl.net>\>
+- [Sygel](https://www.sygel.es):
+  - Manuel Regidor \<<manuel.regidor@sygel.es>\>

--- a/quality_control_stock_oca/static/description/index.html
+++ b/quality_control_stock_oca/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -375,24 +376,36 @@ are done.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
+<p>To create a quality inspection for each lot/serial number used in a
+stock move you need to:</p>
+<ul class="simple">
+<li>Go to Quality Control&gt; Configuration &gt; Triggers.</li>
+<li>Activate the “Inspection Per Lot” option in those triggers which need
+to force a different inspection for each lot/serial number used in a
+stock picking.</li>
+</ul>
+</div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-1">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Put trigger in all languages.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/manufacture/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -400,9 +413,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 <li>AvanzOSC</li>
@@ -410,7 +423,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Oihane Crucelaegui &lt;<a class="reference external" href="mailto:oihanecrucelaegi&#64;avanzosc.es">oihanecrucelaegi&#64;avanzosc.es</a>&gt;</li>
 <li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;agilebg.com">simone.rubino&#64;agilebg.com</a>&gt;</li>
@@ -426,12 +439,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.sygel.es">Sygel</a>:<ul>
+<li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/quality_control_stock_oca/tests/test_quality_control_stock.py
+++ b/quality_control_stock_oca/tests/test_quality_control_stock.py
@@ -23,9 +23,15 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
         cls.trigger = cls.qc_trigger_model.search(
             [("picking_type_id", "=", cls.picking_type.id)]
         )
-        cls.lot = cls.env["stock.lot"].create(
+        cls.lot1 = cls.env["stock.lot"].create(
             {
-                "name": "Lot for tests",
+                "name": "Lot for tests-1",
+                "product_id": cls.product.id,
+            }
+        )
+        cls.lot2 = cls.env["stock.lot"].create(
+            {
+                "name": "Lot for tests-2",
                 "product_id": cls.product.id,
             }
         )
@@ -35,7 +41,7 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
                 "product_id": cls.product.id,
                 "location_id": cls.location.id,
                 "quantity": 1,
-                "lot_id": cls.lot.id,
+                "lot_id": cls.lot1.id,
             }
         )
         cls.user = new_test_user(
@@ -236,6 +242,7 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
         self.product.categ_id.qc_triggers = [
             (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
         ]
+        self.product.tracking = "lot"
         self.picking1._action_done()
         self.assertEqual(
             self.picking1.created_inspections, 1, "Only one inspection must be created"
@@ -246,10 +253,10 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
             "Wrong test picked when creating inspection.",
         )
         self.assertEqual(
-            self.lot.created_inspections, 1, "Only one inspection must be created"
+            self.lot1.created_inspections, 1, "Only one inspection must be created"
         )
         self.assertEqual(
-            self.lot.qc_inspections_ids[:1].test,
+            self.lot1.qc_inspections_ids[:1].test,
             self.test,
             "Wrong test picked when creating inspection.",
         )
@@ -298,7 +305,6 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
         )
         self.inspection1.onchange_object_id()
         self.assertEqual(self.inspection1.picking_id, self.picking1)
-        self.assertEqual(self.inspection1.lot_id, self.lot)
         self.assertEqual(
             self.inspection1.product_id, self.picking1.move_ids[:1].product_id
         )
@@ -306,13 +312,75 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
             self.inspection1.qty, self.picking1.move_ids[:1].product_uom_qty
         )
 
-    def test_qc_inspection_lot(self):
-        self.inspection1.write(
-            {
-                "name": self.picking1.move_ids[:1]._name + "inspection",
-                "object_id": "%s,%d" % (self.lot._name, self.lot.id),
-            }
+    def test_qc_inspection_lot_single(self):
+        self.trigger.inspection_per_lot = False
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.product.tracking = "lot"
+        self.picking1.move_line_ids[0].copy()
+        self.picking1.move_line_ids[0].write({"quantity": 1, "lot_id": self.lot1.id})
+        self.picking1.move_line_ids[1].write({"quantity": 1, "lot_id": self.lot2.id})
+        self.picking1._action_done()
+        self.assertEqual(
+            self.picking1.created_inspections, 1, "One inspections must be created"
         )
-        self.inspection1.onchange_object_id()
-        self.assertEqual(self.inspection1.lot_id, self.lot)
-        self.assertEqual(self.inspection1.product_id, self.lot.product_id)
+        lot1_inspection = self.picking1.qc_inspections_ids.filtered(
+            lambda inspection: inspection.lot_id == self.lot1
+        )
+        self.assertTrue(lot1_inspection, "An inspection with lot1 must be created")
+        self.assertEqual(
+            lot1_inspection.qty, 2, "Quantity for lot1 must be equal to 2."
+        )
+        self.assertEqual(
+            self.lot1.created_inspections,
+            1,
+            "Created inspections for lot1 must be equal to 1.",
+        )
+        lot2_inspection = self.picking1.qc_inspections_ids.filtered(
+            lambda inspection: inspection.lot_id == self.lot2
+        )
+        self.assertFalse(lot2_inspection, "No inspections with lot2 must be created")
+        self.assertEqual(
+            self.lot2.created_inspections,
+            0,
+            "Created inspections for lot2 must be equal to 0.",
+        )
+
+    def test_qc_inspection_lot_multiple(self):
+        self.trigger.inspection_per_lot = True
+        self.product.qc_triggers = [
+            (0, 0, {"trigger": self.trigger.id, "test": self.test.id})
+        ]
+        self.product.tracking = "lot"
+        self.picking1.move_line_ids[0].copy()
+        self.picking1.move_line_ids[0].write({"quantity": 1, "lot_id": self.lot1.id})
+        self.picking1.move_line_ids[1].write({"quantity": 2, "lot_id": self.lot2.id})
+        self.picking1._action_done()
+        self.assertEqual(
+            self.picking1.created_inspections, 2, "Two inspections must be created"
+        )
+        lot1_inspection = self.picking1.qc_inspections_ids.filtered(
+            lambda inspection: inspection.lot_id == self.lot1
+        )
+        self.assertTrue(lot1_inspection, "An inspection with lot1 must be created")
+        self.assertEqual(
+            lot1_inspection.qty, 1, "Quantity for lot1 must be equal to 1."
+        )
+        self.assertEqual(
+            self.lot1.created_inspections,
+            1,
+            "Created inspections for lot1 must be equal to 1.",
+        )
+        lot2_inspection = self.picking1.qc_inspections_ids.filtered(
+            lambda inspection: inspection.lot_id == self.lot2
+        )
+        self.assertTrue(lot2_inspection, "An inspection with lot2 must be created")
+        self.assertEqual(
+            lot2_inspection.qty, 2, "Quantity for lot1 must be equal to 2."
+        )
+        self.assertEqual(
+            self.lot2.created_inspections,
+            1,
+            "Created inspections for lot2 must be equal to 1.",
+        )

--- a/quality_control_stock_oca/views/qc_trigger_view.xml
+++ b/quality_control_stock_oca/views/qc_trigger_view.xml
@@ -7,6 +7,18 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='partner_selectable']" position="after">
                 <field name="picking_type_id" readonly="1" />
+                <field name="inspection_per_lot" invisible="not picking_type_id" />
+            </xpath>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="qc_trigger_tree_view">
+        <field name="name">qc.trigger.form</field>
+        <field name="model">qc.trigger</field>
+        <field name='inherit_id' ref='quality_control_oca.qc_trigger_tree_view' />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_selectable']" position="after">
+                <field name="picking_type_id" column_invisible="True" />
+                <field name="inspection_per_lot" invisible="not picking_type_id" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This improvements adds an option to generate a quality inspection for each serial/lot number used in a stock.picking. This option has to be activated in the triggers related to stock picking operation types.

@sara-castello @HaraldPanten @ValentinVinagre 

T-7403
