### PR TITLE
[16.0][FIX] quality_control_oca: 'timing' is present twice in list view

### DIFF
--- a/quality_control_oca/views/product_template_view.xml
+++ b/quality_control_oca/views/product_template_view.xml
@@ -22,7 +22,6 @@
                                 />
                                 <field name="test" />
                                 <field name="user" />
-                                <field name="timing" />
                                 <field name="partners" widget="many2many_tags" />
                                 <field name="timing" />
                             </tree>


### PR DESCRIPTION
Before fix:

<img width="1219" height="689" alt="bug_oca" src="https://github.com/user-attachments/assets/64daa76d-4cc5-492c-828e-7fad5280b648" />
