### PR TITLE
[16.0][IMP] mrp_unbuild_restore_origin

### DIFF
--- a/mrp_unbuild_restore_origin/models/mrp_unbuild.py
+++ b/mrp_unbuild_restore_origin/models/mrp_unbuild.py
@@ -8,9 +8,9 @@ class MrpUnbuild(models.Model):
     _inherit = "mrp.unbuild"
 
     restore_rm_stock_in_origin_loc = fields.Boolean(
-        string="Restore Raw Materials to Consumed Location",
-        help="If enabled, the source location of the component stock move lines will be used"
-        " as the destination location for the unbuild move lines.",
+        string="Return Components to Original Location",
+        help="If selected, components will be returned to the same location"
+        " they were taken from during manufacturing.",
     )
 
     def action_unbuild(self):

--- a/mrp_unbuild_restore_origin/views/mrp_unbuild_views.xml
+++ b/mrp_unbuild_restore_origin/views/mrp_unbuild_views.xml
@@ -5,11 +5,16 @@
         <field name="model">mrp.unbuild</field>
         <field name="inherit_id" ref="mrp.mrp_unbuild_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='mo_id']" position="after">
+            <xpath expr="//field[@name='location_dest_id']" position="before">
                 <field
                     name="restore_rm_stock_in_origin_loc"
                     attrs="{'invisible': [('mo_id', '=', False)]}"
                 />
+            </xpath>
+            <xpath expr="//field[@name='location_dest_id']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('restore_rm_stock_in_origin_loc', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>
@@ -18,11 +23,16 @@
         <field name="model">mrp.unbuild</field>
         <field name="inherit_id" ref="mrp.mrp_unbuild_form_view_simplified" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='mo_id']" position="after">
+            <xpath expr="//field[@name='location_dest_id']" position="before">
                 <field
                     name="restore_rm_stock_in_origin_loc"
                     attrs="{'invisible': [('mo_id', '=', False)]}"
                 />
+            </xpath>
+            <xpath expr="//field[@name='location_dest_id']" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('restore_rm_stock_in_origin_loc', '=', True)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- Clarified help text for restore_rm_stock_in_origin_loc
- Hide location_dest_id when restore_rm_stock_in_origin_loc is enabled

@qrtl
QT5275