### PR TITLE
[IMP] quality_control_oca, various: Get translated model name in object_id

### DIFF
--- a/quality_control_oca/models/qc_inspection.py
+++ b/quality_control_oca/models/qc_inspection.py
@@ -23,9 +23,13 @@ class QcInspection(models.Model):
     def object_selection_values(self):
         """
         Overridable method for adding more object models to an inspection.
+        Get model and name using ref to have translation for model names.
+        Use self.env.ref(xxx.model_yyy) where xxx is the module name and yyy is the
+        model, replacing dots with underscores.
         :return: A list with the selection's possible values.
         """
-        return [("product.product", "Product")]
+        models_obj = [self.sudo().env.ref("product.model_product_product")]
+        return [(x.model, x.name) for x in models_obj]
 
     @api.depends("object_id")
     def _compute_product_id(self):

--- a/quality_control_stock_oca/models/qc_inspection.py
+++ b/quality_control_stock_oca/models/qc_inspection.py
@@ -18,13 +18,12 @@ class QcInspection(models.Model):
 
     def object_selection_values(self):
         result = super().object_selection_values()
-        result.extend(
-            [
-                ("stock.picking", "Picking List"),
-                ("stock.move", "Stock Move"),
-                ("stock.lot", "Lot/Serial Number"),
-            ]
-        )
+        models_obj = [
+            self.sudo().env.ref("stock.model_stock_picking"),
+            self.sudo().env.ref("stock.model_stock_move"),
+            self.sudo().env.ref("stock.model_stock_lot"),
+        ]
+        result.extend([(x.model, x.name) for x in models_obj])
         return result
 
     @api.depends("object_id")


### PR DESCRIPTION
quality_control_oca, quality_control_stock_oca:
Refactor object_selection_values() in qc.inspection to get model and name from ir.model using env.ref
Model refs are taken from a dependent module.
This makes the selection dropdown in the UI translated (using the model name in ir.model).

As the reimplementation just changes how the models in these modules are inserted in the selection field, any overrides in custom modules still work.