### PR TITLE
[18.0][FIX] quality_control_oca: invisible column is not used

### DIFF
--- a/quality_control_oca/views/qc_inspection_view.xml
+++ b/quality_control_oca/views/qc_inspection_view.xml
@@ -134,9 +134,12 @@
                                         column_invisible="1"
                                         readonly="1"
                                     />
-                                    <field name="test_uom_category" invisible="1" />
-                                    <field name="min_value" invisible="1" />
-                                    <field name="max_value" invisible="1" />
+                                    <field
+                                        name="test_uom_category"
+                                        column_invisible="1"
+                                    />
+                                    <field name="min_value" column_invisible="1" />
+                                    <field name="max_value" column_invisible="1" />
                                     <field name="valid_values" optional="show" />
                                     <field name="success" />
                                 </list>


### PR DESCRIPTION
Invisible column is not used
<img width="1956" height="1059" alt="Selection_002" src="https://github.com/user-attachments/assets/e1b028e8-2905-44da-9e6e-65029082718b" />
