### PR TITLE
[17.0][FIX] mrp_production_serial_matrix_import_xlsx

### DIFF
--- a/mrp_production_serial_matrix_import_xlsx/models/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix_import_xlsx/models/mrp_production_serial_matrix.py
@@ -196,7 +196,7 @@ class MrpProductionSerialMatrix(models.Model):
             finished_lot_ids, component_templates, data_map
         )
 
-        if new_lines_vals:
+        if new_lines_vals or finished_lot_ids:
             self.line_ids = [(5, 0, 0)]
             self.line_ids = [(0, 0, v) for v in new_lines_vals]
             self.finished_lot_ids = [(6, 0, finished_lot_ids.ids)]


### PR DESCRIPTION
If the imported file contains or matrix lines or the finished_lot_ids, the system should allow to import the data.

In line 202 the finished lots are updated, so we want to enter here if we have something to write.