### PR TITLE
[19.0][FIX] `mrp_multi_level` : Ensure the safety stock is rebuilt as soon as the target date is reached

### DIFF
--- a/mrp_multi_level/wizards/mrp_multi_level.py
+++ b/mrp_multi_level/wizards/mrp_multi_level.py
@@ -671,19 +671,25 @@ class MultiLevelMrp(models.TransientModel):
         for move in product_mrp_area.mrp_move_ids:
             if self._exclude_move(move):
                 continue
-            # This works because mrp moves are ordered by:
-            # product_mrp_area_id, mrp_date, mrp_type desc, id
-            if onhand + move.mrp_qty < product_mrp_area.mrp_minimum_stock:
+            safety_stock_target_date = self._get_safety_stock_target_date(
+                product_mrp_area
+            )
+            onhand_before_safety_stock_date = onhand
+            if move.mrp_qty < 0 or move.mrp_date <= safety_stock_target_date:
+                # This works because mrp moves are ordered by:
+                # product_mrp_area_id, mrp_date, mrp_type desc, id
+                onhand_before_safety_stock_date += move.mrp_qty
+            if onhand_before_safety_stock_date < product_mrp_area.mrp_minimum_stock:
                 qtytoorder = self._get_qty_to_order(
                     product_mrp_area,
-                    self._get_safety_stock_target_date(product_mrp_area),
+                    safety_stock_target_date,
                     0,
                     onhand,
                 )
                 name = self.env._("Safety Stock")
                 cm = self.create_action(
                     product_mrp_area_id=product_mrp_area,
-                    mrp_date=self._get_safety_stock_target_date(product_mrp_area),
+                    mrp_date=safety_stock_target_date,
                     mrp_qty=qtytoorder,
                     name=name,
                     values=dict(origin=name),


### PR DESCRIPTION
even if a supply comes a few days after

(Needed for `mrp_multi_level_consume_safety_stock` tests to pass)

This completes https://github.com/OCA/manufacture/commit/57cba495:

If I have 0 units, my safety stock is 5 units and its target date is tomorrow, the procurement recommendation should be 5 units for tomorrow, even if I have a resupply of 5 the day after tomorrow.

Fwport of https://github.com/OCA/manufacture/pull/1682/changes/8fc61e3d05eb9c9290f4ec46345c1f70649587e5