### PR TITLE
[17.0][IMP] mrp_component_operation_scrap_reason: scrap reason in the vals

### DIFF
--- a/mrp_component_operation_scrap_reason/wizards/mrp_component_operate.py
+++ b/mrp_component_operation_scrap_reason/wizards/mrp_component_operate.py
@@ -31,7 +31,9 @@ class MrpComponentOperate(models.Model):
                 )
             rec.allowed_reason_code_ids = codes
 
-    def _create_scrap(self):
-        scrap = super()._create_scrap()
-        scrap.reason_code_id = self.scrap_reason_code_id
-        return scrap
+    def _create_scrap_vals(self):
+        return {
+            **super()._create_scrap_vals(),
+            # As scrap reason is required, we do not need to check if it is set
+            **{"reason_code_id": self.scrap_reason_code_id.id},
+        }


### PR DESCRIPTION
In some scenarios we could be adding a constraint to ensure the scrap has a reason. Passing it in the create values is more accurate.