### PR TITLE
[IMP] mrp_multi_level: add date filters on planned order search view

### DIFF
--- a/mrp_multi_level/i18n/es.po
+++ b/mrp_multi_level/i18n/es.po
@@ -835,6 +835,31 @@ msgid "Release Date"
 msgstr "Fecha de publicación"
 
 #. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 30 Days)"
+msgstr "Publicadas (últimos 30 días)"
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 365 Days)"
+msgstr "Publicadas (últimos 365 días)"
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 7 Days)"
+msgstr "Publicadas (últimos 7 días)"
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released Today"
+msgstr "Publicadas hoy"
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released Yesterday"
+msgstr "Publicadas ayer"
+
+#. module: mrp_multi_level
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_tree
 msgid "Requests for Quotation"
 msgstr ""

--- a/mrp_multi_level/i18n/mrp_multi_level.pot
+++ b/mrp_multi_level/i18n/mrp_multi_level.pot
@@ -831,6 +831,31 @@ msgid "Release Date"
 msgstr ""
 
 #. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 30 Days)"
+msgstr ""
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 365 Days)"
+msgstr ""
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released (Last 7 Days)"
+msgstr ""
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released Today"
+msgstr ""
+
+#. module: mrp_multi_level
+#: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_planned_order_view_search
+msgid "Released Yesterday"
+msgstr ""
+
+#. module: mrp_multi_level
 #: model_terms:ir.ui.view,arch_db:mrp_multi_level.mrp_inventory_tree
 msgid "Requests for Quotation"
 msgstr ""

--- a/mrp_multi_level/views/mrp_planned_order_views.xml
+++ b/mrp_multi_level/views/mrp_planned_order_views.xml
@@ -93,6 +93,35 @@
                     domain="[('mrp_planner_id', '=', uid)]"
                 />
                 <filter string="Fixed" name="fixed" domain="[('fixed','=',True)]" />
+                <separator />
+                <filter
+                    string="Released Today"
+                    name="release_today"
+                    domain="[('order_release_date', '=', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    string="Released Yesterday"
+                    name="release_yesterday"
+                    domain="[('order_release_date', '=', (context_today() - datetime.timedelta(days=1)).strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    string="Released (Last 7 Days)"
+                    name="release_last_7_days"
+                    domain="[('order_release_date', '&gt;=', (context_today() - datetime.timedelta(days=6)).strftime('%Y-%m-%d')),
+                            ('order_release_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    string="Released (Last 30 Days)"
+                    name="release_last_30_days"
+                    domain="[('order_release_date', '&gt;=', (context_today() - datetime.timedelta(days=29)).strftime('%Y-%m-%d')),
+                            ('order_release_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    string="Released (Last 365 Days)"
+                    name="release_last_365_days"
+                    domain="[('order_release_date', '&gt;=', (context_today() - datetime.timedelta(days=364)).strftime('%Y-%m-%d')),
+                            ('order_release_date', '&lt;=', context_today().strftime('%Y-%m-%d'))]"
+                />
                 <group name='group_by' expand="0" string="Group By...">
                     <filter
                         name='product_parameters'


### PR DESCRIPTION
Add predefined date filters (Today, Yesterday, Last 7 Days, Last 30 Days, Last 365 Days) on order_release_date field in the planned order search view.