### PR TITLE
18.0 FIX mrp_bom_section_and_note: consu instead of product in ctx

### DIFF
--- a/mrp_bom_widget_section_and_note_one2many/views/view_mrp_bom.xml
+++ b/mrp_bom_widget_section_and_note_one2many/views/view_mrp_bom.xml
@@ -45,10 +45,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                 name="product_id"
                                 required="not display_type"
                                 invisible="display_type"
-                                context="{
-                              'default_type': 'product',
-                              'default_detailed_type': 'product'
-                            }"
+                                context="{'default_type': 'consu'}"
                             />
                             <field
                                 name="name"


### PR DESCRIPTION
"product" no more exist as product type entry

default_detailed_type field no more exist in 18