### PR TITLE
[16.0][FIX] quality_control: fix inspection timings in stock and MRP

### DIFF
--- a/quality_control_mrp_oca/__manifest__.py
+++ b/quality_control_mrp_oca/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "MRP extension for quality control (OCA)",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.2.1",
     "category": "Quality control",
     "license": "AGPL-3",
     "author": "OdooMRP team, "

--- a/quality_control_mrp_oca/models/mrp_production.py
+++ b/quality_control_mrp_oca/models/mrp_production.py
@@ -1,5 +1,6 @@
 # Copyright 2014 Serv. Tec. Avanzados - Pedro M. Baeza
 # Copyright 2018 Simone Rubino - Agile Business Group
+# Copyright 2026 FactorLibre - Adriana Saiz <adriana.saiz@factorlibre.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
@@ -27,25 +28,60 @@ class MrpProduction(models.Model):
     )
 
     def _post_inventory(self, cancel_backorder=False):
-        done_moves = self.mapped("move_finished_ids").filtered(
-            lambda r: r.state == "done"
-        )
         res = super()._post_inventory(cancel_backorder=cancel_backorder)
-        inspection_model = self.env["qc.inspection"]
-        new_done_moves = (
-            self.mapped("move_finished_ids").filtered(lambda r: r.state == "done")
-            - done_moves
+        # Transition plan inspections to ready (same as stock.picking._action_done)
+        plan_inspections = self.sudo().qc_inspections_ids.filtered(
+            lambda x: x.state == "plan"
         )
-        if new_done_moves:
-            qc_trigger = self.env.ref("quality_control_mrp_oca.qc_trigger_mrp")
-        for move in new_done_moves:
-            trigger_lines = set()
-            for model in self.env["qc.trigger.line"].get_trigger_line_models():
-                trigger_lines = trigger_lines.union(
-                    self.env[model].get_trigger_line_for_product(
-                        qc_trigger, ["after"], move.product_id
-                    )
+        plan_inspections.write({"state": "ready", "date": fields.Datetime.now()})
+        # Create "after" inspections for newly done finished moves
+        for production in self:
+            production._trigger_after_qc_inspections()
+        return res
+
+    def _trigger_after_qc_inspections(self):
+        """Trigger QC inspections with 'after' timing for finished moves.
+
+        Reuses stock.move.trigger_inspection() to stay consistent with
+        the picking type trigger mechanism from quality_control_stock_oca.
+        Falls back to qc_trigger_mrp for backward compatibility.
+        """
+        self.ensure_one()
+        inspection_model = self.env["qc.inspection"].sudo()
+        done_moves = self.move_finished_ids.filtered(lambda m: m.state == "done")
+        for move in done_moves:
+            existing = inspection_model._get_existing_inspections(move)
+            if existing.filtered(lambda i: i.timing == "after"):
+                continue
+            # Use picking type trigger (consistent with before/plan_ahead)
+            move.trigger_inspection(["after"])
+            # Fallback: if nothing was created, try with qc_trigger_mrp
+            if not inspection_model._get_existing_inspections(move).filtered(
+                lambda i: i.timing == "after"
+            ):
+                self._trigger_mrp_qc_fallback(move)
+
+    def _trigger_mrp_qc_fallback(self, move):
+        """Fallback for clients with trigger lines configured on qc_trigger_mrp."""
+        qc_trigger = self.env.ref(
+            "quality_control_mrp_oca.qc_trigger_mrp", raise_if_not_found=False
+        )
+        if not qc_trigger:
+            return
+        trigger_lines = set()
+        for model in self.env["qc.trigger.line"].get_trigger_line_models():
+            trigger_lines = trigger_lines.union(
+                self.env[model].get_trigger_line_for_product(
+                    qc_trigger, ["after"], move.product_id
                 )
-            for trigger_line in _filter_trigger_lines(trigger_lines):
-                inspection_model._make_inspection(move, trigger_line)
+            )
+        inspection_model = self.env["qc.inspection"]
+        for trigger_line in _filter_trigger_lines(trigger_lines):
+            inspection_model._make_inspection(move, trigger_line)
+
+    def action_cancel(self):
+        res = super().action_cancel()
+        self.sudo().qc_inspections_ids.filtered(
+            lambda x: x.state == "plan"
+        ).action_cancel()
         return res

--- a/quality_control_mrp_oca/tests/test_quality_control_mrp.py
+++ b/quality_control_mrp_oca/tests/test_quality_control_mrp.py
@@ -1,5 +1,6 @@
 # Copyright 2015 Oihane Crucelaegui - AvanzOSC
 # Copyright 2018 Simone Rubino - Agile Business Group
+# Copyright 2026 FactorLibre - Adriana Saiz <adriana.saiz@factorlibre.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import Form
@@ -41,11 +42,24 @@ class TestQualityControlMrp(TestQualityControlOcaBase):
         cls.production1 = production_form.save()
         cls.production1.action_confirm()
         cls.production1.action_assign()
+        # Picking type trigger (auto-created by quality_control_stock_oca)
+        cls.picking_type_trigger = cls.env["qc.trigger"].search(
+            [("picking_type_id", "=", cls.production1.picking_type_id.id)], limit=1
+        )
         # Inspection
         inspection_lines = cls.inspection_model._prepare_inspection_lines(cls.test)
         cls.inspection1 = cls.inspection_model.create(
             {"name": "Test Inspection", "inspection_lines": inspection_lines}
         )
+
+    def _create_production(self, qty=2.0):
+        """Helper to create a fresh production order."""
+        production_form = Form(self.env["mrp.production"])
+        production_form.product_id = self.product.product_variant_id
+        production_form.bom_id = self.bom
+        production_form.product_qty = qty
+        production = production_form.save()
+        return production
 
     def test_inspection_create_for_product(self):
         self.product.product_variant_id.qc_triggers = [
@@ -120,3 +134,159 @@ class TestQualityControlMrp(TestQualityControlOcaBase):
             {"object_id": "%s,%d" % (self.production1._name, self.production1.id)}
         )
         self.assertEqual(self.inspection1.production_id, self.production1)
+
+    def test_after_with_picking_type_trigger(self):
+        """After inspection is created using the picking type trigger."""
+        self.assertTrue(
+            self.picking_type_trigger,
+            "Picking type trigger should exist for manufacturing operation",
+        )
+        self.product.product_variant_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": self.test.id,
+                    "timing": "after",
+                },
+            )
+        ]
+        production = self._create_production()
+        production.action_confirm()
+        production.action_assign()
+        # No inspection yet (timing is after)
+        self.assertEqual(production.created_inspections, 0)
+        production.qty_producing = production.product_qty
+        production._post_inventory()
+        self.assertEqual(
+            production.created_inspections,
+            1,
+            "One inspection should be created with after timing",
+        )
+        inspection = production.qc_inspections_ids
+        self.assertEqual(inspection.state, "ready")
+
+    def test_plan_ahead_creates_and_transitions(self):
+        """Plan ahead creates PLAN on confirm and transitions to READY on done."""
+        self.assertTrue(
+            self.picking_type_trigger,
+            "Picking type trigger should exist for manufacturing operation",
+        )
+        self.product.product_variant_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": self.test.id,
+                    "timing": "plan_ahead",
+                },
+            )
+        ]
+        production = self._create_production()
+        production.action_confirm()
+        # Inspection should be created in PLAN state by stock.move._action_confirm
+        self.assertEqual(production.created_inspections, 1)
+        inspection = production.qc_inspections_ids
+        self.assertEqual(inspection.state, "plan")
+        # Mark done — should transition to READY
+        production.action_assign()
+        production.qty_producing = production.product_qty
+        production._post_inventory()
+        self.assertEqual(inspection.state, "ready")
+        # No duplicate inspection should be created
+        self.assertEqual(production.created_inspections, 1)
+
+    def test_before_timing(self):
+        """Before inspection is created at confirm time."""
+        self.assertTrue(
+            self.picking_type_trigger,
+            "Picking type trigger should exist for manufacturing operation",
+        )
+        self.product.product_variant_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": self.test.id,
+                    "timing": "before",
+                },
+            )
+        ]
+        production = self._create_production()
+        production.action_confirm()
+        self.assertEqual(production.created_inspections, 1)
+        inspection = production.qc_inspections_ids
+        self.assertEqual(inspection.state, "ready")
+
+    def test_cancel_production_cancels_plan_inspections(self):
+        """Cancelling production cancels plan inspections."""
+        self.assertTrue(
+            self.picking_type_trigger,
+            "Picking type trigger should exist for manufacturing operation",
+        )
+        self.product.product_variant_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": self.test.id,
+                    "timing": "plan_ahead",
+                },
+            )
+        ]
+        production = self._create_production()
+        production.action_confirm()
+        inspection = production.qc_inspections_ids
+        self.assertEqual(inspection.state, "plan")
+        production.action_cancel()
+        self.assertEqual(inspection.state, "canceled")
+
+    def test_plan_ahead_and_after_combined_mo(self):
+        """plan_ahead + after on same product creates 2 inspections on MO."""
+        self.assertTrue(
+            self.picking_type_trigger,
+            "Picking type trigger should exist for manufacturing operation",
+        )
+        test2 = self.test.copy({"name": "Test After MO"})
+        self.product.product_variant_id.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": self.test.id,
+                    "timing": "plan_ahead",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "trigger": self.picking_type_trigger.id,
+                    "test": test2.id,
+                    "timing": "after",
+                },
+            ),
+        ]
+        production = self._create_production()
+        production.action_confirm()
+        # plan_ahead creates inspection in PLAN
+        self.assertEqual(production.created_inspections, 1)
+        plan_inspection = production.qc_inspections_ids
+        self.assertEqual(plan_inspection.state, "plan")
+        self.assertEqual(plan_inspection.timing, "plan_ahead")
+        # Mark done — plan transitions to ready + after is created
+        production.action_assign()
+        production.qty_producing = production.product_qty
+        production._post_inventory()
+        self.assertEqual(production.created_inspections, 2)
+        self.assertEqual(plan_inspection.state, "ready")
+        after_inspection = production.qc_inspections_ids.filtered(
+            lambda i: i.timing == "after"
+        )
+        self.assertEqual(len(after_inspection), 1)
+        self.assertEqual(after_inspection.state, "ready")

--- a/quality_control_oca/__manifest__.py
+++ b/quality_control_oca/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Quality Control OCA",
-    "version": "16.0.1.8.0",
+    "version": "16.0.1.8.1",
     "category": "Quality Control",
     "license": "AGPL-3",
     "summary": "Generic infrastructure for quality tests.",

--- a/quality_control_oca/i18n/es.po
+++ b/quality_control_oca/i18n/es.po
@@ -93,7 +93,7 @@ msgstr "Icono de tipo de actividad"
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_line__timing__after
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_template_line__timing__after
 msgid "After"
-msgstr ""
+msgstr "Después"
 
 #. module: quality_control_oca
 #: model:ir.model.fields,field_description:quality_control_oca.field_qc_inspection_line__possible_ql_values
@@ -133,7 +133,7 @@ msgstr "Mal"
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_line__timing__before
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_template_line__timing__before
 msgid "Before"
-msgstr ""
+msgstr "Antes"
 
 #. module: quality_control_oca
 #: model_terms:ir.ui.view,arch_db:quality_control_oca.qc_inspection_form_view
@@ -664,7 +664,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_line__timing__plan_ahead
 #: model:ir.model.fields.selection,name:quality_control_oca.selection__qc_trigger_product_template_line__timing__plan_ahead
 msgid "Plan Ahead"
-msgstr ""
+msgstr "Planificado"
 
 #. module: quality_control_oca
 #: model:ir.model.fields,field_description:quality_control_oca.field_qc_inspection__date

--- a/quality_control_oca/models/qc_inspection.py
+++ b/quality_control_oca/models/qc_inspection.py
@@ -100,6 +100,14 @@ class QcInspection(models.Model):
         help="This field will be marked if all tests have succeeded.",
         store=True,
     )
+    timing = fields.Selection(
+        selection=[
+            ("before", "Before"),
+            ("after", "After"),
+            ("plan_ahead", "Plan Ahead"),
+        ],
+        readonly=True,
+    )
     auto_generated = fields.Boolean(
         string="Auto-generated",
         readonly=True,
@@ -227,6 +235,7 @@ class QcInspection(models.Model):
             "test": trigger_line.test.id,
             "user": trigger_line.user.id,
             "auto_generated": True,
+            "timing": trigger_line.timing,
         }
 
     def _prepare_inspection_lines(self, test, force_fill=False):

--- a/quality_control_stock_oca/__manifest__.py
+++ b/quality_control_stock_oca/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Quality control - Stock (OCA)",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.4.1",
     "category": "Quality control",
     "license": "AGPL-3",
     "author": "OdooMRP team, AvanzOSC, Serv. Tecnol. Avanzados - Pedro M. Baeza, "

--- a/quality_control_stock_oca/migrations/16.0.1.4.1/post-migrate.py
+++ b/quality_control_stock_oca/migrations/16.0.1.4.1/post-migrate.py
@@ -1,0 +1,20 @@
+# © 2026 FactorLibre - Adriana Saiz <adriana.saiz@factorlibre.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Create qc.trigger for pre-existing picking types that don't have one."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    existing_trigger_pt_ids = (
+        env["qc.trigger"]
+        .search([("picking_type_id", "!=", False)])
+        .mapped("picking_type_id")
+    )
+    missing = (
+        env["stock.picking.type"].with_context(active_test=False).search([])
+        - existing_trigger_pt_ids
+    )
+    if missing:
+        missing._create_qc_trigger()

--- a/quality_control_stock_oca/models/stock_picking.py
+++ b/quality_control_stock_oca/models/stock_picking.py
@@ -82,8 +82,9 @@ class StockPicking(models.Model):
             self.move_ids
         )
         for inspection in existing_inspections:
-            inspection.onchange_object_id()
-            moves_with_inspections += inspection.object_id
+            if inspection.timing in timings:
+                inspection.onchange_object_id()
+                moves_with_inspections += inspection.object_id
         for operation in self.move_ids - moves_with_inspections:
             operation.trigger_inspection(timings, self.partner_id)
 

--- a/quality_control_stock_oca/tests/test_quality_control_stock.py
+++ b/quality_control_stock_oca/tests/test_quality_control_stock.py
@@ -456,3 +456,101 @@ class TestQualityControlStockOca(TestQualityControlOcaBase):
                 line.quantitative_value = 5.0
         inspection.action_confirm()
         picking2._action_done()
+
+    @mute_logger("odoo.models.unlink")
+    def test_plan_ahead_and_after_combined(self):
+        """plan_ahead + after on same product creates 2 inspections."""
+        test2 = self.test.copy({"name": "Test After"})
+        self.product.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": self.test.id,
+                    "timing": "plan_ahead",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": test2.id,
+                    "timing": "after",
+                },
+            ),
+        ]
+        self.picking_confirmation()
+        # plan_ahead creates inspection in PLAN state
+        self.assertEqual(self.picking1.created_inspections, 1)
+        plan_inspection = self.picking1.qc_inspections_ids
+        self.assertEqual(plan_inspection.state, "plan")
+        self.assertEqual(plan_inspection.timing, "plan_ahead")
+        # Validate picking — plan_ahead transitions to ready + after is created
+        self.picking1._action_done()
+        # pylint: disable=W0104
+        self.picking1.qc_inspections_ids  # Force recompute
+        self.assertEqual(self.picking1.created_inspections, 2)
+        after_inspection = self.picking1.qc_inspections_ids.filtered(
+            lambda i: i.timing == "after"
+        )
+        self.assertEqual(len(after_inspection), 1)
+        self.assertEqual(after_inspection.state, "ready")
+        self.assertEqual(plan_inspection.state, "ready")
+
+    @mute_logger("odoo.models.unlink")
+    def test_all_three_timings(self):
+        """before + plan_ahead + after creates 3 inspections total."""
+        test2 = self.test.copy({"name": "Test Plan Ahead"})
+        test3 = self.test.copy({"name": "Test After"})
+        self.product.qc_triggers = [
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": self.test.id,
+                    "timing": "before",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": test2.id,
+                    "timing": "plan_ahead",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "trigger": self.trigger.id,
+                    "test": test3.id,
+                    "timing": "after",
+                },
+            ),
+        ]
+        self.picking_confirmation()
+        # before (ready) + plan_ahead (plan) = 2 inspections
+        self.assertEqual(self.picking1.created_inspections, 2)
+        before_insp = self.picking1.qc_inspections_ids.filtered(
+            lambda i: i.timing == "before"
+        )
+        plan_insp = self.picking1.qc_inspections_ids.filtered(
+            lambda i: i.timing == "plan_ahead"
+        )
+        self.assertEqual(before_insp.state, "ready")
+        self.assertEqual(plan_insp.state, "plan")
+        # Validate — plan_ahead transitions + after created = 3 total
+        self.picking1._action_done()
+        # pylint: disable=W0104
+        self.picking1.qc_inspections_ids  # Force recompute
+        self.assertEqual(self.picking1.created_inspections, 3)
+        after_insp = self.picking1.qc_inspections_ids.filtered(
+            lambda i: i.timing == "after"
+        )
+        self.assertEqual(after_insp.state, "ready")
+        self.assertEqual(plan_insp.state, "ready")


### PR DESCRIPTION
quality_control_oca:
- Add timing field to qc.inspection to track which timing created each
  inspection (before/after/plan_ahead)
- Pass timing in _prepare_inspection_header
- Add Spanish translations for timing values

quality_control_stock_oca:
- Fix trigger_inspections() to only skip moves that already have an
  inspection of the same timing (allows plan_ahead + after combined)
- Add migration to create qc.trigger for pre-existing picking types

quality_control_mrp_oca:
- Fix after timing: reuse stock.move.trigger_inspection() instead of
  searching against qc_trigger_mrp (wrong trigger)
- Fix plan_ahead timing: add plan→ready transition in _post_inventory
- Add action_cancel() to cancel plan inspections when MO is cancelled