### PR TITLE
[16.0][IMP] mrp_attachment_mgmt: BoM attachments management

### DIFF
--- a/mrp_attachment_mgmt/README.rst
+++ b/mrp_attachment_mgmt/README.rst
@@ -47,15 +47,18 @@ Usage
 =====
 
 #. Go to *Manufacturing -> Operation > Work Orders* and click in window open button (after the "Start" and "Block" options).
-#. The smart-button "Attachments" display the attachments of the related product.
-
+#. The smart-button "Product Attachments" display the attachments of the related product.
+#. The smart-button "BoM Attachments" displays the attachments of the workorder BoM.
 
 #. Go to *Manufacturing -> Products > Bill of material -> Desk Combination*.
 #. Go to "Attachment" icon related to "Office Chair Black" component and upload some file.
-#. The smart-button "Attachments" (from Bill of material) display the attachments of all components.
+#. The smart-button "Components Attachments" (from Bill of material) display the attachments of all components.
+#. Go to the Desk Combination product and upload an attachment
+#. The smart-button "Product Attachments" displays the Desk Combination attachments.
 
 #. Go to *Manufacturing -> Products > Products -> Desk Combination*.
-#. The smart-button "Bom Attachments" display the attachments of all components from Bill of material.
+#. The smart-button "Components Attachments" display the attachments of all components from Bill of material.
+#. The smart-button "Bom Attachments" display the attachments of all the product Bill of materials.
 
 Bug Tracker
 ===========
@@ -82,6 +85,10 @@ Contributors
 
   * Víctor Martínez
   * Pedro M. Baeza
+
+* `ForgeFlow <https://forgeflow.com>`_:
+
+  * Marina Alapont
 
 Maintainers
 ~~~~~~~~~~~

--- a/mrp_attachment_mgmt/models/mrp_bom.py
+++ b/mrp_attachment_mgmt/models/mrp_bom.py
@@ -2,6 +2,7 @@
 # Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, models
+from odoo.tools.safe_eval import safe_eval
 
 
 class MrpBom(models.Model):
@@ -31,3 +32,22 @@ class MrpBom(models.Model):
         )
         products = self.env["product.product"].search([("id", "in", product_ids)])
         return products._action_show_attachments()
+
+    def action_show_product_attachments(self):
+        if self.product_id:
+            return self.product_id._action_show_attachments()
+        return self.product_tmpl_id._action_show_attachments()
+
+    def _action_show_attachments(self):
+        """Returns the action to show the attachments linked to the bom record."""
+        domain = [
+            ("res_model", "=", "mrp.bom"),
+            ("res_id", "in", self.ids),
+        ]
+        action = self.env["ir.actions.actions"]._for_xml_id("base.action_attachment")
+        context = action.get("context", "{}")
+        context = safe_eval(context)
+        context["create"] = False
+        context["edit"] = False
+        action.update({"domain": domain, "context": context})
+        return action

--- a/mrp_attachment_mgmt/models/mrp_production.py
+++ b/mrp_attachment_mgmt/models/mrp_production.py
@@ -8,3 +8,6 @@ class MrpProduction(models.Model):
 
     def action_show_attachments(self):
         return self.product_id._action_show_attachments()
+
+    def action_show_bom_attachments(self):
+        return self.bom_id._action_show_attachments()

--- a/mrp_attachment_mgmt/models/mrp_workorder.py
+++ b/mrp_attachment_mgmt/models/mrp_workorder.py
@@ -22,3 +22,6 @@ class MrpWorkorder(models.Model):
                 % {"error_count": len(error), "error_msg": "\n".join(error)}
             )
         return self.product_id._action_show_attachments()
+
+    def action_see_workorder_bom_attachments(self):
+        return self.production_id.bom_id._action_show_attachments()

--- a/mrp_attachment_mgmt/models/product.py
+++ b/mrp_attachment_mgmt/models/product.py
@@ -10,12 +10,30 @@ class ProductTemplate(models.Model):
     def action_see_bom_documents(self):
         return fields.first(self.bom_ids).action_see_bom_documents()
 
+    def action_see_bom_attachments(self):
+        return self.bom_ids._action_show_attachments()
+
+    def _action_show_attachments(self):
+        """Returns the action to show the attachments linked to the products
+        recordset or to their templates.
+        """
+        domain = [
+            ("res_model", "=", "product.template"),
+            ("res_id", "in", self.ids),
+        ]
+        action = self.env["ir.actions.actions"]._for_xml_id("base.action_attachment")
+        action.update({"domain": domain})
+        return action
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
     def action_see_bom_documents(self):
         return fields.first(self.bom_ids).action_see_bom_documents()
+
+    def action_see_bom_attachments(self):
+        return self.bom_ids._action_show_attachments()
 
     def _action_show_attachments(self):
         """Returns the action to show the attachments linked to the products

--- a/mrp_attachment_mgmt/readme/CONTRIBUTORS.rst
+++ b/mrp_attachment_mgmt/readme/CONTRIBUTORS.rst
@@ -2,3 +2,7 @@
 
   * Víctor Martínez
   * Pedro M. Baeza
+
+* `ForgeFlow <https://forgeflow.com>`_:
+
+  * Marina Alapont

--- a/mrp_attachment_mgmt/readme/USAGE.rst
+++ b/mrp_attachment_mgmt/readme/USAGE.rst
@@ -1,10 +1,13 @@
 #. Go to *Manufacturing -> Operation > Work Orders* and click in window open button (after the "Start" and "Block" options).
-#. The smart-button "Attachments" display the attachments of the related product.
-
+#. The smart-button "Product Attachments" display the attachments of the related product.
+#. The smart-button "BoM Attachments" displays the attachments of the workorder BoM.
 
 #. Go to *Manufacturing -> Products > Bill of material -> Desk Combination*.
 #. Go to "Attachment" icon related to "Office Chair Black" component and upload some file.
-#. The smart-button "Attachments" (from Bill of material) display the attachments of all components.
+#. The smart-button "Components Attachments" (from Bill of material) display the attachments of all components.
+#. Go to the Desk Combination product and upload an attachment
+#. The smart-button "Product Attachments" displays the Desk Combination attachments.
 
 #. Go to *Manufacturing -> Products > Products -> Desk Combination*.
-#. The smart-button "Bom Attachments" display the attachments of all components from Bill of material.
+#. The smart-button "Components Attachments" display the attachments of all components from Bill of material.
+#. The smart-button "Bom Attachments" display the attachments of all the product Bill of materials.

--- a/mrp_attachment_mgmt/static/description/index.html
+++ b/mrp_attachment_mgmt/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -396,12 +397,16 @@ This module allows to get all attachments of a work orders products to produce o
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <ol class="arabic simple">
 <li>Go to <em>Manufacturing -&gt; Operation &gt; Work Orders</em> and click in window open button (after the “Start” and “Block” options).</li>
-<li>The smart-button “Attachments” display the attachments of the related product.</li>
+<li>The smart-button “Product Attachments” display the attachments of the related product.</li>
+<li>The smart-button “BoM Attachments” displays the attachments of the workorder BoM.</li>
 <li>Go to <em>Manufacturing -&gt; Products &gt; Bill of material -&gt; Desk Combination</em>.</li>
 <li>Go to “Attachment” icon related to “Office Chair Black” component and upload some file.</li>
-<li>The smart-button “Attachments” (from Bill of material) display the attachments of all components.</li>
+<li>The smart-button “Components Attachments” (from Bill of material) display the attachments of all components.</li>
+<li>Go to the Desk Combination product and upload an attachment</li>
+<li>The smart-button “Product Attachments” displays the Desk Combination attachments.</li>
 <li>Go to <em>Manufacturing -&gt; Products &gt; Products -&gt; Desk Combination</em>.</li>
-<li>The smart-button “Bom Attachments” display the attachments of all components from Bill of material.</li>
+<li>The smart-button “Components Attachments” display the attachments of all components from Bill of material.</li>
+<li>The smart-button “Bom Attachments” display the attachments of all the product Bill of materials.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -428,12 +433,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://forgeflow.com">ForgeFlow</a>:<ul>
+<li>Marina Alapont</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mrp_attachment_mgmt/tests/common.py
+++ b/mrp_attachment_mgmt/tests/common.py
@@ -91,3 +91,14 @@ class TestMrpAttachmentMgmtBase(common.TransactionCase):
                 "datas": base64.b64encode(b"\xff data"),
             }
         )
+
+    def _create_bom_attachment(self, bom, name=False):
+        name = name if name else "Test file %s" % bom.display_name
+        return self.attachment_model.create(
+            {
+                "name": name,
+                "res_model": "mrp.bom",
+                "res_id": bom.id,
+                "datas": base64.b64encode(b"\xff data"),
+            }
+        )

--- a/mrp_attachment_mgmt/tests/test_mrp_attachment_mgmt.py
+++ b/mrp_attachment_mgmt/tests/test_mrp_attachment_mgmt.py
@@ -34,7 +34,33 @@ class TestMrpAttachmentMgmt(TestMrpAttachmentMgmtBase):
         action = self.workorder.action_see_workorder_attachments()
         self.assertIn(attachment.id, self.attachment_model.search(action["domain"]).ids)
 
+        bom_attachment = self._create_bom_attachment(self.bom)
+        action = self.workorder.action_see_workorder_bom_attachments()
+        self.assertIn(
+            bom_attachment.id, self.attachment_model.search(action["domain"]).ids
+        )
+
     def test_mrp_production_attachments(self):
         attachment = self._create_attachment(self.product)
         action = self.mrp_production.action_show_attachments()
         self.assertIn(attachment.id, self.attachment_model.search(action["domain"]).ids)
+
+        bom_attachment = self._create_bom_attachment(self.bom)
+        action = self.mrp_production.action_show_bom_attachments()
+        self.assertIn(
+            bom_attachment.id, self.attachment_model.search(action["domain"]).ids
+        )
+
+    def test_mrp_bom_attachments(self):
+        product_attachment = self._create_attachment(self.product.product_tmpl_id)
+        action = self.bom.action_show_product_attachments()
+        self.assertIn(
+            product_attachment.id, self.attachment_model.search(action["domain"]).ids
+        )
+
+    def test_product_attachments(self):
+        bom_attachment = self._create_bom_attachment(self.bom)
+        action = self.product.action_see_bom_attachments()
+        self.assertIn(
+            bom_attachment.id, self.attachment_model.search(action["domain"]).ids
+        )

--- a/mrp_attachment_mgmt/views/mrp_bom_view.xml
+++ b/mrp_attachment_mgmt/views/mrp_bom_view.xml
@@ -14,8 +14,21 @@
                     name="action_see_bom_documents"
                     type="object"
                     icon="fa-files-o"
-                    string="Attachments"
-                />
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Components<br />Attachments</span>
+                    </div>
+                </button>
+                <button
+                    class="oe_stat_button"
+                    name="action_show_product_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Product<br />Attachments</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>

--- a/mrp_attachment_mgmt/views/mrp_production_views.xml
+++ b/mrp_attachment_mgmt/views/mrp_production_views.xml
@@ -11,13 +11,26 @@
                     name="action_show_attachments"
                     type="object"
                     icon="fa-files-o"
-                    string="Attachments"
-                />
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Product<br />Attachments</span>
+                    </div>
+                </button>
+                <button
+                    class="oe_stat_button"
+                    name="action_show_bom_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">BoM<br />Attachments</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>
     <record id="action_show_production_attachments" model="ir.actions.server">
-        <field name="name">Attachments</field>
+        <field name="name">Product Attachments</field>
         <field name="model_id" ref="mrp.model_mrp_production" />
         <field name="binding_model_id" ref="mrp.model_mrp_production" />
         <field name="binding_view_types">list</field>
@@ -25,6 +38,17 @@
         <field name="code">
             if records:
                 action = records.action_show_attachments()
+        </field>
+    </record>
+     <record id="action_show_production_bom_attachments" model="ir.actions.server">
+        <field name="name">BoM Attachments</field>
+        <field name="model_id" ref="mrp.model_mrp_production" />
+        <field name="binding_model_id" ref="mrp.model_mrp_production" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.action_show_bom_attachments()
         </field>
     </record>
 </odoo>

--- a/mrp_attachment_mgmt/views/product_views.xml
+++ b/mrp_attachment_mgmt/views/product_views.xml
@@ -11,10 +11,25 @@
                     name="action_see_bom_documents"
                     type="object"
                     icon="fa-files-o"
-                    string="Bom Attachments"
                     groups="mrp.group_mrp_user"
                     attrs="{'invisible': [('bom_count','!=',1)]}"
-                />
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Components<br />Attachments</span>
+                    </div>
+                </button>
+                <button
+                    class="oe_stat_button"
+                    name="action_see_bom_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                    groups="mrp.group_mrp_user"
+                    attrs="{'invisible': [('bom_count','=',0)]}"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">BoMs<br />Attachments</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>
@@ -29,10 +44,25 @@
                     name="action_see_bom_documents"
                     type="object"
                     icon="fa-files-o"
-                    string="Bom Attachments"
                     groups="mrp.group_mrp_user"
                     attrs="{'invisible': [('bom_count','!=',1)]}"
-                />
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Components<br />Attachments</span>
+                    </div>
+                </button>
+                <button
+                    class="oe_stat_button"
+                    name="action_see_bom_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                    groups="mrp.group_mrp_user"
+                    attrs="{'invisible': [('bom_count','=',0)]}"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">BoMs<br />Attachments</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>

--- a/mrp_attachment_mgmt/views/workorder_attachments_views.xml
+++ b/mrp_attachment_mgmt/views/workorder_attachments_views.xml
@@ -11,13 +11,26 @@
                     name="action_see_workorder_attachments"
                     type="object"
                     icon="fa-files-o"
-                    string="Attachments"
-                />
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Product<br />Attachments</span>
+                    </div>
+                </button>
+                <button
+                    class="oe_stat_button"
+                    name="action_see_workorder_bom_attachments"
+                    type="object"
+                    icon="fa-files-o"
+                >
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">BoM<br />Attachments</span>
+                    </div>
+                </button>
             </xpath>
         </field>
     </record>
     <record id="action_see_workorder_attachments" model="ir.actions.server">
-        <field name="name">Attachments</field>
+        <field name="name">Product Attachments</field>
         <field name="model_id" ref="model_mrp_workorder" />
         <field name="binding_model_id" ref="model_mrp_workorder" />
         <field name="binding_view_types">list</field>
@@ -25,6 +38,17 @@
         <field name="code">
             if records:
                 action = records.action_see_workorder_attachments()
+        </field>
+    </record>
+    <record id="action_see_workorder_bom_attachments" model="ir.actions.server">
+        <field name="name">BoM Attachments</field>
+        <field name="model_id" ref="model_mrp_workorder" />
+        <field name="binding_model_id" ref="model_mrp_workorder" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            if records:
+                action = records.action_see_workorder_bom_attachments()
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Currently the module is managing the attachments by making the product attachments accessible in different  mrp views. With this PR the same is done with the BoM attachments.

This can be useful in scenarios where you have a product with multiple bill of materials, and the product has common drawings but also each BoM has specific drawings and documents. Therefore, you may want to have accessible in the different mrp views both, the common product attachments and the BoM specific attachments.

Also the naming of the already existing smart-buttons has been updated, to better differentiate the two buttons in each view.

