### PR TITLE
[16.0][IMP][quality_control_oca] avoid test question without value

### DIFF
--- a/quality_control_oca/models/qc_test.py
+++ b/quality_control_oca/models/qc_test.py
@@ -49,6 +49,19 @@ class QcTest(models.Model):
         default=lambda self: self.env.company,
     )
 
+    @api.constrains("test_lines")
+    def _check_valid_questions(self):
+        for tc in self:
+            for line in tc.test_lines.filtered(lambda l: l.type == "qualitative"):
+                if not line.ql_values:
+                    raise exceptions.ValidationError(
+                        _(
+                            "Question '%s' is not valid: "
+                            "you have to define at least one possible value."
+                        )
+                        % line.name_get()[0][1]
+                    )
+
 
 class QcTestQuestion(models.Model):
     """Each test line is a question with its valid value(s)."""


### PR DESCRIPTION
Since an inspection cannot be confirmed if a test has no answer/value, we must ensure that each test includes at least one answer.