### PR TITLE
[17.0][FIX] quality_control_oca: Restore object_id on qc.test with dynamic model selection

### DIFF
--- a/quality_control_oca/models/qc_test.py
+++ b/quality_control_oca/models/qc_test.py
@@ -32,6 +32,31 @@ class QcTest(models.Model):
         default=lambda self: self.env.company,
     )
 
+    @api.model
+    def _get_object_id_models(self):
+        """Return the list of models selectable for the object_id field.
+        Override this method to add more models.
+        :return: List of model technical names.
+        """
+        return ["product.product", "product.template"]
+
+    @api.model
+    def object_selection_values(self):
+        """Build the selection list for the Reference field from ir.model."""
+        res = []
+        for model_name in self._get_object_id_models():
+            model = self.env["ir.model"]._get(model_name)
+            if model:
+                res.append((model_name, model.name))
+        return res
+
+    object_id = fields.Reference(
+        string="Reference object",
+        selection="object_selection_values",
+        help="If set, this test applies only to this specific object. "
+        "If empty, the test is generic and can be used for any object.",
+    )
+
 
 class QcTestQuestion(models.Model):
     """Each test line is a question with its valid value(s)."""

--- a/quality_control_oca/models/qc_trigger_product_line.py
+++ b/quality_control_oca/models/qc_trigger_product_line.py
@@ -15,6 +15,25 @@ class QcTriggerProductLine(models.Model):
 
     product = fields.Many2one(comodel_name="product.product")
 
+    @api.onchange("product")
+    def onchange_product(self):
+        if self.product:
+            return {
+                "domain": {
+                    "test": [
+                        (
+                            "object_id",
+                            "in",
+                            [
+                                False,
+                                "product.product,%d" % self.product.id,
+                            ],
+                        )
+                    ]
+                }
+            }
+        return {"domain": {"test": [("object_id", "=", False)]}}
+
     def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         trigger_lines = super().get_trigger_line_for_product(
             trigger, timings, product, partner=partner

--- a/quality_control_oca/models/qc_trigger_product_template_line.py
+++ b/quality_control_oca/models/qc_trigger_product_template_line.py
@@ -15,6 +15,25 @@ class QcTriggerProductTemplateLine(models.Model):
 
     product_template = fields.Many2one(comodel_name="product.template")
 
+    @api.onchange("product_template")
+    def onchange_product_template(self):
+        if self.product_template:
+            return {
+                "domain": {
+                    "test": [
+                        (
+                            "object_id",
+                            "in",
+                            [
+                                False,
+                                "product.template,%d" % self.product_template.id,
+                            ],
+                        )
+                    ]
+                }
+            }
+        return {"domain": {"test": [("object_id", "=", False)]}}
+
     def get_trigger_line_for_product(self, trigger, timings, product, partner=False):
         trigger_lines = super().get_trigger_line_for_product(
             trigger, timings, product, partner=partner

--- a/quality_control_oca/views/qc_test_view.xml
+++ b/quality_control_oca/views/qc_test_view.xml
@@ -25,6 +25,7 @@
                     </h1>
                     <group>
                         <group>
+                            <field name="object_id" />
                             <field name="category" />
                             <field name="fill_correct_values" />
                             <field
@@ -61,6 +62,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
+                <field name="object_id" />
                 <field name="category" />
                 <field name="company_id" groups="base.group_multi_company" />
             </tree>


### PR DESCRIPTION
This PR restores the `object_id` field on `qc.test` that was present in 14.0/16.0 but removed in 17.0 due to a broken selection implementation (see #1286).

## What changed

- **qc.test**: Re-introduced `object_id` as a `Reference` field with a dynamic, extensible selection mechanism via `_get_object_id_models()`.
- **Trigger lines**: Added domain filtering in `qc.trigger.product_line` and `qc.trigger.product_template_line` so only generic tests (empty `object_id`) or tests linked to the same product/template can be selected.
- **Views**: Added `object_id` to qc.test form and tree views.

## Architecture

- `object_id` empty = generic test (can be used for any object).
- `object_id` set = product-specific drawing inspection plan.
- Submodules can extend `_get_object_id_models()` to add more model types.

Closes #1568