### PR TITLE
[16.0][FIX] mrp_unbuild_restore_origin: fix when unbuild MO with lot_producing_id

### DIFF
--- a/mrp_unbuild_restore_origin/README.rst
+++ b/mrp_unbuild_restore_origin/README.rst
@@ -32,14 +32,14 @@ Mrp Unbuild Restore Origin
   retaining
 | information from the original move lines.
 
-- | **Owner Retention:** The owner from the original move lines is
-    always retained
-  | automatically when unbuilding a Manufacturing Order.
+-  | **Owner Retention:** The owner from the original move lines is
+     always retained
+   | automatically when unbuilding a Manufacturing Order.
 
-- | **Location Retention (Optional):** A boolean field is available to
-    retain the original
-  | source and destination locations of the move lines during the
-    unbuild process, if needed.
+-  | **Location Retention (Optional):** A boolean field is available to
+     retain the original
+   | source and destination locations of the move lines during the
+     unbuild process, if needed.
 
 **Table of contents**
 
@@ -81,10 +81,11 @@ Authors
 Contributors
 ------------
 
-- `Quartile <https://www.quartile.co>`__:
+-  `Quartile <https://www.quartile.co>`__:
 
-  - Aung Ko Ko Lin
-  - Yoshi Tashiro
+   -  Aung Ko Ko Lin
+   -  Yoshi Tashiro
+   -  Toshikimi Shigenobu
 
 Maintainers
 -----------

--- a/mrp_unbuild_restore_origin/models/mrp_unbuild.py
+++ b/mrp_unbuild_restore_origin/models/mrp_unbuild.py
@@ -29,21 +29,6 @@ class MrpUnbuild(models.Model):
             vals["location_dest_id"] = origin_move_line.location_id.id
         return vals
 
-    def _get_move_line_vals(self, move, move_line):
-        vals = {
-            "move_id": move.id,
-            "owner_id": move_line.owner_id.id,
-            "qty_done": min(move.product_uom_qty, move_line.qty_done),
-            "product_id": move.product_id.id,
-            "product_uom_id": move.product_uom.id,
-            "location_id": move.location_id.id,
-            "location_dest_id": move.location_dest_id.id,
-        }
-        if self.env.context.get("exact_location"):
-            vals["location_id"] = move_line.location_dest_id.id
-            vals["location_dest_id"] = move_line.location_id.id
-        return vals
-
     def _generate_produce_moves(self):
         """This logic may seem a bit complex, but it's necessary due to how the following
         standard code works:
@@ -74,9 +59,16 @@ class MrpUnbuild(models.Model):
                 )
                 if move.has_tracking == "none":
                     vals_list = []
+                    remaining_qty = move.product_uom_qty
                     for move_line in raw_move.move_line_ids:
-                        vals = self._get_move_line_vals(move, move_line)
+                        if remaining_qty <= 0:
+                            break
+                        taken_qty = min(remaining_qty, move_line.qty_done)
+                        if not taken_qty:
+                            continue
+                        vals = self._prepare_move_line_vals(move, move_line, taken_qty)
                         vals_list.append(vals)
+                        remaining_qty -= taken_qty
                     self.env["stock.move.line"].create(vals_list)
                     move.write({"state": "confirmed"})
                 moves += move

--- a/mrp_unbuild_restore_origin/readme/CONTRIBUTORS.md
+++ b/mrp_unbuild_restore_origin/readme/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
 - [Quartile](https://www.quartile.co):
   - Aung Ko Ko Lin
   - Yoshi Tashiro
+  - Toshikimi Shigenobu

--- a/mrp_unbuild_restore_origin/static/description/index.html
+++ b/mrp_unbuild_restore_origin/static/description/index.html
@@ -441,6 +441,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
 <li>Aung Ko Ko Lin</li>
 <li>Yoshi Tashiro</li>
+<li>Toshikimi Shigenobu</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
@qrtl
QT5868

**Issue**
When executing button_unbuild, the lot assigned to the Manufacturing Order (MO) is set in the context as default_lot_id. As a result, when creating related material stock_move_line records, the Unbuild(MO)’s lot is automatically used as the default lot_id.
This causes an error:　"This lot ~~ is incompatible with this product ~~"

**Solution**
Replaced the custom _get_move_line_vals usage with the standard _prepare_move_line_vals, so that lot_id is now correctly set.
_prepare_move_line_vals: https://github.com/OCA/OCB/blob/52bec03/addons/mrp/models/mrp_unbuild.py#L146C5-L155C10


**Improvement (New Logic Added)**
Introduced a taken_quantity calculation following the logic in
`mrp_unbuild.py` L189–L207: https://github.com/OCA/OCB/blob/52bec03/addons/mrp/models/mrp_unbuild.py#L189-L207
This is newly added logic—separate from the fix above—to improve this module.