### PR TITLE
[16.0][IMP] mrp_multi_level: add RfQ quantity and button to check RfQs

### DIFF
--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -48,6 +48,12 @@ class MrpInventory(models.Model):
     date = fields.Date()
     demand_qty = fields.Float(string="Demand")
     supply_qty = fields.Float(string="Supply")
+    rfq_qty = fields.Float(
+        string="RfQ",
+        help="Quantity on Request for Quotation.\n"
+        "This quantity is included in the supply quantity "
+        "but it is not confirmed yet.",
+    )
     initial_on_hand_qty = fields.Float(
         string="Starting Inventory", group_operator="avg"
     )
@@ -137,3 +143,29 @@ class MrpInventory(models.Model):
             "view_mode": "tree,form",
             "domain": domain,
         }
+
+    def action_open_rfqs(self):
+        self.ensure_one()
+        result = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_rfq")
+        rfq_move_domain = [
+            ("mrp_type", "=", "s"),
+            ("mrp_origin", "=", "po"),
+            ("purchase_order_id.state", "in", ["draft", "sent", "to approve"]),
+        ]
+        moves = self.product_mrp_area_id.mrp_move_ids.filtered_domain(rfq_move_domain)
+        if self.date == date.today():
+            moves = moves.filtered(
+                lambda m: m.purchase_line_id.date_planned.date() in [self.date, False]
+            )
+        else:
+            moves = moves.filtered(
+                lambda m: m.purchase_line_id.date_planned.date() == self.date
+            )
+        records = moves.mapped("purchase_order_id")
+        if len(records) != 1:
+            result["domain"] = [("id", "in", records.ids)]
+        else:
+            res = self.env.ref("purchase.purchase_order_form", False)
+            result["views"] = [(res and res.id or False, "form")]
+            result["res_id"] = records[0].id
+        return result

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -393,7 +393,11 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
         )
         self.assertEqual(len(prod_uom_test_inventory_lines), 1)
         self.assertEqual(prod_uom_test_inventory_lines.supply_qty, 12.0)
-        # Supply qty has to be 12 has a dozen of units are in a RFQ.
+        # Supply qty has to be 12, a dozen of units are in a RFQ.
+        self.assertEqual(prod_uom_test_inventory_lines.rfq_qty, 12.0)
+        # check that the action opens the correct RfQ:
+        res = prod_uom_test_inventory_lines.action_open_rfqs()
+        self.assertEqual(res["res_id"], self.po_uom.id)
 
     def test_16_phantom_comp_planning(self):
         """

--- a/mrp_multi_level/views/mrp_inventory_views.xml
+++ b/mrp_multi_level/views/mrp_inventory_views.xml
@@ -27,6 +27,7 @@
                             <field name="initial_on_hand_qty" />
                             <field name="demand_qty" />
                             <field name="supply_qty" />
+                            <field name="rfq_qty" />
                             <field name="final_on_hand_qty" />
                             <field name="to_procure" />
                             <field name="uom_id" groups="uom.group_uom" />
@@ -50,6 +51,14 @@
                 <field name="initial_on_hand_qty" />
                 <field name="demand_qty" />
                 <field name="supply_qty" />
+                <field name="rfq_qty" optional="hide" />
+                <button
+                    attrs="{'invisible': [('rfq_qty', '&lt;=', 0.0)]}"
+                    name="action_open_rfqs"
+                    type="object"
+                    icon="fa-credit-card"
+                    title="Requests for Quotation"
+                />
                 <field name="final_on_hand_qty" />
                 <field name="to_procure" />
                 <button

--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -787,6 +787,19 @@ class MultiLevelMrp(models.TransientModel):
         return query, params
 
     @api.model
+    def _get_rfq_supply_groups(self, product_mrp_area):
+        query = """
+                SELECT mrp_date, sum(mrp_qty)
+                FROM mrp_move
+                WHERE product_mrp_area_id = %(mrp_product)s
+                AND mrp_type = 's' AND mrp_origin = 'po'
+                AND state in ('draft', 'sent', 'to approve')
+                GROUP BY mrp_date
+            """
+        params = {"mrp_product": product_mrp_area.id}
+        return query, params
+
+    @api.model
     def _get_planned_order_groups(self, product_mrp_area):
         query = """
             SELECT due_date, sum(mrp_qty)
@@ -807,6 +820,7 @@ class MultiLevelMrp(models.TransientModel):
         demand_qty_by_date,
         supply_qty_by_date,
         planned_qty_by_date,
+        rfq_supply_qty_by_date,
     ):
         """Return dict to create mrp.inventory records on MRP Multi Level Scheduler"""
         mrp_inventory_data = {"product_mrp_area_id": product_mrp_area.id, "date": mdt}
@@ -814,6 +828,8 @@ class MultiLevelMrp(models.TransientModel):
         mrp_inventory_data["demand_qty"] = abs(demand_qty)
         supply_qty = supply_qty_by_date.get(mdt, 0.0)
         mrp_inventory_data["supply_qty"] = abs(supply_qty)
+        rfq_supply_qty = rfq_supply_qty_by_date.get(mdt, 0.0)
+        mrp_inventory_data["rfq_qty"] = abs(rfq_supply_qty)
         mrp_inventory_data["initial_on_hand_qty"] = on_hand_qty
         if product_mrp_area.supply_method != "phantom":
             on_hand_qty += supply_qty + demand_qty
@@ -841,6 +857,12 @@ class MultiLevelMrp(models.TransientModel):
         self.env.cr.execute(query, params)
         for mrp_date, qty in self.env.cr.fetchall():
             supply_qty_by_date[mrp_date] = qty
+        # Read RFQ Supply:
+        rfq_supply_qty_by_date = {}
+        query, params = self._get_rfq_supply_groups(product_mrp_area)
+        self.env.cr.execute(query, params)
+        for mrp_date, qty in self.env.cr.fetchall():
+            rfq_supply_qty_by_date[mrp_date] = qty
         # Read planned orders:
         planned_qty_by_date = {}
         query, params = self._get_planned_order_groups(product_mrp_area)
@@ -875,6 +897,7 @@ class MultiLevelMrp(models.TransientModel):
                 demand_qty_by_date,
                 supply_qty_by_date,
                 planned_qty_by_date,
+                rfq_supply_qty_by_date,
             )
             mrp_inventory_vals.append(mrp_inventory_data)
         if mrp_inventory_vals:


### PR DESCRIPTION
It is useful to know that the supply quantity might not be confirmed yet directly from the MRP inventory screen.