### PR TITLE
[18.0][IMP] quality_control_oca: remove unused object_id on qt_test

### DIFF
--- a/quality_control_oca/demo/quality_control_demo.xml
+++ b/quality_control_oca/demo/quality_control_demo.xml
@@ -2,7 +2,6 @@
 <odoo noupdate="1">
     <record model="qc.test" id="qc_test_1">
         <field name="name">Generic Test (demo)</field>
-        <field name="type">generic</field>
         <field name="active" eval="True" />
         <field name="category" ref="qc_test_template_category_generic" />
     </record>

--- a/quality_control_oca/models/qc_test.py
+++ b/quality_control_oca/models/qc_test.py
@@ -17,14 +17,6 @@ class QcTest(models.Model):
     _description = "Quality control test"
     _inherit = "mail.thread"
 
-    def object_selection_values(self):
-        return set()
-
-    @api.onchange("type")
-    def onchange_type(self):
-        if self.type == "generic":
-            self.object_id = False
-
     active = fields.Boolean(default=True)
     name = fields.Char(required=True, translate=True)
     test_lines = fields.One2many(
@@ -33,16 +25,7 @@ class QcTest(models.Model):
         string="Questions",
         copy=True,
     )
-    object_id = fields.Reference(
-        string="Reference object",
-        selection="object_selection_values",
-    )
     fill_correct_values = fields.Boolean(string="Pre-fill with correct values")
-    type = fields.Selection(
-        [("generic", "Generic"), ("related", "Related")],
-        required=True,
-        default="generic",
-    )
     category = fields.Many2one(comodel_name="qc.test.category")
     company_id = fields.Many2one(
         comodel_name="res.company",

--- a/quality_control_oca/views/qc_test_view.xml
+++ b/quality_control_oca/views/qc_test_view.xml
@@ -25,10 +25,6 @@
                     </h1>
                     <group>
                         <group>
-                            <field name="type" />
-                            <field name="object_id" invisible="type == 'generic'" />
-                        </group>
-                        <group>
                             <field name="category" />
                             <field name="fill_correct_values" />
                             <field
@@ -63,8 +59,6 @@
             <list>
                 <field name="name" />
                 <field name="category" />
-                <field name="type" />
-                <field name="object_id" />
                 <field name="company_id" groups="base.group_multi_company" />
             </list>
         </field>


### PR DESCRIPTION
Forward port of #1568 from 17.0 to 18.0
As reported in issue https://github.com/OCA/manufacture/issues/1378 qc_test type field allows for display of object_id for which is selection is set(), creating invalid display.
Since this field does not seem to be used anywhere (none of the depending modules are using it neither), I propose with this PR to remove both object_id and type from qc_test.

Note : a field with same name object_id is used on qc_inspection model and make a lot of sense there !