### PR TITLE
[18.0][IMP] mrp_multi_level: consider location_final_id

### DIFF
--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -275,7 +275,9 @@ class ProductMRPArea(models.Model):
             ("product_qty", ">", 0.00),
             "!",
             ("location_id", "child_of", locations.ids),
+            "|",
             ("location_dest_id", "child_of", locations.ids),
+            ("location_final_id", "child_of", locations.ids),
         ]
 
     def _out_stock_moves_domain(self):
@@ -286,8 +288,11 @@ class ProductMRPArea(models.Model):
             ("state", "not in", ["done", "cancel"]),
             ("product_qty", ">", 0.00),
             ("location_id", "child_of", locations.ids),
+            "|",
             "!",
             ("location_dest_id", "child_of", locations.ids),
+            "!",
+            ("location_final_id", "child_of", locations.ids),
         ]
 
     def action_view_stock_moves(self, domain):

--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -267,6 +267,20 @@ class TestMrpMultiLevelCommon(TransactionCase):
                 "location_id": cls.stock_location.id,
             }
         )
+        # Product to test multi-step routes
+        cls.product_routes = cls.product_obj.create(
+            {
+                "name": "Product Multi-step Routes",
+                "is_storable": True,
+                "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                "list_price": 100.0,
+                "route_ids": [(6, 0, [route_buy])],
+                "seller_ids": [(0, 0, {"partner_id": vendor1.id, "price": 35.0})],
+            }
+        )
+        cls.product_mrp_area_obj.create(
+            {"product_id": cls.product_routes.id, "mrp_area_id": cls.mrp_area.id}
+        )
 
         # Product MRP Parameter to test supply method computation
         cls.env.ref("stock.route_warehouse0_mto").active = True
@@ -654,3 +668,27 @@ class TestMrpMultiLevelCommon(TransactionCase):
         # Confirm the MO to generate stock moves:
         mo.action_confirm()
         return mo
+
+    @classmethod
+    def _run_procurement(
+        cls, product, location=None, product_qty=10.0, extra_values=None
+    ):
+        if not location:
+            location = cls.customer_location
+        values = {"warehouse_id": cls.wh}
+        if extra_values and isinstance(extra_values, dict):
+            values.update(extra_values)
+        return cls.env["procurement.group"].run(
+            [
+                cls.env["procurement.group"].Procurement(
+                    product,
+                    product_qty,
+                    product.uom_id,
+                    location,
+                    product.name,
+                    "/",
+                    cls.env.company,
+                    values,
+                )
+            ]
+        )

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -918,3 +918,67 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
             .create({})
         )
         self.assertEqual(len(procure_wizard.item_ids), 0)
+
+    def test_25_multi_step_routes(self):
+        """Test that deliveries and receipts in several steps are
+        correctly considered."""
+        # Enable 3 step routes
+        self.wh.write(
+            {
+                "delivery_steps": "pick_pack_ship",
+                "reception_steps": "three_steps",
+            }
+        )
+        # Create delivery first step
+        self._run_procurement(self.product_routes)
+        move = self.env["stock.move"].search(
+            [("product_id", "=", self.product_routes.id)]
+        )
+        self.assertEqual(len(move), 1)
+        self.assertEqual(move.location_dest_id, self.wh.wh_pack_stock_loc_id)
+        self.assertEqual(move.location_final_id, self.customer_location)
+        # create incoming first step
+        self._run_procurement(self.product_routes, location=self.wh.lot_stock_id)
+        pol = self.env["purchase.order.line"].search(
+            [("product_id", "=", self.product_routes.id)]
+        )
+        pol.order_id.button_confirm()
+        move = self.env["stock.move"].search(
+            [
+                ("product_id", "=", self.product_routes.id),
+                ("location_id.usage", "!=", "internal"),
+            ]
+        )
+        self.assertEqual(len(move), 1)
+        self.assertEqual(move.location_dest_id, self.wh.wh_input_stock_loc_id)
+        self.assertEqual(move.location_final_id, self.wh.lot_stock_id)
+        # Execute MRP and check result
+        self.mrp_multi_level_wiz.create(
+            {"mrp_area_ids": [(6, 0, self.mrp_area.ids)]}
+        ).run_mrp_multi_level()
+        inventory = self.mrp_inventory_obj.search(
+            [
+                ("mrp_area_id", "=", self.mrp_area.id),
+                ("product_id", "=", self.product_routes.id),
+            ]
+        )
+        self.assertEqual(len(inventory), 1)
+        self.assertEqual(inventory.demand_qty, 10.0)
+        self.assertEqual(inventory.supply_qty, 10.0)
+        # Change area location to include intermediate locations.
+        # A planned operation from WH/stock to WH/Packing Zone should
+        # still be considered demand if the final destination is out of
+        # the area (case of standard deliver in 3-step route).
+        self.mrp_area.location_id = self.wh.view_location_id
+        self.mrp_multi_level_wiz.create(
+            {"mrp_area_ids": [(6, 0, self.mrp_area.ids)]}
+        ).run_mrp_multi_level()
+        inventory = self.mrp_inventory_obj.search(
+            [
+                ("mrp_area_id", "=", self.mrp_area.id),
+                ("product_id", "=", self.product_routes.id),
+            ]
+        )
+        self.assertEqual(len(inventory), 1)
+        self.assertEqual(inventory.demand_qty, 10.0)
+        self.assertEqual(inventory.supply_qty, 10.0)


### PR DESCRIPTION
Since v18, routes in several steps can be configured to delay the creation of next steps. This is the case for standard multi step routes for incoming and outgoing.