### PR TITLE
[16.0][FIX] mrp_stock_owner_restriction: AttributeError

### DIFF
--- a/mrp_stock_owner_restriction/models/mrp_production.py
+++ b/mrp_stock_owner_restriction/models/mrp_production.py
@@ -16,13 +16,3 @@ class MrpProduction(models.Model):
         help="Produced products will be assigned to this owner.",
     )
     owner_restriction = fields.Selection(related="picking_type_id.owner_restriction")
-
-    def write(self, vals):
-        if "owner_id" in vals:
-            for production in self:
-                if production.owner_restriction in (
-                    "unassigned_owner",
-                    "picking_partner",
-                ):
-                    production.move_line_raw_ids.unlink()
-        return super().write(vals)


### PR DESCRIPTION
'mrp.production' object has no attribute 'move_line_raw_ids'

Fixes: #1522
