### PR TITLE
[18.0][IMP] mrp_multi_level: user_has_groups call is deprecated

### DIFF
--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -32,7 +32,7 @@ class MrpInventoryProcure(models.TransientModel):
     def fields_view_get(
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
-        if self.user_has_groups("mrp_multi_level.group_change_mrp_procure_qty"):
+        if self.env.user.has_group("mrp_multi_level.group_change_mrp_procure_qty"):
             view_id = self.env.ref(
                 "mrp_multi_level.view_mrp_inventory_procure_wizard"
             ).id


### PR DESCRIPTION
Not causing errors in v18, but better to anticipate errors in newer versions.

Method user_has_groups() calls self.env.user.has_group