### PR TITLE
[16.0][FIX] mrp_bom_tracking: catch UoM qty mrp_bom_tracking rounding errors

### DIFF
--- a/mrp_bom_tracking/models/mrp_bom.py
+++ b/mrp_bom_tracking/models/mrp_bom.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from odoo import fields, models
+from odoo.tools import float_compare
 
 
 class MrpBom(models.Model):
@@ -56,7 +57,7 @@ class MrpBomLine(models.Model):
                 if product_id:
                     product_id = self.env["product.product"].browse(product_id)
                 product_id = product_id or lines.product_id
-                if lines:
+                if lines and product_id != lines.product_id:
                     bom.message_post_with_view(
                         "mrp_bom_tracking.track_bom_template_2",
                         values={"lines": lines, "product_id": product_id},
@@ -70,6 +71,18 @@ class MrpBomLine(models.Model):
                     product_uom_id = values.get("product_uom_id")
                     if product_uom_id:
                         product_uom_id = self.env["uom.uom"].browse(product_uom_id)
+                    # Catch and discard float write rounding errors
+                    # when the qty has not even changed
+                    if (
+                        float_compare(
+                            product_qty,
+                            lines.product_qty,
+                            precision_rounding=lines.product_uom_id.rounding,
+                        )
+                        == 0
+                        and not product_uom_id
+                    ):
+                        continue
                     product_uom_id = product_uom_id or lines.product_uom_id
                     bom.message_post_with_view(
                         "mrp_bom_tracking.track_bom_line_template",

--- a/mrp_bom_tracking/tests/test_mrp_bom_tracking.py
+++ b/mrp_bom_tracking/tests/test_mrp_bom_tracking.py
@@ -57,3 +57,10 @@ class TestBomTracking(TransactionCase):
         after = self.bom.message_ids
         self.assertEqual(len(after - before), 1)
         self.line_2.write({"product_uom_id": 2})
+
+    def test_03_change_bom_line_qty_rounding(self):
+        self.line_2.write({"product_qty": 2})
+        before = self.bom.message_ids
+        self.line_2.write({"product_qty": 2.0000000000001})
+        after = self.bom.message_ids
+        self.assertEqual(len(after - before), 0)


### PR DESCRIPTION
Avoid this:

![image](https://github.com/user-attachments/assets/8a154f45-e128-4d2c-9d60-8fe4ae3d9811)

and this:

![image](https://github.com/user-attachments/assets/956187ca-d36f-4585-b03c-918db21de73f)
