### PR TITLE
[18.0] [FIX] quality_control_oca: Move div inside group 

### DIFF
--- a/quality_control_oca/views/qc_test_view.xml
+++ b/quality_control_oca/views/qc_test_view.xml
@@ -96,37 +96,39 @@
                         </list>
                     </field>
                 </group>
-                <div
+                <group
                     name="quantitative"
-                    align="center"
+                    colspan="4"
                     invisible="type != 'quantitative'"
                 >
-                    <h1 name="quantitative-data">
-                        <span name="quantitative-interval">
-                            <field
-                                name="min_value"
-                                class="oe_inline"
-                                nolabel="1"
-                                required="type == 'quantitative'"
-                            />
-                            <span> - </span>
-                            <field
-                                name="max_value"
-                                class="oe_inline"
-                                nolabel="1"
-                                required="type == 'quantitative'"
-                            />
-                        </span>
-                        <span name="quantitative-uom">
-                            <field
-                                name="uom_id"
-                                class="oe_inline"
-                                nolabel="1"
-                                required="type == 'quantitative'"
-                            />
-                        </span>
-                    </h1>
-                </div>
+                    <div align="center">
+                        <h1 name="quantitative-data">
+                            <span name="quantitative-interval">
+                                <field
+                                    name="min_value"
+                                    class="oe_inline"
+                                    nolabel="1"
+                                    required="type == 'quantitative'"
+                                />
+                                <span> - </span>
+                                <field
+                                    name="max_value"
+                                    class="oe_inline"
+                                    nolabel="1"
+                                    required="type == 'quantitative'"
+                                />
+                            </span>
+                            <span name="quantitative-uom">
+                                <field
+                                    name="uom_id"
+                                    class="oe_inline"
+                                    nolabel="1"
+                                    required="type == 'quantitative'"
+                                />
+                            </span>
+                        </h1>
+                    </div>
+                </group>
                 <field name="notes" />
             </form>
         </field>


### PR DESCRIPTION
in qc.test.question.form

Having the div just inside the form makes adding extra fields in the form view ugly. This fixes this by moving the quantitative related fields inside a group that preserves div for the existing fields and allows to properly add extra fields. Breaking change: The same attribute value for name (quantitative) that was used for the div is now used for the group so if there where any ugly hacks to add extra fields inside the div, these will require changing the path