### PR TITLE
[14.0][FIX] mrp_bom_attribute_match: use sudo to reset product on bom line

### DIFF
--- a/mrp_bom_attribute_match/models/mrp_production.py
+++ b/mrp_bom_attribute_match/models/mrp_production.py
@@ -9,7 +9,7 @@ class MrpProduction(models.Model):
         for bom_line in self.bom_id.bom_line_ids:
             if bom_line.component_template_id:
                 # product_id was set in mrp.bom.explode for correct flow. Need to remove it.
-                bom_line.product_id = False
+                bom_line.sudo().write({"product_id": False})
         return res
 
     @api.constrains("bom_id")


### PR DESCRIPTION
Use sudo() to reset product_id on mrp.bom.line, as group_mrp_user only has read access on this model