### PR TITLE
[17.0][IMP] mrp_multi_level_estimate: allow to ignore estimates

### DIFF
--- a/mrp_multi_level_estimate/models/mrp_area.py
+++ b/mrp_multi_level_estimate/models/mrp_area.py
@@ -20,6 +20,7 @@ class MRPArea(models.Model):
                 "ignore_overlapping",
                 "Ignore other sources during periods with estimates",
             ),
+            ("ignore_estimates", "Ignore estimates"),
         ],
         default="all",
         help="Define the strategy to follow in MRP multi level when there is a"
@@ -32,5 +33,6 @@ class MRPArea(models.Model):
         "* Ignore other sources during periods with estimates: When "
         "you create demand estimates for a period and product, "
         "other sources of demand will be ignored during that period "
-        "for those products.",
+        "for those products.\n"
+        "* Ignore estimates: Completely ignore demand estimates.",
     )

--- a/mrp_multi_level_estimate/tests/test_mrp_multi_level_estimate.py
+++ b/mrp_multi_level_estimate/tests/test_mrp_multi_level_estimate.py
@@ -336,6 +336,25 @@ class TestMrpMultiLevelEstimate(TestMrpMultiLevelCommon):
         self.assertEqual(
             demand_from_other_sources.mrp_date, self.date_without_ranges.date()
         )
+        # 4. "ignore_estimates"
+        self.estimate_area.estimate_demand_and_other_sources_strat = "ignore_estimates"
+        self.mrp_multi_level_wiz.create(
+            {"mrp_area_ids": [(6, 0, self.estimate_area.ids)]}
+        ).run_mrp_multi_level()
+        moves = self.mrp_move_obj.search(
+            [
+                ("product_id", "=", self.prod_test.id),
+                ("mrp_area_id", "=", self.estimate_area.id),
+            ]
+        )
+        demand_from_estimates = moves.filtered(
+            lambda m: m.mrp_type == "d" and m.mrp_origin == "fc"
+        )
+        demand_from_other_sources = moves.filtered(
+            lambda m: m.mrp_type == "d" and m.mrp_origin != "fc"
+        )
+        self.assertEqual(len(demand_from_estimates), 0)
+        self.assertEqual(len(demand_from_other_sources), 2)
 
     def test_06_estimate_and_other_sources_strat_with_mo(self):
         """

--- a/mrp_multi_level_estimate/wizards/mrp_multi_level.py
+++ b/mrp_multi_level_estimate/wizards/mrp_multi_level.py
@@ -59,6 +59,12 @@ class MultiLevelMrp(models.TransientModel):
 
     @api.model
     def _estimates_domain(self, product_mrp_area):
+        estimate_strat = (
+            product_mrp_area.mrp_area_id.estimate_demand_and_other_sources_strat
+        )
+        if estimate_strat == "ignore_estimates":
+            # Return an impossible domain to ignore estimates.
+            return [("location_id", "=", 1), ("location_id", "=", 2)]
         locations = product_mrp_area.mrp_area_id._get_locations()
         return [
             ("product_id", "=", product_mrp_area.product_id.id),


### PR DESCRIPTION
This module is auto-installed but sometimes you need to ignore estimates, so adding the possibility via configuration is useful.

Backport of https://github.com/OCA/manufacture/pull/1693