### PR TITLE
[16.0][FIX] mrp_multi_level: Fix MRP wizard logic

### DIFF
--- a/mrp_multi_level/i18n/es.po
+++ b/mrp_multi_level/i18n/es.po
@@ -42,6 +42,16 @@ msgid "Action"
 msgstr "Acción"
 
 #. module: mrp_multi_level
+#: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_inventory_procure_item__mrp_action
+msgid "Procurement Method"
+msgstr "Método de aprovisionamiento"
+
+#. module: mrp_multi_level
+#: model:ir.model.fields,help:mrp_multi_level.field_mrp_inventory_procure_item__mrp_action
+msgid "Method to use for procurement. Can be modified before executing."
+msgstr "Método que se usará para el aprovisionamiento. Puede modificarse antes de ejecutar."
+
+#. module: mrp_multi_level
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_area__active
 #: model:ir.model.fields,field_description:mrp_multi_level.field_product_mrp_area__active
 msgid "Active"
@@ -102,6 +112,7 @@ msgstr "Confirmado"
 
 #. module: mrp_multi_level
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_tree
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_form
 msgid "Create Procurement"
 msgstr "Crear Aprovisionamiento"
 
@@ -482,8 +493,9 @@ msgstr "Crear Aprovisionamiento desde Proyecciones de Stock MRP"
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_move__production_id
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_move__mrp_origin__mo
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__manufacture
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__manufacture
 msgid "Manufacturing Order"
-msgstr "Order de Fabricación"
+msgstr "Orden de Fabricación"
 
 #. module: mrp_multi_level
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_planned_order__mrp_production_ids
@@ -566,6 +578,7 @@ msgstr "No se encontró producto MRP"
 
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__none
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__none
 msgid "None"
 msgstr "Ninguno/a"
 
@@ -749,6 +762,7 @@ msgstr "Orden de producción"
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__pull_push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__pull_push
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__pull_push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__pull_push
 msgid "Pull & Push"
 msgstr "Tira y Empuja"
@@ -756,6 +770,7 @@ msgstr "Tira y Empuja"
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__pull
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__pull
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__pull
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__pull
 msgid "Pull From"
 msgstr "Tirar desde"
@@ -764,6 +779,7 @@ msgstr "Tirar desde"
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_move__purchase_order_id
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_move__mrp_origin__po
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__buy
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__buy
 msgid "Purchase Order"
 msgstr "Orden de Compra"
 
@@ -780,6 +796,7 @@ msgstr "Órdenes de Compra"
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__push
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__push
 msgid "Push To"
 msgstr "Empujar a"
@@ -950,8 +967,8 @@ msgstr ""
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_inventory_procure_item__supply_method
 #: model:ir.model.fields,field_description:mrp_multi_level.field_product_mrp_area__supply_method
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_search
-msgid "Supply Method"
-msgstr "Método de Suministro"
+msgid "Default Supply Method"
+msgstr "Método de Suministro por defecto"
 
 #. module: mrp_multi_level
 #: model:ir.model.fields,help:mrp_multi_level.field_mrp_area__company_id

--- a/mrp_multi_level/i18n/mrp_multi_level.pot
+++ b/mrp_multi_level/i18n/mrp_multi_level.pot
@@ -39,6 +39,16 @@ msgid "Action"
 msgstr ""
 
 #. module: mrp_multi_level
+#: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_inventory_procure_item__mrp_action
+msgid "Procurement Method"
+msgstr ""
+
+#. module: mrp_multi_level
+#: model:ir.model.fields,help:mrp_multi_level.field_mrp_inventory_procure_item__mrp_action
+msgid "Method to use for procurement. Can be modified before executing."
+msgstr ""
+
+#. module: mrp_multi_level
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_area__active
 #: model:ir.model.fields,field_description:mrp_multi_level.field_product_mrp_area__active
 msgid "Active"
@@ -99,6 +109,7 @@ msgstr ""
 
 #. module: mrp_multi_level
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_tree
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_form
 msgid "Create Procurement"
 msgstr ""
 
@@ -480,6 +491,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_move__production_id
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_move__mrp_origin__mo
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__manufacture
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__manufacture
 msgid "Manufacturing Order"
 msgstr ""
 
@@ -564,6 +576,7 @@ msgstr ""
 
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__none
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__none
 msgid "None"
 msgstr ""
 
@@ -745,6 +758,7 @@ msgstr ""
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__pull_push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__pull_push
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__pull_push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__pull_push
 msgid "Pull & Push"
 msgstr ""
@@ -752,6 +766,7 @@ msgstr ""
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__pull
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__pull
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__pull
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__pull
 msgid "Pull From"
 msgstr ""
@@ -760,6 +775,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_move__purchase_order_id
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_move__mrp_origin__po
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__buy
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__buy
 msgid "Purchase Order"
 msgstr ""
 
@@ -776,6 +792,7 @@ msgstr ""
 #. module: mrp_multi_level
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__supply_method__push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_planned_order__mrp_action__push
+#: model:ir.model.fields.selection,name:mrp_multi_level.selection__mrp_inventory_procure_item__mrp_action__push
 #: model:ir.model.fields.selection,name:mrp_multi_level.selection__product_mrp_area__supply_method__push
 msgid "Push To"
 msgstr ""
@@ -947,7 +964,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:mrp_multi_level.field_mrp_inventory_procure_item__supply_method
 #: model:ir.model.fields,field_description:mrp_multi_level.field_product_mrp_area__supply_method
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_search
-msgid "Supply Method"
+msgid "Default Supply Method"
 msgstr ""
 
 #. module: mrp_multi_level

--- a/mrp_multi_level/models/__init__.py
+++ b/mrp_multi_level/models/__init__.py
@@ -9,3 +9,4 @@ from . import product_mrp_area
 from . import stock_rule
 from . import mrp_production
 from . import stock_quant
+from . import procurement_group

--- a/mrp_multi_level/models/mrp_inventory.py
+++ b/mrp_multi_level/models/mrp_inventory.py
@@ -71,10 +71,15 @@ class MrpInventory(models.Model):
         comodel_name="mrp.planned.order", inverse_name="mrp_inventory_id", readonly=True
     )
     supply_method = fields.Selection(
-        string="Supply Method",
+        string="Default Supply Method",
         related="product_mrp_area_id.supply_method",
         readonly=True,
         store=True,
+        help=(
+            "Supply method derived from routes/stock rules. "
+            "Used as default when procuring from MRP projections if the procurement "
+            "method is not explicitly specified."
+        ),
     )
     main_supplier_id = fields.Many2one(
         string="Main Supplier",

--- a/mrp_multi_level/models/procurement_group.py
+++ b/mrp_multi_level/models/procurement_group.py
@@ -1,0 +1,39 @@
+from odoo import api, models
+
+
+class ProcurementGroup(models.Model):
+    _inherit = "procurement.group"
+
+    @api.model
+    def _get_rule(self, product_id, location_id, values):
+        """Override to respect mrp_action from MRP Multi Level wizard."""
+        mrp_action = values.get("mrp_action")
+
+        if not mrp_action or mrp_action in ("none", False):
+            return super()._get_rule(product_id, location_id, values)
+
+        company = values.get("company_id", self.env.company)
+        company_id = company.id if hasattr(company, "id") else company
+
+        domain = [
+            ("action", "=", mrp_action),
+            ("company_id", "in", [company_id, False]),
+        ]
+
+        rule = self.env["stock.rule"].search(
+            domain + [("location_dest_id", "=", location_id.id)],
+            order="sequence",
+            limit=1,
+        )
+
+        if not rule:
+            warehouse = values.get("warehouse_id")
+            if warehouse:
+                warehouse_id = warehouse.id if hasattr(warehouse, "id") else warehouse
+                rule = self.env["stock.rule"].search(
+                    domain + [("warehouse_id", "=", warehouse_id)],
+                    order="sequence",
+                    limit=1,
+                )
+
+        return rule or super()._get_rule(product_id, location_id, values)

--- a/mrp_multi_level/models/product_mrp_area.py
+++ b/mrp_multi_level/models/product_mrp_area.py
@@ -87,6 +87,12 @@ class ProductMRPArea(models.Model):
             ("pull_push", "Pull & Push"),
         ],
         compute="_compute_supply_method",
+        string="Default Supply Method",
+        help=(
+            "Supply method derived from routes/stock rules. "
+            "This default strategy is used to create procurements from MRP when the "
+            "procurement method is not explicitly specified."
+        ),
     )
     supply_bom_id = fields.Many2one(
         comodel_name="mrp.bom",

--- a/mrp_multi_level/models/stock_rule.py
+++ b/mrp_multi_level/models/stock_rule.py
@@ -7,6 +7,31 @@ from odoo import models
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
+    def _make_po_get_domain(self, company_id, values, partner):
+        domain = super()._make_po_get_domain(company_id, values, partner)
+        if isinstance(domain, list):
+            domain = tuple(domain)
+        currency_id = values.get("currency_id")
+        if currency_id:
+            domain = tuple(domain) + (("currency_id", "=", currency_id),)
+        return domain
+
+    def _prepare_purchase_order(self, company_id, origins, values):
+        res = super()._prepare_purchase_order(company_id, origins, values)
+
+        currency_id = False
+        if isinstance(values, dict):
+            currency_id = values.get("currency_id")
+        elif isinstance(values, (list, tuple)):
+            for v in values:
+                if isinstance(v, dict) and v.get("currency_id"):
+                    currency_id = v.get("currency_id")
+                    break
+
+        if currency_id:
+            res["currency_id"] = currency_id
+        return res
+
     def _prepare_mo_vals(
         self,
         product_id,

--- a/mrp_multi_level/tests/test_mrp_multi_level.py
+++ b/mrp_multi_level/tests/test_mrp_multi_level.py
@@ -2,8 +2,12 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from datetime import date, datetime, timedelta
+from unittest.mock import patch
 
 from odoo import fields
+from odoo.exceptions import ValidationError
+
+from odoo.addons.purchase_stock.models import stock_rule as purchase_stock_rule
 
 from .common import TestMrpMultiLevelCommon
 
@@ -920,3 +924,728 @@ class TestMrpMultiLevel(TestMrpMultiLevelCommon):
             .create({})
         )
         self.assertEqual(len(procure_wizard.item_ids), 0)
+
+    def test_26_procure_wizard_mrp_action_override_to_buy(self):
+        """Test override to 'buy' creates PO with correct data and
+        updates planned_order."""
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.fp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv, "No MRP inventory found for FP-1")
+
+        # Get planned order and save initial qty_released
+        planned_order = mrp_inv.planned_order_ids.filtered(
+            lambda x: x.qty_released < x.mrp_qty
+        )[:1]
+        self.assertTrue(planned_order, "No planned order with pending qty")
+        qty_released_before = planned_order.qty_released
+
+        self.fp_1.write(
+            {
+                "seller_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "partner_id": self.vendor.id,
+                            "min_qty": 0.0,
+                            "price": 10.0,
+                            "delay": 1,
+                        },
+                    )
+                ]
+            }
+        )
+
+        self.mo_obj.search([("product_id", "=", self.fp_1.id)]).unlink()
+        before_po_count = self.po_obj.search_count(
+            [("company_id", "=", self.company.id)]
+        )
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+
+        item = wiz.item_ids[0]
+        item_qty = item.qty
+
+        item.write({"mrp_action": "buy"})
+        wiz.make_procurement()
+
+        mos = self.mo_obj.search([("product_id", "=", self.fp_1.id)])
+        self.assertFalse(mos, "No MO should be created for 'buy' action")
+
+        after_po_count = self.po_obj.search_count(
+            [("company_id", "=", self.company.id)]
+        )
+        self.assertGreater(after_po_count, before_po_count, "PO should be created")
+
+        po = self.po_obj.search(
+            [
+                ("partner_id", "=", self.vendor.id),
+                ("order_line.product_id", "=", self.fp_1.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+        self.assertTrue(po, "PO with correct vendor and product should exist")
+
+        po_line = po.order_line.filtered(lambda l: l.product_id == self.fp_1)
+        self.assertTrue(po_line, "PO should have line for FP-1")
+        self.assertEqual(
+            po_line.product_qty, item_qty, f"PO line qty should be {item_qty}"
+        )
+        self.assertEqual(
+            po_line.product_uom, self.fp_1.uom_id, "PO line should use product UoM"
+        )
+
+        self.assertEqual(
+            planned_order.qty_released,
+            qty_released_before + item_qty,
+            "qty_released MUST increase - order must be marked as released",
+        )
+
+    def test_27_procure_wizard_onchange_sets_vendor_currency(self):
+        """Onchange purchase defaults should set supplier and currency."""
+        planned = self.planned_order_obj.search(
+            [("product_id", "=", self.pp_1.id)], limit=1
+        )
+        self.assertTrue(planned)
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.planned.order",
+            active_ids=planned.ids,
+            active_id=planned.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+
+        item.mrp_action = "buy"
+        item._onchange_purchase_defaults()
+
+        self.assertEqual(item.mrp_action, "buy")
+        self.assertTrue(item.supplier_id)
+        self.assertTrue(item.currency_id)
+
+    def test_28_stock_rule_make_po_domain_and_prepare_po_currency(self):
+        usd = self.env.ref("base.USD")
+        rule = self.env["stock.rule"].search([], limit=1)
+        self.assertTrue(rule)
+
+        dom = rule._make_po_get_domain(
+            self.company, {"currency_id": usd.id}, self.vendor
+        )
+        self.assertIsInstance(dom, tuple)
+        self.assertIn(("currency_id", "=", usd.id), dom)
+        supplierinfo = self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.vendor.id,
+                "product_tmpl_id": self.pp_1.product_tmpl_id.id,
+                "min_qty": 0.0,
+                "price": 10.0,
+                "delay": 1,
+            }
+        )
+        po_vals = rule._prepare_purchase_order(
+            self.company,
+            ["MRP: TEST"],
+            [
+                {
+                    "currency_id": usd.id,
+                    "date_planned": fields.Datetime.now(),
+                    "supplier": supplierinfo,
+                }
+            ],
+        )
+        self.assertEqual(po_vals.get("currency_id"), usd.id)
+
+    def test_29_procure_item_onchange_uom_planned_order(self):
+        """Onchange UoM: when source is a planned order, restore the original qty."""
+        planned = self.planned_order_obj.search(
+            [("product_id", "=", self.pp_1.id)], limit=1
+        )
+        self.assertTrue(planned)
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.planned.order",
+            active_ids=planned.ids,
+            active_id=planned.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+
+        item.write(
+            {
+                "source_context": "planned_order",
+                "original_qty": 5.0,
+                "qty": 0.0,
+                "uom_id": self.ref("uom.product_uom_unit"),
+            }
+        )
+        item.onchange_uom_id()
+        self.assertEqual(item.qty, 5.0)
+
+    def test_30_procure_item_onchange_uom_inventory_to_procure(self):
+        """Onchange UoM: when source is inventory, default qty from `to_procure`."""
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.fp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv)
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+
+        item.write(
+            {
+                "source_context": "inventory",
+                "original_qty": 0.0,
+                "qty": 0.0,
+                "uom_id": self.ref("uom.product_uom_unit"),
+            }
+        )
+        mrp_inv.write({"to_procure": 3.0})
+
+        item.onchange_uom_id()
+        self.assertEqual(item.qty, 3.0)
+
+    def test_31_get_rule_respects_mrp_action(self):
+        """Test that _get_rule returns rule matching mrp_action when provided."""
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.fp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv)
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+        route = self.env["stock.route"].create(
+            {
+                "name": "Test route (mrp_multi_level)",
+                "product_selectable": False,
+                "warehouse_selectable": False,
+                "company_id": self.company.id,
+            }
+        )
+        picking_type = item.warehouse_id.in_type_id
+        pull_rule = self.env["stock.rule"].create(
+            {
+                "name": "Test pull rule (mrp_multi_level)",
+                "route_id": route.id,
+                "action": "pull",
+                "location_src_id": self.supplier_location.id,
+                "location_dest_id": item.location_id.id,
+                "picking_type_id": picking_type.id,
+                "company_id": self.company.id,
+            }
+        )
+        # Veriffy  _get_rule returns pull rule when mrp_action='pull'
+        pg = self.env["procurement.group"]
+        values = {
+            "mrp_action": "pull",
+            "company_id": self.company,
+            "warehouse_id": item.warehouse_id,
+        }
+        found_rule = pg._get_rule(item.product_id, item.location_id, values)
+        self.assertEqual(found_rule.id, pull_rule.id)
+        self.assertEqual(found_rule.action, "pull")
+
+    def test_32_procure_item_onchange_uom_fallback_original_qty(self):
+        """Onchange UoM: when no context, fallback to original qty."""
+        planned = self.planned_order_obj.search(
+            [("product_id", "=", self.pp_1.id)], limit=1
+        )
+        self.assertTrue(planned)
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.planned.order",
+            active_ids=planned.ids,
+            active_id=planned.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+
+        item.write(
+            {
+                "source_context": "inventory",
+                "mrp_inventory_id": False,
+                "original_qty": 7.0,
+                "qty": 0.0,
+                "uom_id": self.ref("uom.product_uom_unit"),
+            }
+        )
+        item.onchange_uom_id()
+        self.assertEqual(item.qty, 7.0)
+
+    def test_33_procure_wizard_mrp_action_override_to_manufacture(self):
+        """Test override to 'manufacture' creates MO with correct data and
+        updates planned_order."""
+        # Use PP-1 which has supply_method='buy' but we will override to manufacture
+        # First we need to create a BOM for PP-1
+        bom = self.mrp_bom_obj.create(
+            {
+                "product_tmpl_id": self.pp_1.product_tmpl_id.id,
+                "product_id": self.pp_1.id,
+                "type": "normal",
+                "product_qty": 1.0,
+            }
+        )
+        self.assertTrue(bom)
+        self.assertEqual(bom.product_id, self.pp_1)
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.pp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv, "No MRP inventory found for PP-1")
+
+        planned_order = mrp_inv.planned_order_ids.filtered(
+            lambda x: x.qty_released < x.mrp_qty
+        )[:1]
+        self.assertTrue(planned_order, "No planned order with pending qty")
+        qty_released_before = planned_order.qty_released
+
+        before_mo_count = self.mo_obj.search_count([("product_id", "=", self.pp_1.id)])
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+
+        item = wiz.item_ids[0]
+        item_qty = item.qty
+
+        # Override to manufacture (PP-1 normally uses 'buy')
+        item.write({"mrp_action": "manufacture"})
+        wiz.make_procurement()
+
+        after_mo_count = self.mo_obj.search_count([("product_id", "=", self.pp_1.id)])
+        self.assertGreater(
+            after_mo_count,
+            before_mo_count,
+            "A Manufacturing Order should have been created",
+        )
+
+        mo = self.mo_obj.search(
+            [
+                ("product_id", "=", self.pp_1.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+        self.assertTrue(mo, "Manufacturing Order should exist")
+        self.assertEqual(mo.product_id, self.pp_1, "MO should have correct product")
+        self.assertEqual(mo.product_qty, item_qty, f"MO qty should be {item_qty}")
+        self.assertEqual(mo.bom_id, bom, "MO should use created BOM")
+        self.assertEqual(
+            mo.product_uom_id, self.pp_1.uom_id, "MO should use product UoM"
+        )
+
+        self.assertEqual(
+            planned_order.qty_released,
+            qty_released_before + item_qty,
+            "qty_released MUST increase - order must be marked as released",
+        )
+
+    def test_34_procure_wizard_mrp_action_override_to_pull(self):
+        """Test override to 'pull' creates picking with correct data and
+        updates planned_order."""
+        # Use FP-1 which has supply_method='manufacture' but we will override to pull
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.fp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv, "No MRP inventory found for FP-1")
+
+        # Get planned order and save initial qty_released
+        planned_order = mrp_inv.planned_order_ids.filtered(
+            lambda x: x.qty_released < x.mrp_qty
+        )[:1]
+        self.assertTrue(planned_order, "No planned order with pending qty")
+        qty_released_before = planned_order.qty_released
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+        item_qty = item.qty
+
+        # Create a pull rule for this location
+        route = self.env["stock.route"].create(
+            {
+                "name": "Test route for pull (test_34)",
+                "product_selectable": False,
+                "warehouse_selectable": False,
+                "company_id": self.company.id,
+            }
+        )
+        picking_type = item.warehouse_id.int_type_id
+        pull_rule = self.env["stock.rule"].create(
+            {
+                "name": "Test pull rule (test_34)",
+                "route_id": route.id,
+                "action": "pull",
+                "location_src_id": self.supplier_location.id,
+                "location_dest_id": item.location_id.id,
+                "picking_type_id": picking_type.id,
+                "company_id": self.company.id,
+                "procure_method": "make_to_stock",
+            }
+        )
+        self.assertTrue(pull_rule)
+        self.assertEqual(pull_rule.action, "pull")
+        # Count existing pickings and MOs for this product
+        before_picking_count = self.stock_picking_obj.search_count(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ]
+        )
+        # Clear any existing MOs for FP-1 to avoid confusion
+        self.mo_obj.search([("product_id", "=", self.fp_1.id)]).unlink()
+        before_mo_count = self.mo_obj.search_count([("product_id", "=", self.fp_1.id)])
+        # Override to pull (FP-1 normally uses 'manufacture')
+        item.write({"mrp_action": "pull"})
+        wiz.make_procurement()
+        # Verify picking was created (not MO)
+        after_picking_count = self.stock_picking_obj.search_count(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ]
+        )
+        after_mo_count = self.mo_obj.search_count([("product_id", "=", self.fp_1.id)])
+        self.assertGreater(
+            after_picking_count,
+            before_picking_count,
+            "A stock picking should have been created for pull action",
+        )
+        self.assertEqual(
+            after_mo_count,
+            before_mo_count,
+            "No new Manufacturing Order should have been created",
+        )
+
+        picking = self.stock_picking_obj.search(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+        self.assertTrue(picking, "Stock picking should exist")
+
+        move = picking.move_ids.filtered(lambda m: m.product_id == self.fp_1)
+        self.assertTrue(move, "Picking should have move for FP-1")
+        self.assertEqual(
+            move.product_uom_qty, item_qty, f"Move qty should be {item_qty}"
+        )
+        self.assertEqual(
+            move.location_id,
+            self.supplier_location,
+            "Move should come from supplier location",
+        )
+        self.assertEqual(
+            move.location_dest_id, item.location_id, "Move should go to item location"
+        )
+
+        self.assertEqual(
+            planned_order.qty_released,
+            qty_released_before + item_qty,
+            "qty_released MUST increase - order must be marked as released",
+        )
+
+    def test_35_procure_wizard_mrp_action_override_to_pull_push(self):
+        """Test override to 'pull_push' creates picking with correct data and
+        updates planned_order."""
+        mrp_inv = self.mrp_inventory_obj.search(
+            [("product_mrp_area_id.product_id", "=", self.fp_1.id)], limit=1
+        )
+        self.assertTrue(mrp_inv, "No MRP inventory found for FP-1")
+
+        planned_order = mrp_inv.planned_order_ids.filtered(
+            lambda x: x.qty_released < x.mrp_qty
+        )[:1]
+        self.assertTrue(planned_order, "No planned order with pending qty")
+        qty_released_before = planned_order.qty_released
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.inventory",
+            active_ids=mrp_inv.ids,
+            active_id=mrp_inv.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+        item_qty = item.qty
+
+        # Create a pull_push rule for this location
+        route = self.env["stock.route"].create(
+            {
+                "name": "Test route for pull_push (test_35)",
+                "product_selectable": False,
+                "warehouse_selectable": False,
+                "company_id": self.company.id,
+            }
+        )
+        picking_type = item.warehouse_id.int_type_id
+        pull_push_rule = self.env["stock.rule"].create(
+            {
+                "name": "Test pull_push rule (test_35)",
+                "route_id": route.id,
+                "action": "pull_push",
+                "location_src_id": self.supplier_location.id,
+                "location_dest_id": item.location_id.id,
+                "picking_type_id": picking_type.id,
+                "company_id": self.company.id,
+                "procure_method": "make_to_stock",
+                "auto": "manual",
+            }
+        )
+        self.assertTrue(pull_push_rule)
+        self.assertEqual(pull_push_rule.action, "pull_push")
+        # Count existing pickings and MOs for this product
+        before_picking_count = self.stock_picking_obj.search_count(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ]
+        )
+        self.mo_obj.search([("product_id", "=", self.fp_1.id)]).unlink()
+        before_mo_count = self.mo_obj.search_count([("product_id", "=", self.fp_1.id)])
+        # Override to pull_push (FP-1 normally uses 'manufacture')
+        item.write({"mrp_action": "pull_push"})
+        wiz.make_procurement()
+        # Verify picking was created (not MO)
+        after_picking_count = self.stock_picking_obj.search_count(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ]
+        )
+        after_mo_count = self.mo_obj.search_count([("product_id", "=", self.fp_1.id)])
+        self.assertGreater(
+            after_picking_count,
+            before_picking_count,
+            "A stock picking should have been created for pull_push action",
+        )
+        self.assertEqual(
+            after_mo_count,
+            before_mo_count,
+            "No new Manufacturing Order should have been created",
+        )
+
+        picking = self.stock_picking_obj.search(
+            [
+                ("move_ids.product_id", "=", self.fp_1.id),
+                ("picking_type_id", "=", picking_type.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+        self.assertTrue(picking, "Stock picking should exist")
+
+        move = picking.move_ids.filtered(lambda m: m.product_id == self.fp_1)
+        self.assertTrue(move, "Picking should have move for FP-1")
+        self.assertEqual(
+            move.product_uom_qty, item_qty, f"Move qty should be {item_qty}"
+        )
+
+        self.assertEqual(
+            planned_order.qty_released,
+            qty_released_before + item_qty,
+            "qty_released MUST increase - order must be marked as released",
+        )
+
+    # NOTE: Test for 'push' action is not included because push rules work
+    # differently in Odoo - they are triggered automatically when stock enters
+    # a location, not through manual procurement calls. The _run_push method
+    # expects self to be a singleton rule.
+
+    def test_36_stock_rule_currency_domain_coverage(self):
+        """Cover list->tuple domain conversion and values dict/list parsing."""
+        rule = self.env["stock.rule"].search([], limit=1)
+        self.assertTrue(rule, "Expected at least one stock.rule record")
+
+        partner = self.env["res.partner"].create({"name": "Test Vendor"})
+        currency_id = self.env.company.currency_id.id
+
+        # 1) domain returned by super as list must be converted to tuple
+        with patch.object(
+            purchase_stock_rule.StockRule,
+            "_make_po_get_domain",
+            return_value=[("dummy", "=", 1)],
+        ):
+            domain = rule._make_po_get_domain(
+                self.env.company, {"currency_id": currency_id}, partner
+            )
+        self.assertIsInstance(domain, tuple)
+        self.assertIn(("currency_id", "=", currency_id), domain)
+
+        # 2) values is dict -> currency_id picked from values.get("currency_id")
+        with patch.object(
+            purchase_stock_rule.StockRule,
+            "_prepare_purchase_order",
+            return_value={},
+        ):
+            res = rule._prepare_purchase_order(
+                self.env.company,
+                origins=["TEST"],
+                values={"currency_id": currency_id},
+            )
+        self.assertEqual(res.get("currency_id"), currency_id)
+
+        # 3) values is tuple/list -> currency_id picked from first dict having it
+        values = (
+            {"currency_id": False},
+            {"currency_id": currency_id},
+        )
+        with patch.object(
+            purchase_stock_rule.StockRule,
+            "_prepare_purchase_order",
+            return_value={},
+        ):
+            res = rule._prepare_purchase_order(self.env.company, ["TEST"], values)
+        self.assertEqual(res.get("currency_id"), currency_id)
+
+    def test_37_procure_wizard_onchange_and_make_procurement_validations(self):
+        planned = self.planned_order_obj.search(
+            [("product_id", "=", self.pp_1.id)], limit=1
+        )
+        self.assertTrue(planned)
+
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.planned.order",
+            active_ids=planned.ids,
+            active_id=planned.id,
+        ).create({})
+        self.assertTrue(wiz.item_ids)
+        item = wiz.item_ids[0]
+
+        # Cover branch: if not buy/product/warehouse -> supplier/currency reset
+        item.mrp_action = "buy"
+        item._onchange_purchase_defaults()
+        self.assertTrue(item.supplier_id)
+        self.assertTrue(item.currency_id)
+
+        item.mrp_action = "manufacture"
+        item._onchange_purchase_defaults()
+        self.assertFalse(item.supplier_id)
+        self.assertFalse(item.currency_id)
+
+        # Cover validation: qty must be positive
+        item.qty = 0.0
+        with self.assertRaises(ValidationError) as exc:
+            wiz.make_procurement()
+        self.assertIn("Quantity must be positive", str(exc.exception))
+
+    def test_38_grouped_procurement_multiple_actions(self):
+        """Test grouped procurement with multiple items and different actions.
+        Verifies that multiple planned orders create wizard with multiple items,
+        executing correctly handles all items with their respective actions
+        (buy, manufacture, pull) and updates all qty_released values.
+        """
+        # Arrange: Find multiple planned orders that will create wizard items
+        # Criteria: not phantom, not fully released
+        planned_orders = self.planned_order_obj.search(
+            [
+                ("mrp_action", "!=", "phantom"),
+                ("qty_released", "<", 100000),
+            ],
+            limit=5,
+        )
+        self.assertGreaterEqual(
+            len(planned_orders), 3, "Expected at least 3 valid planned orders"
+        )
+
+        # Ensure they have unreleased quantities
+        for p in planned_orders[:3]:
+            if p.qty_released >= p.mrp_qty:
+                p.qty_released = 0.0
+
+        planned_orders = planned_orders[:3]
+
+        planned_1 = planned_orders[0]
+        planned_2 = planned_orders[1]
+        planned_3 = planned_orders[2]
+
+        qty_released_1_before = planned_1.qty_released
+        qty_released_2_before = planned_2.qty_released
+        qty_released_3_before = planned_3.qty_released
+
+        # Create wizard with multiple planned orders selected
+        wiz = self.mrp_inventory_procure_wiz.with_context(
+            active_model="mrp.planned.order",
+            active_ids=planned_orders.ids,
+            active_id=planned_1.id,
+        ).create({})
+
+        self.assertEqual(
+            len(wiz.item_ids),
+            3,
+            "Expected wizard to have 3 items (one per planned order)",
+        )
+
+        # Force different actions on items to test grouped procurement
+        item_1 = wiz.item_ids[0]
+        item_2 = wiz.item_ids[1]
+        item_3 = wiz.item_ids[2]
+
+        # Force mrp_action to test different procurement paths
+        # Only override if the product supports it (has BOM for manufacture, etc)
+        if item_1.product_id.bom_ids:
+            item_1.mrp_action = "manufacture"
+        else:
+            item_1.mrp_action = "buy"
+
+        # Second item: always buy (safest option, works for all products)
+        item_2.mrp_action = "buy"
+
+        # Third item: try pull if possible, otherwise buy
+        pull_rule = self.env["stock.rule"].search([("action", "=", "pull")], limit=1)
+        if pull_rule:
+            item_3.mrp_action = "pull"
+        else:
+            item_3.mrp_action = "buy"
+
+        qty_1 = item_1.qty
+        qty_2 = item_2.qty
+        qty_3 = item_3.qty
+
+        wiz.make_procurement()
+
+        # Verify qty_released updated for ALL planned orders
+        planned_1.invalidate_recordset()
+        planned_2.invalidate_recordset()
+        planned_3.invalidate_recordset()
+
+        self.assertEqual(
+            planned_1.qty_released,
+            qty_released_1_before + qty_1,
+            f"Expected planned_1.qty_released to be {qty_released_1_before + qty_1}, "
+            f"got {planned_1.qty_released}",
+        )
+        self.assertEqual(
+            planned_2.qty_released,
+            qty_released_2_before + qty_2,
+            f"Expected planned_2.qty_released to be {qty_released_2_before + qty_2}, "
+            f"got {planned_2.qty_released}",
+        )
+        self.assertEqual(
+            planned_3.qty_released,
+            qty_released_3_before + qty_3,
+            f"Expected planned_3.qty_released to be {qty_released_3_before + qty_3}, "
+            f"got {planned_3.qty_released}",
+        )

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -20,7 +20,13 @@
                 <field name="qty_released" />
                 <field name="mrp_qty" />
                 <field name="fixed" />
-                <field name="mrp_action" optional="hide" />
+                <field
+                    name="mrp_action"
+                    widget="badge"
+                    decoration-info="mrp_action == 'buy'"
+                    decoration-success="mrp_action == 'manufacture'"
+                    decoration-warning="mrp_action in ('pull', 'push', 'pull_push')"
+                />
             </tree>
         </field>
     </record>
@@ -29,6 +35,15 @@
         <field name="model">mrp.planned.order</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <button
+                        name="%(mrp_multi_level.act_mrp_inventory_procure)d"
+                        string="Create Procurement"
+                        type="action"
+                        class="oe_highlight"
+                        attrs="{'invisible': ['|', ('qty_released', '&gt;=', 'mrp_qty'), ('mrp_action', '=', 'phantom')]}"
+                    />
+                </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button

--- a/mrp_multi_level/wizards/mrp_inventory_procure.py
+++ b/mrp_multi_level/wizards/mrp_inventory_procure.py
@@ -15,9 +15,14 @@ class MrpInventoryProcure(models.TransientModel):
 
     @api.model
     def _prepare_item(self, planned_order):
+        active_model = self.env.context.get("active_model", "mrp.inventory")
+        source_context = (
+            "planned_order" if active_model == "mrp.planned.order" else "inventory"
+        )
+        qty_pending = planned_order.mrp_qty - planned_order.qty_released
         return {
             "planned_order_id": planned_order.id,
-            "qty": planned_order.mrp_qty - planned_order.qty_released,
+            "qty": qty_pending,
             "uom_id": planned_order.mrp_inventory_id.uom_id.id,
             "date_planned": planned_order.due_date,
             "mrp_inventory_id": planned_order.mrp_inventory_id.id,
@@ -26,6 +31,10 @@ class MrpInventoryProcure(models.TransientModel):
             "location_id": planned_order.product_mrp_area_id.location_proc_id.id
             or planned_order.mrp_area_id.location_id.id,
             "supply_method": planned_order.product_mrp_area_id.supply_method,
+            "mrp_action": planned_order.mrp_action
+            or planned_order.product_mrp_area_id.supply_method,
+            "original_qty": qty_pending,
+            "source_context": source_context,
         }
 
     @api.model
@@ -74,30 +83,48 @@ class MrpInventoryProcure(models.TransientModel):
         self.ensure_one()
         errors = []
         pg = self.env["procurement.group"]
-        procurements = []
         for item in self.item_ids:
             if not item.qty:
                 raise ValidationError(_("Quantity must be positive."))
-            values = item._prepare_procurement_values()
-            procurements.append(
-                pg.Procurement(
-                    item.product_id,
-                    item.qty,
-                    item.uom_id,
-                    item.location_id,
-                    "MRP: " + (item.planned_order_id.name or self.env.user.login),
-                    "MRP: " + (item.planned_order_id.origin or self.env.user.login),
-                    item.mrp_inventory_id.company_id,
-                    values,
+            if not item.uom_id:
+                item.uom_id = item.product_id.uom_id
+            if not item.uom_id.rounding or item.uom_id.rounding <= 0:
+                raise ValidationError(
+                    _(
+                        "The Unit of Measure '%(uom)s' has an invalid rounding (%(rounding)s). "
+                        "Please fix the UoM configuration (rounding must be > 0)."
+                    )
+                    % {
+                        "uom": item.uom_id.display_name,
+                        "rounding": item.uom_id.rounding,
+                    }
                 )
+
+            values = item._prepare_procurement_values()
+            company = (
+                item.mrp_inventory_id.company_id
+                or item.warehouse_id.company_id
+                or self.env.company
             )
-        # Run procurements
-        try:
-            pg.run(procurements)
-            for item in self.item_ids:
+            values["company_id"] = company
+
+            procurement = pg.Procurement(
+                item.product_id,
+                item.qty,
+                item.uom_id,
+                item.location_id,
+                "MRP: " + (item.planned_order_id.name or self.env.user.login),
+                "MRP: " + (item.planned_order_id.origin or self.env.user.login),
+                company,
+                values,
+            )
+
+            try:
+                pg.run([procurement])
                 item.planned_order_id.qty_released += item.qty
-        except UserError as error:
-            errors.append(error.name)
+            except UserError as error:
+                errors.append(error.name)
+
         if errors:
             raise UserError("\n".join(errors))
         return {"type": "ir.actions.act_window_close"}
@@ -133,19 +160,143 @@ class MrpInventoryProcureItem(models.TransientModel):
             ("pull_push", "Pull & Push"),
         ],
         readonly=True,
+        string="Default Supply Method",
+        help=(
+            "Default supply strategy derived from routes/stock rules for the product/area. "
+            "It will be used when creating procurements if the procurement method is not "
+            "explicitly specified."
+        ),
+    )
+    supplier_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Vendor",
+        help="Vendor selected from the product's vendor list (seller info).",
+    )
+    currency_id = fields.Many2one(
+        comodel_name="res.currency",
+        string="Currency",
+        help="Currency that will be used for a purchase procurement.",
+    )
+    original_qty = fields.Float(
+        string="Original Planned Qty",
+        help="Original quantity from planned order, used as reference",
+        readonly=True,
+    )
+    source_context = fields.Selection(
+        selection=[
+            ("inventory", "From Inventory"),
+            ("planned_order", "From Planned Order"),
+        ],
+        default="inventory",
+        readonly=True,
+    )
+    mrp_action = fields.Selection(
+        selection=[
+            ("manufacture", "Manufacturing Order"),
+            ("buy", "Purchase Order"),
+            ("pull", "Pull From"),
+            ("push", "Push To"),
+            ("pull_push", "Pull & Push"),
+            ("none", "None"),
+        ],
+        string="Procurement Method",
+        help="Method to use for procurement. Can be modified before executing.",
     )
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        for rec in records:
+            if rec.mrp_action == "buy" and rec.product_id and rec.warehouse_id:
+                rec._onchange_purchase_defaults()
+        return records
+
+    @api.onchange(
+        "product_id", "warehouse_id", "qty", "uom_id", "date_planned", "mrp_action"
+    )
+    def _onchange_purchase_defaults(self):
+        """Pre-fill vendor/currency for buy procurements so the user can see them."""
+        for rec in self:
+            if rec.mrp_action != "buy" or not rec.product_id or not rec.warehouse_id:
+                rec.supplier_id = False
+                rec.currency_id = False
+                continue
+
+            company = rec.warehouse_id.company_id or rec.env.company
+            qty = rec.qty or 0.0
+            uom = rec.uom_id or rec.product_id.uom_id
+
+            seller = rec.product_id._select_seller(
+                quantity=qty,
+                date=rec.date_planned,
+                uom_id=uom,
+                partner_id=False,
+            )
+            if not seller:
+                seller = rec.product_id.seller_ids.filtered(
+                    lambda s: (not s.company_id or s.company_id == company)
+                ).sorted(lambda s: (s.sequence, s.min_qty, s.price))[:1]
+
+            rec.supplier_id = seller.partner_id if seller else False
+            rec.currency_id = (
+                seller.currency_id
+                if (seller and seller.currency_id)
+                else company.currency_id
+            )
+
     def _prepare_procurement_values(self, group=False):
-        return {
+        company = self.warehouse_id.company_id or self.env.company
+        currency = company.currency_id
+        res = {
             "date_planned": self.date_planned,
             "warehouse_id": self.warehouse_id,
             "group_id": group,
             "planned_order_id": self.planned_order_id.id,
+            "company_id": company,
+            "currency_id": currency.id,
         }
+        if self.mrp_action:
+            res["mrp_action"] = self.mrp_action
+        should_add_supplier = (self.mrp_action == "buy") or (
+            not self.mrp_action and self.supply_method == "buy"
+        )
+        if should_add_supplier:
+            qty = self.qty or 0.0
+            uom = self.uom_id or self.product_id.uom_id
+            supplier_info = self.product_id._select_seller(
+                quantity=qty,
+                date=self.date_planned,
+                uom_id=uom,
+                partner_id=self.supplier_id,
+            )
+            if not supplier_info:
+                supplier_info = self.product_id.seller_ids.filtered(
+                    lambda s: (not s.company_id or s.company_id == company)
+                ).sorted(lambda s: (s.sequence, s.min_qty, s.price))[:1]
+            if supplier_info:
+                res["supplierinfo_id"] = supplier_info
+                res["currency_id"] = (
+                    supplier_info.currency_id or company.currency_id
+                ).id
+            else:
+                res["currency_id"] = company.currency_id.id
+        return res
 
     @api.onchange("uom_id")
     def onchange_uom_id(self):
         for rec in self:
-            rec.qty = rec.mrp_inventory_id.uom_id._compute_quantity(
-                rec.mrp_inventory_id.to_procure, rec.uom_id
-            )
+            if rec.source_context == "planned_order":
+                if rec.original_qty and rec.uom_id:
+                    product_uom = rec.product_id.uom_id
+                    rec.qty = product_uom._compute_quantity(
+                        rec.original_qty, rec.uom_id
+                    )
+                continue
+
+            if rec.mrp_inventory_id and rec.mrp_inventory_id.to_procure > 0:
+                rec.qty = rec.mrp_inventory_id.uom_id._compute_quantity(
+                    rec.mrp_inventory_id.to_procure, rec.uom_id
+                )
+            elif rec.original_qty:
+                product_uom = rec.product_id.uom_id
+                rec.qty = product_uom._compute_quantity(rec.original_qty, rec.uom_id)

--- a/mrp_multi_level/wizards/mrp_inventory_procure_views.xml
+++ b/mrp_multi_level/wizards/mrp_inventory_procure_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <!--  Make Procurement with security access right -->
     <record id="view_mrp_inventory_procure_wizard" model="ir.ui.view">
         <field name="name">mrp.inventory.procure.form</field>
         <field name="model">mrp.inventory.procure</field>
@@ -12,6 +11,11 @@
                     this may trigger a draft purchase order, a manufacturing
                     order or a transfer picking.
                 </p>
+                <div class="alert alert-info" role="alert">
+                    <strong
+                    >Info:</strong> You can modify the procurement method (Procurement Method)
+                    for each line before executing the procurement.
+                </div>
                 <group name="items" string="Items" />
                     <field name="item_ids" nolabel="1">
                         <tree nocreate="1" editable="top">
@@ -31,6 +35,17 @@
                             <field name="uom_id" groups="uom.group_uom" />
                             <field name="date_planned" />
                             <field name="supply_method" />
+                            <field
+                            name="supplier_id"
+                            optional="show"
+                            attrs="{'invisible': [('mrp_action', '!=', 'buy')]}"
+                        />
+                            <field
+                            name="currency_id"
+                            optional="hide"
+                            attrs="{'invisible': [('mrp_action', '!=', 'buy')]}"
+                        />
+                            <field name="mrp_action" />
                         </tree>
                     </field>
                 <footer>
@@ -53,6 +68,9 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <field name="qty" position="attributes">
+                <attribute name="readonly">1</attribute>
+            </field>
+            <field name="mrp_action" position="attributes">
                 <attribute name="readonly">1</attribute>
             </field>
         </field>


### PR DESCRIPTION
# [16.0][FIX] mrp_multi_level: Fix MRP wizard logic (PR #1683)

## Why
Previously, the MRP Multi Level procurement wizard did not reliably allow users to explicitly choose the procurement method (manufacture/buy/pull/push/pull_push): the actual rule/action used at execution time could be driven by routes/rules and end up different from what the user intended.

This change makes the resulting procurement behavior consistent with the user’s explicit selection.

## What changed

### 1) Wizard: propagate the selected method + keep better context
In `mrp_multi_level/wizards/mrp_inventory_procure.py`:

- Each wizard line now carries extra context to behave correctly depending on where the wizard was opened from:
  - `source_context` (planned order vs inventory)
  - `original_qty` (used to keep quantities stable when changing the UoM)
- The selected procurement method is propagated through `values["mrp_action"]` so the downstream rule selection can use it.

### 2) New file: procurement group override (new flow)
Added `mrp_multi_level/models/procurement_group.py`:

- Override `procurement.group._get_rule()` to respect `mrp_action` when it is provided in `values`.
- The search is deterministic and safer for multi-company setups:
  - Filters by `company_id in [company, False]`
  - Uses `order="sequence"` to pick the highest priority rule
  - Tries destination location first, then falls back to warehouse

### 3) Multi-currency POs: avoid cross-currency draft reuse
In `mrp_multi_level/models/stock_rule.py`:

- Include `currency_id` in the draft PO lookup domain when present in `values`.
- Force the PO currency when `currency_id` is provided (supports both a single `dict` and grouped `values`).

### 4) UI: make the method clearly editable
In `mrp_multi_level/wizards/mrp_inventory_procure_views.xml`:

- Keep wizard lines editable (`editable="top"`).
- Show vendor/currency columns only when the line action is `buy`.
- Add an info message encouraging users to adjust the procurement method per line before executing.

### 5) Planned orders: clearer action + direct entrypoint
In `mrp_multi_level/views/mrp_planned_order_views.xml`:

- Improve `mrp_action` visibility using a badge + decorations.
- Add a “Create Procurement” button on the planned order form to open the wizard.

### 6) Change supply_method string:  

- Changed the string to “default supply method” instead of “supply method”, to avoid confusion between the mrp_action field and supply_method.ange stringo to Default supply method 

### 7) Tests
In `mrp_multi_level/tests/test_mrp_multi_level.py`:

- Added/updated tests covering the new wizard flows and the fact that `_get_rule()` respects `mrp_action`.

## Modified files
- `mrp_multi_level/models/__init__.py`
- `mrp_multi_level/models/procurement_group.py` (new)
- `mrp_multi_level/models/mrp_inventory.py`
- `mrp_multi_level/models/stock_rule.py`
- `mrp_multi_level/models/product_mrp_area.py`
- `mrp_multi_level/wizards/mrp_inventory_procure.py`
- `mrp_multi_level/wizards/mrp_inventory_procure_views.xml`
- `mrp_multi_level/views/mrp_planned_order_views.xml`
- `mrp_multi_level/tests/test_mrp_multi_level.py`
