### PR TITLE
[18.0][FIX] mrp_bom_attribute_match: Error when use Compute Price from BOM on Product use Attribute Match on BOM Lines

### DIFF
--- a/mrp_bom_attribute_match/models/product.py
+++ b/mrp_bom_attribute_match/models/product.py
@@ -1,4 +1,4 @@
-from odoo import _, api, models
+from odoo import Command, _, api, models
 from odoo.exceptions import UserError
 
 
@@ -65,3 +65,34 @@ class ProductTemplate(models.Model):
         if bom_lines:
             return bom_lines.mapped("bom_id")
         return False
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _compute_bom_price(self, bom, boms_to_recompute=False, byproduct_bom=False):
+        self.ensure_one()
+        # OVERRIDE to fill in the `line.product_id` if a component template is used.
+        # To avoid a complete override, we HACK the bom by replacing it with a virtual
+        # record, and modifying it's lines on-the-fly.
+        has_template_lines = any(
+            line.component_template_id for line in bom.bom_line_ids
+        )
+        product = self
+        if has_template_lines:
+            bom = bom.new(origin=bom)
+            to_ignore_line_ids = []
+            for line in bom.bom_line_ids:
+                if line._skip_bom_line(product) or not line.component_template_id:
+                    continue
+                line_product = bom._get_component_template_product(
+                    line, product, line.product_id
+                )
+                if not line_product:
+                    to_ignore_line_ids.append(line.id)
+                    continue
+                else:
+                    line.product_id = line_product
+            if to_ignore_line_ids:
+                bom.bom_line_ids = [Command.unlink(id) for id in to_ignore_line_ids]
+        return super()._compute_bom_price(bom, boms_to_recompute, byproduct_bom)


### PR DESCRIPTION
Odoo's "Compute Price from BOM" button on the product template expects a concrete product variant (product.product) on the BOM line to retrieve the Unit of Measure (uom_id).

When BOM Attribute Match is used, a user selects a product template (product.template) instead of a specific variant. This leads to an error because the BOM line's product_id field is not populated, causing the system to fail when trying to compute the price.

