### PR TITLE
[18.0][FIX] mrp_bom_attribute_match: Error when use Compute Price from BOM on Product use Attribute Match on BOM Lines

### DIFF
--- a/mrp_bom_attribute_match/models/product.py
+++ b/mrp_bom_attribute_match/models/product.py
@@ -1,4 +1,4 @@
-from odoo import _, api, models
+from odoo import Command, _, api, models
 from odoo.exceptions import UserError
 
 
@@ -65,3 +65,33 @@ class ProductTemplate(models.Model):
         if bom_lines:
             return bom_lines.mapped("bom_id")
         return False
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _compute_bom_price(self, bom, boms_to_recompute=False, byproduct_bom=False):
+        self.ensure_one()
+        # OVERRIDE to fill in the `line.product_id` if a component template is used.
+        # To avoid a complete override, we HACK the bom by replacing it with a virtual
+        # record, and modifying it's lines on-the-fly.
+        has_template_lines = any(
+            line.component_template_id for line in bom.bom_line_ids
+        )
+        if has_template_lines:
+            bom = bom.new(origin=bom)
+            to_ignore_line_ids = []
+            for line in bom.bom_line_ids:
+                if line._skip_bom_line(self) or not line.component_template_id:
+                    continue
+                line_product = bom._get_component_template_product(
+                    line, self, line.product_id
+                )
+                if not line_product:
+                    to_ignore_line_ids.append(line.id)
+                    continue
+                else:
+                    line.product_id = line_product
+            if to_ignore_line_ids:
+                bom.bom_line_ids = [Command.unlink(id) for id in to_ignore_line_ids]
+        return super()._compute_bom_price(bom, boms_to_recompute, byproduct_bom)

--- a/mrp_bom_attribute_match/tests/test_mrp_bom_attribute_match.py
+++ b/mrp_bom_attribute_match/tests/test_mrp_bom_attribute_match.py
@@ -196,3 +196,71 @@ class TestMrpBomAttributeMatch(TestMrpBomAttributeMatchBase):
             res["lines"]["components"][0]["parent_id"],
             self.bom_id.id,
         )
+
+    def test_compute_bom_price_with_component_template_matching(self):
+        sword_cyan = self.product_sword.product_variant_ids.filtered(
+            lambda v: "Cyan" in v.display_name
+        )
+        self.assertTrue(sword_cyan, "Cyan sword variant should exist")
+
+        # Set standard prices for components to make calculation predictable
+        plastic_cyan = self.product_plastic.product_variant_ids.filtered(
+            lambda v: "Cyan" in v.display_name
+        )
+        self.assertTrue(plastic_cyan, "Cyan plastic variant should exist")
+        plastic_cyan.standard_price = 10.0
+        self.product_9.standard_price = 5.0
+
+        # Calculate BOM price for cyan sword
+        bom_price = sword_cyan._compute_bom_price(self.bom_id)
+
+        # Expected price should be:
+        # - 1 * 10.0 (plastic component with matching attribute)
+        # - 1 * 5.0 (regular component without template)
+        expected_price = 15.0
+        self.assertEqual(
+            bom_price,
+            expected_price,
+            f"BOM price should be {expected_price}, got {bom_price}",
+        )
+
+    def test_compute_bom_price_line_product_none(self):
+        # Create component with same attribute as sword but different values
+        # This will pass the attribute check but fail the combination check
+        component = self.env["product.template"].create(
+            {
+                "name": "Test Component",
+                "is_storable": True,
+            }
+        )
+
+        # Create a new attribute value that doesn't exist in sword
+        red_value = self.env["product.attribute.value"].create(
+            {"name": "Red", "attribute_id": self.product_attribute.id}
+        )
+
+        # Add the same attribute (Colour) to component but with Red value only
+        self.env["product.template.attribute.line"].create(
+            {
+                "attribute_id": self.product_attribute.id,
+                "product_tmpl_id": component.id,
+                "value_ids": [Command.set([red_value.id])],
+            }
+        )
+
+        # Create BOM with this component
+        test_bom = self._create_bom(
+            self.product_sword,
+            [dict(component_template_id=component.id, product_qty=1)],
+        )
+
+        # Use cyan sword variant - this has Cyan attribute value
+        sword_variant = self.product_sword.product_variant_ids.filtered(
+            lambda v: "Cyan" in v.display_name
+        )[0]
+
+        # This should trigger len(combination) == 0 and return False
+        bom_price = sword_variant._compute_bom_price(test_bom)
+
+        # BOM price should be 0 since the component line is ignored
+        self.assertEqual(bom_price, 0.0)


### PR DESCRIPTION
Odoo's "Compute Price from BOM" button on the product template expects a concrete product variant (product.product) on the BOM line to retrieve the Unit of Measure (uom_id).

When BOM Attribute Match is used, a user selects a product template (product.template) instead of a specific variant. This leads to an error because the BOM line's product_id field is not populated, causing the system to fail when trying to compute the price.


**Reproduce:**
1/ Create a BOM Attribute Match for Test 1
<img width="1252" height="583" alt="image" src="https://github.com/user-attachments/assets/4a8fb1a4-3db9-4990-b0fb-1918d365f6e8" />

2/ Go to Product Variant of Test 1 -> Click on Compute Price from BOM
<img width="1544" height="931" alt="image" src="https://github.com/user-attachments/assets/a5c1269c-7527-4624-8e47-e55e7120b1bd" />

**Full error message:**
Traceback (most recent call last):
  File "/opt/odoo/odoo/models.py", line 6268, in ensure_one
    _id, = self._ids
ValueError: not enough values to unpack (expected 1, got 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 2144, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/opt/odoo/odoo/service/model.py", line 156, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 2111, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 2359, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 42, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "/opt/odoo/addons/mrp_account/models/product.py", line 37, in button_bom_cost
    self._set_price_from_bom()
  File "/opt/odoo/addons/mrp_account/models/product.py", line 48, in _set_price_from_bom
    self.standard_price = self._compute_bom_price(bom, boms_to_recompute=boms_to_recompute)
  File "/opt/odoo/addons/mrp_subcontracting_account/models/product_product.py", line 12, in _compute_bom_price
    price = super()._compute_bom_price(bom, boms_to_recompute, byproduct_bom)
  File "/opt/odoo/addons/mrp_account/models/product.py", line 105, in _compute_bom_price
    total += line.product_id.uom_id._compute_price(line.product_id.standard_price, line.product_uom_id) * line.product_qty
  File "/opt/odoo/addons/uom/models/uom_uom.py", line 244, in _compute_price
    self.ensure_one()
  File "/opt/odoo/odoo/models.py", line 6271, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: uom.uom()