### PR TITLE
[16.0][FIX] mrp_subcontracting_skip_no_negative: fix backorder creation

### DIFF
--- a/mrp_subcontracting_skip_no_negative/models/__init__.py
+++ b/mrp_subcontracting_skip_no_negative/models/__init__.py
@@ -1,2 +1,3 @@
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking

--- a/mrp_subcontracting_skip_no_negative/models/stock_move.py
+++ b/mrp_subcontracting_skip_no_negative/models/stock_move.py
@@ -11,9 +11,7 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     def _action_done(self, cancel_backorder=False):
-        moves_with_no_check = self.filtered(lambda x: x.is_subcontract).with_context(
-            skip_negative_qty_check=True
-        )
+        moves_with_no_check = self.filtered(lambda x: x.is_subcontract)
         # For rather unlikely occassions where linked production is not in the right
         # state.
         for move in moves_with_no_check:
@@ -69,10 +67,7 @@ class StockMove(models.Model):
                             location=location.complete_name,
                         )
                     )
-        res = super(StockMove, moves_with_no_check)._action_done(
-            cancel_backorder=cancel_backorder
-        )
-        res += super(StockMove, self - moves_with_no_check)._action_done(
-            cancel_backorder=cancel_backorder
-        )
-        return res
+        return super(
+            StockMove,
+            self.with_context(skip_no_negative_move_ids=moves_with_no_check.ids),
+        )._action_done(cancel_backorder=cancel_backorder)

--- a/mrp_subcontracting_skip_no_negative/models/stock_move_line.py
+++ b/mrp_subcontracting_skip_no_negative/models/stock_move_line.py
@@ -1,0 +1,21 @@
+# Copyright 2026 ForgeFlow
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _action_done(self):
+        skip_ids = self.env.context.get("skip_no_negative_move_ids")
+        if not skip_ids:
+            return super()._action_done()
+        skip_ids = set(skip_ids)
+        mls_to_skip = self.filtered(lambda ml: ml.move_id.id in skip_ids)
+        super(
+            StockMoveLine,
+            mls_to_skip.with_context(skip_negative_qty_check=True),
+        )._action_done()
+        super(StockMoveLine, self - mls_to_skip)._action_done()
+        return

--- a/mrp_subcontracting_skip_no_negative/models/stock_picking.py
+++ b/mrp_subcontracting_skip_no_negative/models/stock_picking.py
@@ -20,25 +20,3 @@ class StockPicking(models.Model):
             ]
         )
         quants.check_negative_qty()
-
-    def _get_moves_to_backorder(self):
-        self.ensure_one()
-        moves = super()._get_moves_to_backorder()
-        if self.env.context.get("skip_negative_qty_check"):
-            return moves.filtered(lambda x: x.is_subcontract)
-        return moves
-
-    def _create_backorder_picking(self):
-        self.ensure_one()
-        existing_backorder_picking = self.env["stock.picking"].search(
-            [("backorder_id", "=", self.id)]
-        )
-        existing_subcontract_moves = existing_backorder_picking.move_ids.filtered(
-            lambda x: x.is_subcontract
-        )
-        if (
-            self.move_ids.filtered(lambda x: x.state == "done" and x.is_subcontract)
-            and existing_subcontract_moves
-        ):
-            return existing_backorder_picking
-        return super()._create_backorder_picking()

--- a/mrp_subcontracting_skip_no_negative/tests/test_mrp_subcontracting_skip_no_negative.py
+++ b/mrp_subcontracting_skip_no_negative/tests/test_mrp_subcontracting_skip_no_negative.py
@@ -129,3 +129,57 @@ class TestMrpSubcontractingSkipNoNegative(TestMrpSubcontractingCommon):
         self.assertIn(another_product, products)
         for move in self.subcontracting_receipt.move_ids:
             self.assertEqual(move.quantity_done, 1)
+
+    def test_mrp_subcontracting_with_normal_product_backorder(self):
+        """
+        Mixed receipt: validate only the subcontract move, request a backorder.
+        The normal move (qty_done=0) must be moved to a backorder picking.
+        """
+        another_product = self.env["product.product"].create(
+            {
+                "name": "Another Product",
+                "type": "product",
+            }
+        )
+        normal_move = self.env["stock.move"].create(
+            {
+                "picking_id": self.subcontracting_receipt.id,
+                "product_id": another_product.id,
+                "name": another_product.name,
+                "product_uom": another_product.uom_id.id,
+                "product_uom_qty": 1,
+                "location_id": self.subcontracting_receipt.location_id.id,
+                "location_dest_id": self.subcontracting_receipt.location_dest_id.id,
+            }
+        )
+        self._create_stock_quant(self.comp1, 10)
+        self._create_stock_quant(self.comp2, 10)
+        self.subcontracting_receipt.action_confirm()
+        self.assertEqual(self.subcontracting_receipt.state, "assigned")
+        # Only set qty_done on the subcontract move; leave the normal move at 0.
+        subcontract_move = self.subcontracting_receipt.move_ids.filtered(
+            lambda m: m.is_subcontract
+        )
+        subcontract_move.quantity_done = 1
+        backorder_wizard = self.subcontracting_receipt.sudo().button_validate()
+        self.assertEqual(
+            backorder_wizard.get("res_model"), "stock.backorder.confirmation"
+        )
+        backorder_wizard_form = Form(
+            self.env[backorder_wizard["res_model"]].with_context(
+                **backorder_wizard["context"]
+            )
+        ).save()
+        backorder_wizard_form.process()
+        # The subcontract move is done on the original picking.
+        self.assertEqual(subcontract_move.state, "done")
+        self.assertEqual(subcontract_move.quantity_done, 1)
+        # A backorder picking must have been created with the unprocessed
+        # normal move; it must no longer be on the original picking.
+        backorder = self.env["stock.picking"].search(
+            [("backorder_id", "=", self.subcontracting_receipt.id)]
+        )
+        self.assertTrue(backorder)
+        self.assertNotIn(normal_move, self.subcontracting_receipt.move_ids)
+        self.assertIn(normal_move, backorder.move_ids)
+        self.assertEqual(normal_move.product_uom_qty, 1)


### PR DESCRIPTION
With the current logic, we are calling separately _action_done on stock move for subcontracted moves and other moves.

In a scenario where we process the subcontracted move but not the other moves, _action_done is called for stock moves with no qty done. In the standard method, no moves are considered to be done (https://github.com/odoo/odoo/blob/19027e4986a469eee7a9781c444bbd2a1e7aaea5/addons/stock/models/stock_move.py#L1833) and consequently no picking is assigned to be backordered (https://github.com/odoo/odoo/blob/19027e4986a469eee7a9781c444bbd2a1e7aaea5/addons/stock/models/stock_move.py#L1867).

In simple words, Odoo will not trigger the backordering logic if all moves that enter _action_done have no qty done.

To fix it we must consolidate the call to _action_done including all moves. However, in order to keep the no negative check split evaluation, we do it in the stock move line _action_done as it is eventually called in the stock move method (https://github.com/odoo/odoo/blob/19027e4986a469eee7a9781c444bbd2a1e7aaea5/addons/stock/models/stock_move.py#L1857)

The fix that was added in https://github.com/OCA/manufacture/pull/1467 was not covering this problem.