### PR TITLE
Update mrp_multi_level.py

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -130,6 +130,13 @@ class MultiLevelMrp(models.TransientModel):
             / bomline.bom_id.product_qty
         )
         line_quantity = factor * bomline.product_qty
+        
+        # Convert from BOM line UoM to the component product’s UoM
+        line_uom = bomline.product_uom_id or bomline.product_id.uom_id
+        line_quantity_in_product_uom = line_uom._compute_quantity(
+            line_quantity,
+            bomline.product_id.uom_id,
+            
         return {
             "mrp_area_id": product_mrp_area.mrp_area_id.id,
             "product_id": bomline.product_id.id,
@@ -138,7 +145,7 @@ class MultiLevelMrp(models.TransientModel):
             "purchase_order_id": None,
             "purchase_line_id": None,
             "stock_move_id": None,
-            "mrp_qty": -line_quantity,  # TODO: review with UoM
+            "mrp_qty": -line_quantity_in_product_uom,
             "current_qty": None,
             "mrp_date": mrp_date_demand_2,
             "current_date": None,


### PR DESCRIPTION
Added UOM conversion from the BOM UOM to the product UOM.  Previously, for example, a BOM line specified in OZ and stored in LBS was being put on the MO in BOM quantities but using product UOM in LBS.