### PR TITLE
[17.0][FIX] mrp_bom_attribute_match

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_bom.py
+++ b/mrp_bom_attribute_match/models/mrp_bom.py
@@ -27,7 +27,24 @@ class MrpBomLine(models.Model):
         "uom.category",
         related=None,
         compute="_compute_product_uom_category_id",
+        compute_sudo=True,
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for values in vals_list:
+            if (
+                not values.get("product_id")
+                and "product_uom_id" not in values
+                and "component_template_id" in values
+                and values["component_template_id"]
+            ):
+                values["product_uom_id"] = (
+                    self.env["product.template"]
+                    .browse(values["component_template_id"])
+                    .uom_id.id
+                )
+        return super().create(vals_list)
 
     @api.depends("product_id", "component_template_id")
     def _compute_product_uom_category_id(self):


### PR DESCRIPTION
If a user tries to create a BOM and is not part of the **"Manage Multiple Units of Measure"** group, the **UoM** (Unit of Measure) option does not appear next to the **"Quantity"** field on the form. When they try to save the new BOM, the validation error from the screenshot pops up. This happens because when the **"product_uom_category_id"** field is overwritten, the **"_compute_product_uom_category_id()"** function attempts to modify the UoM based on the **"Product Template"** or **"Product Variant"**. However, the user in the current session does not have the permissions to modify this field, which triggers the error. The fact that the user is not in this group doesn't prevent them from being able to create a BOM.

<img width="1241" height="644" alt="Captura desde 2025-08-05 15-14-35" src="https://github.com/user-attachments/assets/d731d66c-7b43-4b58-bc0f-5b7a5bf85d73" />

<img width="1300" height="662" alt="image" src="https://github.com/user-attachments/assets/dd5aae3f-ef41-4c80-8b05-0048801dc4ec" />

<img width="1517" height="560" alt="image" src="https://github.com/user-attachments/assets/0fed5fe8-ecaa-4b76-bdc6-07e0bbb40fcc" />
