### PR TITLE
[18.0][FIX] mrp_multi_level: make scheduling tests date-independent

### DIFF
--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -3,14 +3,27 @@
 
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
+
+# The scheduling assertions in these tests compare MRP inventory buckets against
+# dates computed with ``calendar.plan_days`` (working days). Whether a given
+# offset lands on a particular bucket depends on which weekday "today" is, so the
+# suite is not deterministic across run dates (e.g. it passes mid-week but fails
+# on Mondays). Freeze the whole suite to a fixed working day so both the setup
+# and the planning run see the same reference date.
+FREEZE_DATE = "2024-06-12"  # Wednesday
 
 
 class TestMrpMultiLevelCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        freezer = freeze_time(FREEZE_DATE)
+        freezer.start()
+        cls.addClassCleanup(freezer.stop)
         cls.mo_obj = cls.env["mrp.production"]
         cls.po_obj = cls.env["purchase.order"]
         cls.product_obj = cls.env["product.product"]


### PR DESCRIPTION
## Problem

`mrp_multi_level`'s scheduling tests (`TestMrpMultiLevel`) compute their expected
MRP inventory buckets with `calendar.plan_days(...)` (working days) anchored on
`datetime.today()`. Whether a given offset lands on the asserted bucket depends on
which weekday the suite runs on, so the suite is **not deterministic across run dates**.

This makes CI flap with the calendar:

- Green on Wed **2026-06-17**, red on Mon **2026-06-22** — with **no code change** in between.
- Failure: `test_04_mrp_multi_level` → `AssertionError: 0 != 1` (`len(fp_2_line_2)`), because a
  one-working-day shift moves the FP-2 supply out of the asserted `date_10` bucket.

The `18.0` branch has been red since 2026-06-22 for this reason, and it red-lights
unrelated PRs (the whole repo suite runs per PR).

## Fix

Freeze the shared test setup — and, via `addClassCleanup`, the test methods — to a fixed
working day (`2024-06-12`, a Wednesday), so `plan_days` math is deterministic regardless
of when CI runs. No production code is touched; this is a test-only change.

`freezegun` is already used in this repo (`mrp_stock_move_actual_date`).

## Test

`oca_run_tests` locally (via `act`) on `18.0`:
- Before: `1 failed, 0 error(s) of 218 tests` (`test_04_mrp_multi_level`).
- After: `0 failed, 0 error(s) of 218 tests` ✅
