### PR TITLE
[17.0][FIX] mrp_production_serial_matrix

### DIFF
--- a/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix.py
@@ -250,6 +250,8 @@ class MrpProductionSerialMatrix(models.TransientModel):
                     if matrix_lines:
                         self._amend_reservations(move, matrix_lines)
                         self._consume_selected_lots(move, matrix_lines)
+                elif move.quantity > 0:
+                    move.picked = True
 
             # Complete MO and create backorder if needed.
             mos += current_mo


### PR DESCRIPTION
The consumed field was being left as false in the non lot lines, causing it to show a different popup than backorder breaking the chain.