### PR TITLE
[18.0][FIX] quality_control_oca: reference field error

### DIFF
--- a/quality_control_oca/models/qc_test.py
+++ b/quality_control_oca/models/qc_test.py
@@ -18,7 +18,11 @@ class QcTest(models.Model):
     _inherit = "mail.thread"
 
     def object_selection_values(self):
-        return set()
+        """
+        Overridable method for adding more object models to a test.
+        :return: A list with the selection's possible values.
+        """
+        return [("product.product", "Product")]
 
     @api.onchange("type")
     def onchange_type(self):


### PR DESCRIPTION
Reference fields must have list type.

Step to test:
1. Create test and select Type is Related
2. Reference Object will show empty string. and error
<img width="1543" height="519" alt="Selection_046" src="https://github.com/user-attachments/assets/8aa0d50b-830d-489c-b17b-764deb333dc1" />


Question:
- Currently, This field is not used. Should we delete it or add function to auto select it in  `qc.inspection`
TODO
- Cherry-pick with #1568 