### PR TITLE
[18.0][ADD] mrp_workorder_blocking_time: French translation

### DIFF
--- a/mrp_workorder_blocking_time/i18n/fr.po
+++ b/mrp_workorder_blocking_time/i18n/fr.po
@@ -1,0 +1,143 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* mrp_workorder_blocking_time
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr\n"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_form_view
+msgid "Accept and stop WO"
+msgstr "Accepter et arrêter l'OT"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder__blocking_period_interrupted
+msgid "Blocking Period Interrupted"
+msgstr "Période de blocage interrompue"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_routing_workcenter__blocking_stage
+msgid "Blocking Stage"
+msgstr "Étape de blocage"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder__blocking_stage_end
+msgid "Blocking Stage End"
+msgstr "Fin de l'étape de blocage"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_form_view
+msgid "Cancel and continue WO"
+msgstr "Annuler et continuer l'OT"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__id
+msgid "ID"
+msgstr "ID"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder__interruption_reason
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__interruption_reason
+msgid "Interruption Reason"
+msgstr "Motif d'interruption"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Dernière modification par"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_workorder_blocking_reason_wizard__write_date
+msgid "Last Updated on"
+msgstr "Dernière modification le"
+
+#. module: mrp_workorder_blocking_time
+#. odoo-python
+#: code:addons/mrp_workorder_blocking_time/wizards/wizard_open_blocking_popup.py:0
+msgid "No action to do"
+msgstr "Aucune action à effectuer"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_routing_workcenter_blocking_time_form_inherit
+msgid "Rec. Blocking Time"
+msgstr "Temps de blocage recom."
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_routing_workcenter_blocking_time_tree_inherit
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_routing_workcenter_bom_blocking_time_tree_inherit
+msgid "Rec. Blocking Time (hours)"
+msgstr "Temps de blocage recom. (heures)"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model.fields,field_description:mrp_workorder_blocking_time.field_mrp_routing_workcenter__recommended_blocking_time
+msgid "Recommended Blocking Time"
+msgstr "Temps de blocage recommandé"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_form_view
+msgid "Warning"
+msgstr "Avertissement"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model,name:mrp_workorder_blocking_time.model_mrp_workorder_blocking_reason_wizard
+msgid "Wizard to open a blocking reason popup for a workorder"
+msgstr "Assistant pour ouvrir une fenêtre de motif de blocage pour un ordre de travail"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model,name:mrp_workorder_blocking_time.model_mrp_routing_workcenter
+msgid "Work Center Usage"
+msgstr "Utilisation du poste de travail"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.model,name:mrp_workorder_blocking_time.model_mrp_workorder
+msgid "Work Order"
+msgstr "Ordre de travail"
+
+#. module: mrp_workorder_blocking_time
+#: model:ir.actions.act_window,name:mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_act_window
+msgid "WorkOrder Blocking Reason Popup"
+msgstr "Fenêtre de motif de blocage de l'ordre de travail"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_workorder_blocking_reason_wizard_form_view
+msgid ""
+"You are trying to pause/finish a workorder, but the blocking period is not over.\n"
+"                                Are you sure you want to continue?"
+msgstr ""
+"Vous essayez de mettre en pause/terminer un ordre de travail, mais la période de blocage n'est pas terminée.\n"
+"                                Êtes-vous sûr de vouloir continuer ?"
+
+#. module: mrp_workorder_blocking_time
+#. odoo-python
+#: code:addons/mrp_workorder_blocking_time/models/mrp_workorder.py:0
+msgid "You cannot remove a blocking operation!"
+msgstr "Vous ne pouvez pas supprimer une opération bloquante !"
+
+#. module: mrp_workorder_blocking_time
+#: model_terms:ir.ui.view,arch_db:mrp_workorder_blocking_time.mrp_routing_workcenter_blocking_time_form_inherit
+msgid "hours"
+msgstr "heures"


### PR DESCRIPTION
Adding French translation for the `mrp_workorder_blocking_time` module.