### PR TITLE
[18.0][FIX] stock_whole_kit_constraint: remove dead code with deprecated qty_done

### DIFF
--- a/stock_whole_kit_constraint/models/stock_move.py
+++ b/stock_whole_kit_constraint/models/stock_move.py
@@ -36,17 +36,4 @@ class StockMove(models.Model):
             quantity_done.setdefault(move.product_id.id, 0)
             quantity_todo[move.product_id.id] += move.product_uom_qty
             quantity_done[move.product_id.id] += move.quantity
-        for ops in self.mapped("move_line_ids").filtered(
-            lambda x: x.package_id and not x.product_id and not x.move_id
-        ):
-            for quant in ops.package_id.quant_ids:
-                quantity_done.setdefault(quant.product_id.id, 0)
-                quantity_done[quant.product_id.id] += quant.qty
-        for pack in self.mapped("move_line_ids").filtered(
-            lambda x: x.product_id and not x.move_id
-        ):
-            quantity_done.setdefault(pack.product_id.id, 0)
-            quantity_done[pack.product_id.id] += pack.product_uom_id._compute_quantity(
-                pack.qty_done, pack.product_id.uom_id
-            )
         return any(quantity_done[x] < quantity_todo.get(x, 0) for x in quantity_done)


### PR DESCRIPTION
The `_check_backorder_moves` method in stock_whole_kit_constraint contained two unreachable loops iterating over move_line_ids filtered with `move_id=False`. Since move_line_ids is a One2many inverse field, it never returns lines without a parent move — making both loops dead code.

The second loop also referenced `pack.qty_done` on `stock.move.line`, a field removed in Odoo 17 (replaced by `stock.move.line.quantity`). Removing the dead code eliminates this deprecated field reference.

The method's remaining logic (computing quantity_todo and quantity_done from move.product_uom_qty and move.quantity) is functionally intact.

Reference: OCA OpenUpgrade 17.0 upgrade_analysis.txt for stock module.

@BinhexTeam T23802