### PR TITLE
[16.0][IMP]quality_control_stock_oca: adding default_object_id on context

### DIFF
--- a/quality_control_stock_oca/__manifest__.py
+++ b/quality_control_stock_oca/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Quality control - Stock (OCA)",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Quality control",
     "license": "AGPL-3",
     "author": "OdooMRP team, AvanzOSC, Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/quality_control_stock_oca/views/stock_picking_view.xml
+++ b/quality_control_stock_oca/views/stock_picking_view.xml
@@ -7,6 +7,9 @@
         <field name="res_model">qc.inspection</field>
         <field name="view_mode">tree,form</field>
         <field name="domain">[('picking_id', '=', active_id)]</field>
+        <field
+            name="context"
+        >{'default_object_id': 'stock.picking,' + active_id}</field>
     </record>
     <record id="action_qc_inspection_per_picking_done" model="ir.actions.act_window">
         <field name="name">Quality inspection from picking done</field>
@@ -15,6 +18,9 @@
         <field
             name="domain"
         >[('picking_id', '=', active_id), ('state', 'not in', ['draft', 'waiting'])]</field>
+        <field
+            name="context"
+        >{'default_object_id': 'stock.picking,' + active_id}</field>
     </record>
     <record id="action_qc_inspection_per_picking_passed" model="ir.actions.act_window">
         <field name="name">Quality inspection from picking passed</field>
@@ -23,6 +29,9 @@
         <field
             name="domain"
         >[('picking_id', '=', active_id), ('state', '=', 'success')]</field>
+        <field
+            name="context"
+        >{'default_object_id': 'stock.picking,' + active_id}</field>
     </record>
     <record id="action_qc_inspection_per_picking_failed" model="ir.actions.act_window">
         <field name="name">Quality inspections from picking failed</field>
@@ -31,6 +40,9 @@
         <field
             name="domain"
         >[('picking_id', '=', active_id), ('state', '=', 'failed')]</field>
+        <field
+            name="context"
+        >{'default_object_id': 'stock.picking,' + active_id}</field>
     </record>
     <record model="ir.ui.view" id="stock_picking_qc_view">
         <field name="name">stock.picking.qc.view</field>


### PR DESCRIPTION
Good morning, I suggest this change as it makes it easier to create a quality control from the delivery order since it will pass the object reference by default.