### PR TITLE
[18.0][IMP] mrp_production_check_bom_alignment: detail misaligned items in warning

### DIFF
--- a/mrp_production_check_bom_alignment/models/mrp_production.py
+++ b/mrp_production_check_bom_alignment/models/mrp_production.py
@@ -82,9 +82,17 @@ class MrpProduction(models.Model):
             lambda m: m.state != "cancel" and m.bom_line_id
         )
         if bom_line_ids != set(active_moves.bom_line_id.ids):
+            products = (
+                bom.bom_line_ids.filtered(
+                    lambda bl: bl.id not in active_moves.bom_line_id.ids
+                ).product_id
+                | active_moves.filtered(
+                    lambda m: m.bom_line_id.id not in bom_line_ids
+                ).product_id
+            )
             return self.env._(
                 f"The components of MO {mo_name} are not aligned with the current "
-                f"BoM configuration."
+                f"BoM configuration: {', '.join(products.mapped('display_name'))}."
             )
         for move in active_moves:
             bom_line = move.bom_line_id
@@ -96,26 +104,29 @@ class MrpProduction(models.Model):
             ):
                 return self.env._(
                     f"The component quantities of MO {mo_name} are not aligned "
-                    f"with the current BoM configuration."
+                    f"with the current BoM configuration: "
+                    f"{move.product_id.display_name}."
                 )
         for move in active_moves:
             if move.operation_id != move.bom_line_id.operation_id:
                 return self.env._(
                     f"The 'Consumed in Operation' for components of MO {mo_name} "
-                    f"is not aligned with the current BoM configuration."
+                    f"is not aligned with the current BoM configuration: "
+                    f"{move.product_id.display_name}."
                 )
 
         # --- Operation checks ---
-        bom_operation_ids = set(bom.operation_ids.ids)
-        wo_operation_ids = set(
-            self.workorder_ids.filtered(
-                lambda w: w.state != "cancel" and w.operation_id
-            ).operation_id.ids
-        )
-        if bom_operation_ids != wo_operation_ids:
+        bom_operations = bom.operation_ids
+        wo_operations = self.workorder_ids.filtered(
+            lambda w: w.state != "cancel" and w.operation_id
+        ).operation_id
+        if set(bom_operations.ids) != set(wo_operations.ids):
+            diff_operations = (bom_operations | wo_operations) - (
+                bom_operations & wo_operations
+            )
             return self.env._(
                 f"The operations of MO {mo_name} are not aligned with the current "
-                f"BoM configuration."
+                f"BoM configuration: {', '.join(diff_operations.mapped('name'))}."
             )
 
         # --- By-product checks ---
@@ -123,9 +134,17 @@ class MrpProduction(models.Model):
             lambda m: m.state != "cancel" and m.byproduct_id
         )
         if set(bom.byproduct_ids.ids) != set(active_byproduct_moves.byproduct_id.ids):
+            products = (
+                bom.byproduct_ids.filtered(
+                    lambda bp: bp.id not in active_byproduct_moves.byproduct_id.ids
+                ).product_id
+                | active_byproduct_moves.filtered(
+                    lambda m: m.byproduct_id.id not in bom.byproduct_ids.ids
+                ).product_id
+            )
             return self.env._(
                 f"The by-products of MO {mo_name} are not aligned with the current "
-                f"BoM configuration."
+                f"BoM configuration: {', '.join(products.mapped('display_name'))}."
             )
         for move in active_byproduct_moves:
             byproduct = move.byproduct_id
@@ -137,13 +156,15 @@ class MrpProduction(models.Model):
             ):
                 return self.env._(
                     f"The by-product quantities of MO {mo_name} are not aligned "
-                    f"with the current BoM configuration."
+                    f"with the current BoM configuration: "
+                    f"{move.product_id.display_name}."
                 )
         for move in active_byproduct_moves:
             if move.operation_id != move.byproduct_id.operation_id:
                 return self.env._(
                     f"The 'Produced in Operation' for by-products of MO {mo_name} "
-                    f"is not aligned with the current BoM configuration."
+                    f"is not aligned with the current BoM configuration: "
+                    f"{move.product_id.display_name}."
                 )
 
         return False

--- a/mrp_production_check_bom_alignment/tests/test_mrp_production_check_bom_alignment.py
+++ b/mrp_production_check_bom_alignment/tests/test_mrp_production_check_bom_alignment.py
@@ -105,7 +105,9 @@ class TestMrpProductionCheckBomAlignment(TransactionCase):
             Command.create({"product_id": self.component_3.id, "product_qty": 1.0})
         ]
         self.assertTrue(mo.is_outdated_bom)
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.component_3.display_name, error)
 
     def test_bom_operation_added_returns_error(self):
         mo = self._create_mo()
@@ -116,17 +118,23 @@ class TestMrpProductionCheckBomAlignment(TransactionCase):
                 "bom_id": self.test_bom.id,
             }
         )
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn("Extra Operation", error)
 
     def test_component_qty_changed_returns_error(self):
         mo = self._create_mo()
         self.bom_line_1.product_qty += 1.0
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.component_1.display_name, error)
 
     def test_consumed_at_operation_changed_returns_error(self):
         mo = self._create_mo()
         self.bom_line_1.operation_id = self.operation_2
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.component_1.display_name, error)
 
     def test_action_confirm_aligned_confirms_mo(self):
         mo = self.env["mrp.production"].create(
@@ -191,17 +199,23 @@ class TestMrpProductionCheckBomAlignment(TransactionCase):
                 }
             )
         ]
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.byproduct_product_2.display_name, error)
 
     def test_byproduct_qty_changed_returns_error(self):
         mo = self._create_mo()
         self.bom_byproduct.product_qty += 1.0
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.byproduct_product.display_name, error)
 
     def test_produced_at_operation_changed_returns_error(self):
         mo = self._create_mo()
         self.bom_byproduct.operation_id = self.operation_2
-        self.assertTrue(mo._get_bom_alignment_error(mo.name))
+        error = mo._get_bom_alignment_error(mo.name)
+        self.assertTrue(error)
+        self.assertIn(self.byproduct_product.display_name, error)
 
     def test_action_update_and_confirm(self):
         mo = self.env["mrp.production"].create(


### PR DESCRIPTION
The BoM alignment warnings only stated that the MO was not aligned with its BoM, without saying which items were off, forcing the user to compare the MO against the BoM by hand. Now the message adds which component is not aligned