### PR TITLE
[16.0][IMP] mrp_workorder_last_worker: make field storable

### DIFF
--- a/mrp_workorder_last_worker/models/mrp_workorder.py
+++ b/mrp_workorder_last_worker/models/mrp_workorder.py
@@ -10,6 +10,7 @@ class MrpWorkorder(models.Model):
     last_worker_id = fields.Many2one(
         comodel_name="res.users",
         compute="_compute_last_worker_id",
+        store=True,
     )
 
     @api.depends("time_ids.date_start", "time_ids.user_id")


### PR DESCRIPTION
Make field store=True so that workorders can be filtered and grouped by the last person that worked on them