### PR TITLE
[17.0][FIX] mrp_production_serial_matrix: increase line_ids limit

### DIFF
--- a/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix_view.xml
+++ b/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix_view.xml
@@ -91,7 +91,7 @@
                         options='{"no_create": True, "no_open": True}'
                         colspan="2"
                     >
-                        <tree editable="True" nolabel="1" create="false">
+                        <tree editable="True" nolabel="1" create="false" limit="1000">
                             <field name="component_column_name" />
                             <field name="finished_lot_name" />
                             <field name="component_lot_id" />


### PR DESCRIPTION
When generating a matrix with more than 20 finished_lot_ids, only the first 20 were displayed. 

As we can see we select 30 finished_lot_ids
![Screenshot from 2025-03-27 16-05-57](https://github.com/user-attachments/assets/35b89e4d-8e9a-4ede-b9dd-5e0f5a16b55e)

And only the first 20 lots are displayed
![Screenshot from 2025-03-27 16-06-30](https://github.com/user-attachments/assets/288f9827-bd3a-4e2b-a99a-2fb73d32efcf)
