### PR TITLE
[19.0][FIX] mrp_multi_level: use PTAV ids in bom_product_template_attribute_value_ids test setUp

### DIFF
--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -822,6 +822,20 @@ class TestMrpMultiLevelCommon(TransactionCase):
         product_4b.default_code = "product.product_product_4b"
         product_4c.default_code = "product.product_product_4c"
 
+        # Resolve product.template.attribute.value (PTAV) records for product_4.
+        # `attr1_v1` and friends are `product.attribute.value` (PAV) records;
+        # `bom_product_template_attribute_value_ids` requires PTAV ids, which are
+        # per-template and auto-created when product_4 is created above.
+        def _ptav(pav):
+            return product_4.attribute_line_ids.product_template_value_ids.filtered(
+                lambda v: v.product_attribute_value_id == pav
+            )
+
+        ptav_attr1_v1 = _ptav(attr1_v1)
+        ptav_attr1_v2 = _ptav(attr1_v2)
+        ptav_attr2_v1 = _ptav(attr2_v1)
+        ptav_attr2_v2 = _ptav(attr2_v2)
+
         # Create MRP Areas for products
         products_to_area = [
             "FP-1",
@@ -1072,7 +1086,9 @@ class TestMrpMultiLevelCommon(TransactionCase):
                 "product_uom_id": uom_unit.id,
                 "sequence": 1,
                 "bom_id": bom_p4.id,
-                "bom_product_template_attribute_value_ids": [(6, 0, [attr1_v1.id])],
+                "bom_product_template_attribute_value_ids": [
+                    (6, 0, [ptav_attr1_v1.id])
+                ],
             }
         )
         cls.env["mrp.bom.line"].create(
@@ -1082,7 +1098,9 @@ class TestMrpMultiLevelCommon(TransactionCase):
                 "product_uom_id": uom_unit.id,
                 "sequence": 2,
                 "bom_id": bom_p4.id,
-                "bom_product_template_attribute_value_ids": [(6, 0, [attr1_v2.id])],
+                "bom_product_template_attribute_value_ids": [
+                    (6, 0, [ptav_attr1_v2.id])
+                ],
             }
         )
         cls.env["mrp.bom.line"].create(
@@ -1092,7 +1110,9 @@ class TestMrpMultiLevelCommon(TransactionCase):
                 "product_uom_id": uom_unit.id,
                 "sequence": 3,
                 "bom_id": bom_p4.id,
-                "bom_product_template_attribute_value_ids": [(6, 0, [attr2_v1.id])],
+                "bom_product_template_attribute_value_ids": [
+                    (6, 0, [ptav_attr2_v1.id])
+                ],
             }
         )
         cls.env["mrp.bom.line"].create(
@@ -1102,7 +1122,9 @@ class TestMrpMultiLevelCommon(TransactionCase):
                 "product_uom_id": uom_unit.id,
                 "sequence": 4,
                 "bom_id": bom_p4.id,
-                "bom_product_template_attribute_value_ids": [(6, 0, [attr2_v2.id])],
+                "bom_product_template_attribute_value_ids": [
+                    (6, 0, [ptav_attr2_v2.id])
+                ],
             }
         )
 


### PR DESCRIPTION
The `bom_product_template_attribute_value_ids` m2m on `mrp.bom.line` targets `product.template.attribute.value` (PTAV), not `product.attribute.value` (PAV). These are two different models with **independent PostgreSQL id sequences**:

- `product.attribute.value` (PAV) — the global catalog entry, e.g. "the color Steel exists as a value of the Material attribute".
- `product.template.attribute.value` (PTAV) — the per-template binding, auto-created when a product.template references PAVs via its `attribute_line_ids`.

`tests/common.py::_create_demo_data` passes `attr1_v1.id` (a PAV id) into the m2m at lines 1075/1085/1095/1105. The test passes only when that integer happens to coincide with a valid PTAV id by accidental sequence alignment.

## How this surfaces as a CI failure

If any unrelated test in the same CI sweep shifts the PostgreSQL `product_attribute_value_id_seq` ahead of `product_template_attribute_value_id_seq` (e.g. via `TestMrpCommon`-derived setUpClass executions running before `mrp_multi_level`), the alignment breaks and we get:

```
psycopg2.errors.ForeignKeyViolation:
  insert or update on table "mrp_bom_line_product_template_attribute_value_rel"
  violates foreign key constraint
  "mrp_bom_line_product_template_product_template_attribute_v_fkey"
DETAIL: Key (product_template_attribute_value_id)=(N) is not present
  in table "product_template_attribute_value".
```

This was hit during CI on [#1786](https://github.com/OCA/manufacture/pull/1786) (`[19.0][MIG] mrp_bom_line_formula_quantity`), but the bug is independent of that PR — any module added to the install set can trigger it by shifting id sequences.

## Fix

Resolve PTAVs from `product_4`'s `attribute_line_ids.product_template_value_ids` and use those resolved ids in the four BoM line creates. The PAV usage on lines 800/808 (where `value_ids` of `product.template.attribute.line` legitimately takes PAV ids) is correct and stays as-is.

## Verification

Locally on `odoo:19.0` with demo data, two-phase CI-faithful install:

| State | Result |
|---|---|
| Before fix (sequences misaligned) | `0 failed, 1 error(s) of 28 tests` — `setUpClass` FK violation |
| After fix | `0 failed, 0 error(s) of 53 tests` |

cc: @JordiMForgeFlow @pedrobaeza @LoisRForgeFlow