### PR TITLE
Draft: [14.0][IMP] Make the serial matrix able to produce multiple quantities partially

### DIFF
--- a/mrp_production_serial_matrix/__manifest__.py
+++ b/mrp_production_serial_matrix/__manifest__.py
@@ -16,6 +16,7 @@
         "security/ir.model.access.csv",
         "wizards/mrp_production_serial_matrix_view.xml",
         "views/mrp_production_views.xml",
+        "views/res_config_settings.xml",
     ],
     "installable": True,
 }

--- a/mrp_production_serial_matrix/models/__init__.py
+++ b/mrp_production_serial_matrix/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mrp_production
+from . import res_config_settings

--- a/mrp_production_serial_matrix/models/res_config_settings.py
+++ b/mrp_production_serial_matrix/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    mrp_serial_matrix_allow_exceptions = fields.Boolean(
+        "Allow manufacturing exceptions",
+        config_parameter="mrp_production_serial_matrix.mrp_serial_matrix_allow_exceptions",
+    )

--- a/mrp_production_serial_matrix/static/description/index.html
+++ b/mrp_production_serial_matrix/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -450,7 +450,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/mrp_production_serial_matrix/views/res_config_settings.xml
+++ b/mrp_production_serial_matrix/views/res_config_settings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="15" />
+        <field name="inherit_id" ref="mrp.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@name='process_operations_setting_container']"
+                position="inside"
+            >
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="mrp_serial_matrix_allow_exceptions" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="mrp_serial_matrix_allow_exceptions" />
+                        <div class="text-muted">
+                            Allow manufacturing orders to be partially produced when an exception occurs at one of the productions.
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/wizards/mrp_production_serial_matrix.py
@@ -1,9 +1,13 @@
 # Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import logging
+import threading
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.float_utils import float_compare, float_is_zero
+
+_logger = logging.getLogger(__name__)
 
 
 class MrpProductionSerialMatrix(models.TransientModel):
@@ -214,6 +218,58 @@ class MrpProductionSerialMatrix(models.TransientModel):
             rec.line_ids = False
             rec.write({"line_ids": [(0, 0, x) for x in matrix_lines]})
 
+    def _button_validate_lot(self, mos, current_mo, lot):
+        backorder_ids = False
+
+        # Apply selected lots in matrix and set the qty producing
+        current_mo.lot_producing_id = lot
+        current_mo.qty_producing = 1.0
+        current_mo._set_qty_producing()
+        for move in current_mo.move_raw_ids:
+            rounding = move.product_id.uom_id.rounding
+            if float_is_zero(move.product_qty, precision_rounding=rounding):
+                # Component moves cannot be deleted in in-progress MO's; however,
+                # they can be set to 0 units to consume. In such case, we ignore
+                # the move.
+                continue
+            if move.product_id.tracking in ["serial", "lot"]:
+                # We filter using the lot nane because the ORM sometimes
+                # is not storing correctly the finished_lot_id in the lines
+                # after passing through the `_onchange_finished_lot_ids`
+                # method.
+                matrix_lines = self.line_ids.filtered(
+                    lambda l: (
+                        l.finished_lot_id == lot or l.finished_lot_name == lot.name
+                    )
+                    and l.component_id == move.product_id
+                )
+                if matrix_lines:
+                    self._amend_reservations(move, matrix_lines)
+                    self._consume_selected_lots(move, matrix_lines)
+
+        # Complete MO and create backorder if needed.
+        mos += current_mo
+        res = current_mo.button_mark_done()
+        backorder_wizard = self.env["mrp.production.backorder"]
+        if isinstance(res, dict) and res.get("res_model") == backorder_wizard._name:
+            # create backorders...
+            lines = res.get("context", {}).get(
+                "default_mrp_production_backorder_line_ids"
+            )
+            wizard = backorder_wizard.create(
+                {
+                    "mrp_production_ids": current_mo.ids,
+                    "mrp_production_backorder_line_ids": lines,
+                }
+            )
+            wizard.action_backorder()
+
+            backorder_ids = current_mo.procurement_group_id.mrp_production_ids.filtered(
+                lambda mo: mo.state not in ["done", "cancel"]
+            )
+
+        return backorder_ids
+
     def button_validate(self):
         self.ensure_one()
         if self.lot_selection_warning_count > 0:
@@ -221,63 +277,49 @@ class MrpProductionSerialMatrix(models.TransientModel):
                 _("Some issues has been detected in your selection: %s")
                 % self.lot_selection_warning_msg
             )
-        mos = self.env["mrp.production"]
+        exceptions_allowed = self.env["ir.config_parameter"].get_param(
+            "mrp_production_serial_matrix.mrp_serial_matrix_allow_exceptions"
+        )
+        backorder_ids = False
         current_mo = self.production_id
-        for fp_lot in self.finished_lot_ids:
-            # Apply selected lots in matrix and set the qty producing
-            current_mo.lot_producing_id = fp_lot
-            current_mo.qty_producing = 1.0
-            current_mo._set_qty_producing()
-            for move in current_mo.move_raw_ids:
-                rounding = move.product_id.uom_id.rounding
-                if float_is_zero(move.product_qty, precision_rounding=rounding):
-                    # Component moves cannot be deleted in in-progress MO's; however,
-                    # they can be set to 0 units to consume. In such case, we ignore
-                    # the move.
-                    continue
-                if move.product_id.tracking in ["serial", "lot"]:
-                    # We filter using the lot nane because the ORM sometimes
-                    # is not storing correctly the finished_lot_id in the lines
-                    # after passing through the `_onchange_finished_lot_ids`
-                    # method.
-                    matrix_lines = self.line_ids.filtered(
-                        lambda l: (
-                            l.finished_lot_id == fp_lot
-                            or l.finished_lot_name == fp_lot.name
-                        )
-                        and l.component_id == move.product_id
-                    )
-                    if matrix_lines:
-                        self._amend_reservations(move, matrix_lines)
-                        self._consume_selected_lots(move, matrix_lines)
-
-            # Complete MO and create backorder if needed.
-            mos += current_mo
-            res = current_mo.button_mark_done()
-            backorder_wizard = self.env["mrp.production.backorder"]
-            if isinstance(res, dict) and res.get("res_model") == backorder_wizard._name:
-                # create backorders...
-                lines = res.get("context", {}).get(
-                    "default_mrp_production_backorder_line_ids"
-                )
-                wizard = backorder_wizard.create(
-                    {
-                        "mrp_production_ids": current_mo.ids,
-                        "mrp_production_backorder_line_ids": lines,
-                    }
-                )
-                wizard.action_backorder()
-
-                backorder_ids = (
-                    current_mo.procurement_group_id.mrp_production_ids.filtered(
-                        lambda mo: mo.state not in ["done", "cancel"]
-                    )
-                )
-                current_mo = backorder_ids[0] if backorder_ids else False
-                if not current_mo:
+        finished_count = 0
+        mos = self.env["mrp.production"]
+        try:
+            for fp_lot in self.finished_lot_ids:
+                backorder_ids = self._button_validate_lot(mos, current_mo, fp_lot)
+                if not backorder_ids:
                     break
-            else:
-                break
+                current_mo = backorder_ids[0] if backorder_ids else False
+                finished_count += 1
+
+                # Commit changes in case processing any of the MO's fails
+                # somewhere, since it is ok to only produce a part of the
+                # quantity.
+                if exceptions_allowed and not getattr(
+                    threading.currentThread(), "testing", False
+                ):
+                    self.env.cr.commit()  # pylint: disable=invalid-commit
+        except Exception as e:
+            if getattr(threading.currentThread(), "testing", False):
+                raise e
+            if not exceptions_allowed or finished_count == 0:
+                raise e
+
+            self.env.cr.rollback()
+            _logger.error(e)
+            if backorder_ids:
+                message = _(
+                    "Not all orders where produced because an exception occurred: "
+                ) + str(e)
+                backorder_ids[0].message_post(body=message)
+                return {
+                    "res_id": backorder_ids[0].id,
+                    "name": _("Manufacturing Order"),
+                    "view_mode": "form",
+                    "res_model": "mrp.production",
+                    "type": "ir.actions.act_window",
+                }
+            raise e
 
         # TODO: not specified lots: auto create lots?
         if not mos:


### PR DESCRIPTION
Hello,

Here are some changes to the `mrp_production_serial_matrix` module that make it possible to use the serial matrix wizard to produce multiple quantities at once, each with one of the selected serials, but allowing a part of the quantity to be produced when one fails.

So as an example, when you would like to produce an MO with a quantity of 10, and the 7th product fails to be produced, you would still end up with 6 produced orders, and a backorder for the remaining 4 products.
A message about the exception that just occurred is posted on the backorder.

Now, since this may not be a feature everyone would want to use, I've added a checkbox on the mrp settings page so that it can be enabled if desired.

The real reason that we wanted this implemented, is actually so that the transaction that produces multiple products (with serials), which can become pretty large, doesn't have to lock up Odoo because db tables are locked up for a long period of time.
So after each order is produced for a single product, the db transaction is committed.