### PR TITLE
[FIX] quality_control_stock_oca: fix Done filter to match done_inspection count

### DIFF
--- a/quality_control_stock_oca/views/stock_picking_view.xml
+++ b/quality_control_stock_oca/views/stock_picking_view.xml
@@ -15,7 +15,7 @@
         <field name="view_mode">list,form</field>
         <field
             name="domain"
-        >[('picking_id', '=', active_id), ('state', 'not in', ['draft', 'waiting'])]</field>
+        >[('picking_id', '=', active_id), ('state', 'in', ['success', 'failed'])]</field>
         <field name="context">{'default_picking_id': active_id}</field>
     </record>
     <record id="action_qc_inspection_per_picking_passed" model="ir.actions.act_window">

--- a/quality_control_stock_oca/views/stock_production_lot_view.xml
+++ b/quality_control_stock_oca/views/stock_production_lot_view.xml
@@ -15,7 +15,7 @@
         <field name="view_mode">list,form</field>
         <field
             name="domain"
-        >[('lot_id', '=', active_id), ('state', 'not in', ['draft', 'waiting'])]</field>
+        >[('lot_id', '=', active_id), ('state', 'in', ['success', 'failed'])]</field>
         <field name="context">{'default_lot_id': active_id}</field>
     </record>
     <record id="action_qc_inspection_per_lot_passed" model="ir.actions.act_window">


### PR DESCRIPTION
## Description

The "Done" button (stat) shows the count of passed + failed inspections, but when clicking on it, the action domain was filtering by `state not in (draft, waiting)`, which also includes `ready` state - causing a mismatch between the displayed count and the actual records shown.

## Steps to reproduce

1. Install quality_control_stock_oca module
2. Create a picking with quality inspections
3. Note that some inspections may be in "ready" state
4. The Done button shows (passed + failed) count
5. Clicking the button shows more records (including ready state)

## Fix

Changed the domain in both stock_picking_view.xml and stock_production_lot_view.xml from:
- `state not in ['draft', 'waiting']`
to:
- `state in ['success', 'failed']`

This matches the logic in the computed field `done_inspections = passed_inspections + failed_inspections`.

## Related Issue

Closes https://github.com/OCA/manufacture/issues/1713

---

Contributor from SMWLAB community.