### PR TITLE
[19.0][FIX] mrp_production_back_to_draft: not move_raw_ids

### DIFF
--- a/mrp_production_back_to_draft/models/mrp_production.py
+++ b/mrp_production_back_to_draft/models/mrp_production.py
@@ -38,4 +38,11 @@ class MrpProduction(models.Model):
                 and all(m.state == "draft" for m in production.move_finished_ids)
             ):
                 production.state = "draft"
+            elif (
+                production.state == "confirmed"
+                and not production.move_raw_ids
+                and production.move_finished_ids
+                and all(m.state == "draft" for m in production.move_finished_ids)
+            ):
+                production.state = "draft"
         return

--- a/mrp_production_back_to_draft/tests/test_mrp_return_to_draft.py
+++ b/mrp_production_back_to_draft/tests/test_mrp_return_to_draft.py
@@ -109,3 +109,27 @@ class TestMrpProductionAutovalidate(BaseCommon):
         self.mo_1.workorder_ids.action_mark_as_done()
         with self.assertRaises(UserError):
             self.mo_1.action_return_to_draft()
+
+    def test_02_mrp_return_to_draft_no_raw_moves(self):
+        self.test_bom_2 = self.env["mrp.bom"].create(
+            {
+                "product_id": self.prod_tp1.id,
+                "product_tmpl_id": self.prod_tp1.product_tmpl_id.id,
+                "product_uom_id": self.prod_tp1.uom_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+            }
+        )
+        self.mo_2 = self.env["mrp.production"].create(
+            {
+                "name": "MO ABCD",
+                "product_id": self.prod_tp1.id,
+                "product_uom_id": self.prod_tp1.uom_id.id,
+                "product_qty": 2,
+                "bom_id": self.test_bom_2.id,
+            }
+        )
+        self.mo_2.action_confirm()
+        self.assertEqual(self.mo_2.state, "confirmed")
+        self.mo_2.action_return_to_draft()
+        self.assertEqual(self.mo_2.state, "draft")


### PR DESCRIPTION
- This case occurs when you try to revert a 'mrp.production' to draft when you don't have components or 'move_raw_ids', since then it doesn't modify the status of the 'mrp.production' and it remains as confirmed, then the raise UserError is triggered because 'rec.state != ‘draft’'.

<img width="2549" height="1002" alt="image" src="https://github.com/user-attachments/assets/6d0ed14e-107e-4771-b6f3-a13645cf1735" />
