### PR TITLE
[17.0][IMP] mrp_production_serial_matrix: cancel status + allowed_component_lot_ids api.depends

### DIFF
--- a/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
@@ -20,6 +20,7 @@ class MrpProductionSerialMatrix(models.Model):
             ("in_progress", "In Progress"),
             ("exception", "Exception"),
             ("done", "Done"),
+            ("cancel", "Cancelled"),
         ],
         string="Status",
         required=True,
@@ -33,6 +34,10 @@ class MrpProductionSerialMatrix(models.Model):
         string="Manufacturing Order",
         readonly=True,
         ondelete="cascade",
+    )
+    production_state = fields.Selection(
+        related="production_id.state",
+        string="MO Status",
     )
     product_id = fields.Many2one(
         related="production_id.product_id",
@@ -67,11 +72,84 @@ class MrpProductionSerialMatrix(models.Model):
 
     def unlink(self):
         for matrix in self:
-            if matrix.state in ["done", "in_progress"]:
+            if matrix.state in ["done", "in_progress", "cancel"]:
                 raise UserError(
-                    _("You cannot delete a serial matrix that is in progress or done.")
+                    _(
+                        "You cannot delete a serial matrix that is in progress, "
+                        "done or cancelled."
+                    )
                 )
         return super().unlink()
+
+    def action_cancel_matrix(self):
+        self.ensure_one()
+        if self.production_id.state not in ("done", "cancel"):
+            raise UserError(
+                _(
+                    "The matrix can only be cancelled when the related MO is "
+                    "done or cancelled."
+                )
+            )
+        if self.state in ("done", "cancel"):
+            raise UserError(_("The matrix is already %s.") % self.state)
+        self.state = "cancel"
+        self.message_post(
+            body=_(
+                "Matrix manually cancelled. The related MO (%(mo)s) is in state "
+                "'%(state)s'."
+            )
+            % {"mo": self.production_id.name, "state": self.production_id.state}
+        )
+
+    def action_reset_to_draft(self):
+        self.ensure_one()
+        if self.state != "exception":
+            raise UserError(
+                _("Only matrices in 'Exception' state can be reset to 'Draft'.")
+            )
+        pg = self.production_id.procurement_group_id
+        if pg:
+            related_mos = pg.mrp_production_ids
+            pending_mos = related_mos.filtered(
+                lambda m: m.state not in ("done", "cancel")
+            )
+            processed_lots = related_mos.filtered(lambda m: m.state == "done").mapped(
+                "lot_producing_id"
+            )
+        else:
+            pending_mos = self.production_id.filtered(
+                lambda m: m.state not in ("done", "cancel")
+            )
+            processed_lots = self.env["stock.lot"]
+        if not pending_mos:
+            raise UserError(
+                _(
+                    "There is no pending MO related to this matrix. Cancel the "
+                    "matrix instead."
+                )
+            )
+        pending_mo = pending_mos[:1]
+        remaining_lots = self.finished_lot_ids - processed_lots
+        self.production_id = pending_mo
+        self.line_ids.unlink()
+        matrix_lines = self._get_matrix_lines(pending_mo, remaining_lots)
+        self.write(
+            {
+                "finished_lot_ids": [(6, 0, remaining_lots.ids)],
+                "line_ids": [(0, 0, x) for x in matrix_lines],
+                "state": "draft",
+            }
+        )
+        self.message_post(
+            body=_(
+                "Matrix reset to 'Draft'. Pending MO: %(mo)s. Remaining serial "
+                "numbers to process: %(lots)s."
+            )
+            % {
+                "mo": pending_mo.name,
+                "lots": ", ".join(remaining_lots.mapped("name")) or "—",
+            }
+        )
 
     @api.depends("line_ids", "line_ids.component_lot_id")
     def _compute_lot_selection_warning(self):

--- a/mrp_production_serial_matrix/models/mrp_production_serial_matrix_line.py
+++ b/mrp_production_serial_matrix/models/mrp_production_serial_matrix_line.py
@@ -1,7 +1,7 @@
 # Copyright 2019-24 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MrpProductionSerialMatrixLine(models.Model):
@@ -27,6 +27,7 @@ class MrpProductionSerialMatrixLine(models.Model):
     lot_qty = fields.Float(digits="Product Unit of Measure")
     state = fields.Selection(related="wizard_id.state")
 
+    @api.depends("component_id", "production_id.location_src_id")
     def _compute_allowed_component_lot_ids(self):
         for rec in self:
             available_quants = self.env["stock.quant"].search(

--- a/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
@@ -478,5 +478,115 @@ class TestMrpProductionSerialMatrix(TransactionCase):
         serial_matrix.state = "in_progress"
         with self.assertRaises(UserError):
             serial_matrix.unlink()
+        serial_matrix.state = "cancel"
+        with self.assertRaises(UserError):
+            serial_matrix.unlink()
         serial_matrix.state = "draft"
         serial_matrix.unlink()
+
+    def test_07_cancel_matrix(self):
+        """A matrix can be cancelled when the related MO is done or cancelled."""
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create({"production_id": production.id})
+        matrix.state = "exception"
+        # Cannot cancel while MO is still active
+        with self.assertRaises(UserError):
+            matrix.action_cancel_matrix()
+        # Set MO to done manually and cancel the matrix
+        production.state = "done"
+        matrix.action_cancel_matrix()
+        self.assertEqual(matrix.state, "cancel")
+        # Cannot cancel a matrix that is already cancelled or done
+        with self.assertRaises(UserError):
+            matrix.action_cancel_matrix()
+
+    def test_08_cancel_requires_manager_in_view(self):
+        """The Cancel button is restricted to mrp.group_mrp_manager users."""
+        manager_group = self.env.ref("mrp.group_mrp_manager")
+        # group is referenced only on the view; ensure it exists and the action
+        # is callable regardless (group enforcement is the view's responsibility).
+        self.assertTrue(manager_group)
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create({"production_id": production.id})
+        matrix.state = "exception"
+        production.state = "done"
+        matrix.action_cancel_matrix()
+        self.assertEqual(matrix.state, "cancel")
+
+    def test_09_reset_to_draft_no_split(self):
+        """Reset to draft when the exception happened before any MO split."""
+        production = self._create_mo(2.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp_1 = self._create_serial_number(self.final_product, "FP-RTD-1", qty=0)
+        serial_fp_2 = self._create_serial_number(self.final_product, "FP-RTD-2", qty=0)
+        matrix.finished_lot_ids = serial_fp_1 | serial_fp_2
+        matrix._onchange_finished_lot_ids()
+        line_count_before = len(matrix.line_ids)
+        matrix.state = "exception"
+        # Cannot reset from another state
+        matrix.state = "draft"
+        with self.assertRaises(UserError):
+            matrix.action_reset_to_draft()
+        matrix.state = "exception"
+        # Reset should regenerate lines for all serials and point to the same MO
+        matrix.action_reset_to_draft()
+        self.assertEqual(matrix.state, "draft")
+        self.assertEqual(matrix.production_id, production)
+        self.assertEqual(matrix.finished_lot_ids, serial_fp_1 | serial_fp_2)
+        self.assertEqual(len(matrix.line_ids), line_count_before)
+
+    def test_10_reset_to_draft_after_split(self):
+        """Reset to draft after a successful first iteration: matrix points to the
+        backorder MO and lines are regenerated for the remaining serials."""
+        production = self._create_mo(2.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp_1 = self._create_serial_number(self.final_product, "FP-RTD-3", qty=0)
+        serial_fp_2 = self._create_serial_number(self.final_product, "FP-RTD-4", qty=0)
+        matrix.finished_lot_ids = serial_fp_1 | serial_fp_2
+        matrix._onchange_finished_lot_ids()
+        # Fill row for serial_fp_1 only
+        line_1_c1 = matrix.line_ids.filtered(
+            lambda line: line.finished_lot_id == serial_fp_1
+            and line.component_id == self.component_1_serial
+        )
+        line_1_c1.component_lot_id = self.serial_1_001
+        c2_lines_1 = matrix.line_ids.filtered(
+            lambda line: line.finished_lot_id == serial_fp_1
+            and line.component_id == self.component_2_serial
+        )
+        c2_lines_1[0].component_lot_id = self.serial_2_001
+        c2_lines_1[1].component_lot_id = self.serial_2_002
+        matrix.line_ids.filtered(
+            lambda line: line.finished_lot_id == serial_fp_1
+            and line.component_id == self.component_3_lot
+        ).component_lot_id = self.lot_3_001
+        # Process only the first finished serial; simulate the exception that
+        # would have happened on the second iteration.
+        matrix._prepare_mo_for_serial(production, serial_fp_1)
+        matrix._process_component_moves(
+            production, serial_fp_1, matrix._get_matrix_lines_map()
+        )
+        backorder_mo = matrix._validate_and_get_backorder(production)
+        self.assertTrue(backorder_mo)
+        self.assertEqual(production.state, "done")
+        matrix.state = "exception"
+        matrix.action_reset_to_draft()
+        self.assertEqual(matrix.state, "draft")
+        self.assertEqual(matrix.production_id, backorder_mo)
+        self.assertEqual(matrix.finished_lot_ids, serial_fp_2)
+        # Lines should now correspond to the backorder MO's qty (1) for the
+        # remaining serial only.
+        self.assertEqual(matrix.line_ids.mapped("finished_lot_id"), serial_fp_2)
+
+    def test_11_reset_to_draft_no_pending_mo(self):
+        """If all related MOs are done, reset to draft must fail."""
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create({"production_id": production.id})
+        matrix.state = "exception"
+        production.state = "done"
+        with self.assertRaises(UserError):
+            matrix.action_reset_to_draft()

--- a/mrp_production_serial_matrix/views/mrp_production_serial_matrix_view.xml
+++ b/mrp_production_serial_matrix/views/mrp_production_serial_matrix_view.xml
@@ -13,7 +13,21 @@
                         class="oe_highlight"
                         invisible="state not in ['draft', 'exception']"
                     />
-                    <field
+                        <button
+                        name="action_reset_to_draft"
+                        string="Reset to Draft"
+                        type="object"
+                        invisible="state != 'exception'"
+                    />
+                        <button
+                        name="action_cancel_matrix"
+                        string="Cancel"
+                        type="object"
+                        invisible="state in ('done', 'cancel') or production_state not in ('done', 'cancel')"
+                        groups="mrp.group_mrp_manager"
+                    />
+                        <field name="production_state" invisible="1" />
+                        <field
                         name="state"
                         widget="statusbar"
                         statusbar_visible="draft,in_progress,done"
@@ -130,6 +144,7 @@
                     decoration-info="state == 'draft'"
                     decoration-success="state == 'done'"
                     decoration-danger="state == 'exception'"
+                    decoration-muted="state == 'cancel'"
                 />
                 <field name="company_id" optional="hide" />
                 <field name="include_lots" optional="hide" />
@@ -176,6 +191,11 @@
                     name="state_exception"
                     string="Exception"
                     domain="[('state', '=', 'exception')]"
+                />
+                <filter
+                    name="state_cancel"
+                    string="Cancelled"
+                    domain="[('state', '=', 'cancel')]"
                 />
                 <separator />
             </search>


### PR DESCRIPTION
Depend allowed_component_lot_ids on related fields to ensure the value is always correctly updated. Allow manual cancel and reset to draft.