### PR TITLE
[16.0][FIX] mrp_bom_hierarchy: bom lines read permission

### DIFF
--- a/mrp_bom_hierarchy/model/mrp_bom_line.py
+++ b/mrp_bom_hierarchy/model/mrp_bom_line.py
@@ -12,6 +12,7 @@ class MrpBomLine(models.Model):
     has_bom = fields.Boolean(
         string="Has sub BoM",
         compute="_compute_has_bom",
+        compute_sudo=True,
     )
 
     @api.depends("product_id", "bom_id")


### PR DESCRIPTION
FIX: #1488 w/ proposed solution

This fix uses sudo() in _compute_has_bom to bypass the access rights issue.
While it solves the problem, it is not the best approach as it elevates permissions more than strictly required.

A safer long-term solution would be to restrict access to the specific fields needed or explicitly check read permissions on mrp.bom.line

