### PR TITLE
[19.0][FIX] mrp_multi_level: make scheduling tests date-independent

### DIFF
--- a/mrp_multi_level/tests/common.py
+++ b/mrp_multi_level/tests/common.py
@@ -3,14 +3,27 @@
 
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
+
+# The scheduling assertions in these tests compare MRP inventory buckets against
+# dates computed with ``calendar.plan_days`` (working days). Whether a given
+# offset lands on a particular bucket depends on which weekday "today" is, so the
+# suite is not deterministic across run dates (e.g. it passes mid-week but fails
+# on Mondays). Freeze the whole suite to a fixed working day so both the setup
+# and the planning run see the same reference date.
+FREEZE_DATE = "2024-06-12"  # Wednesday
 
 
 class TestMrpMultiLevelCommon(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        freezer = freeze_time(FREEZE_DATE)
+        freezer.start()
+        cls.addClassCleanup(freezer.stop)
         cls.mo_obj = cls.env["mrp.production"]
         cls.po_obj = cls.env["purchase.order"]
         cls.product_obj = cls.env["product.product"]


### PR DESCRIPTION
Forward port of #1817 to 19.0, as requested by @LoisRForgeFlow.

## Problem

`mrp_multi_level`'s scheduling tests compute expected MRP inventory buckets with
`calendar.plan_days(...)` (working days) anchored on `datetime.today()`, so whether an
offset lands on the asserted bucket depends on which weekday the suite runs on — the tests
are not deterministic across run dates (green mid-week, red on Mondays), and only when the
full addons set is installed together (as CI does).

## Fix

Freeze the shared `TestMrpMultiLevelCommon.setUpClass` — and, via `addClassCleanup`, the test
methods — to a fixed working day (`2024-06-12`, a Wednesday), so `plan_days` math is
deterministic. Test-only; no production code touched. `freezegun` is already used in this repo.

> Note: the explicit `freezer.start()` after `super().setUpClass()` + `addClassCleanup(freezer.stop)`
> is deliberate rather than the `@freeze_time` class decorator — the decorator freezes time around
> `TransactionCase`'s cursor/savepoint setup+teardown, which leaves a lock on `mrp_production` and
> makes the next module install (`ALTER TABLE mrp_production ...`) fail with a lock timeout. See the
> discussion on #1817.

## Test

`oca_run_tests` locally (via `act`) on 19.0: `mrp_multi_level: 27 tests`, `0 failed, 0 error(s) of 74 tests`. ✅
