### PR TITLE
[15.0][FIX] mrp_2_steps_consumed_qty_sync: keep pending demand on pick backorder

### DIFF
--- a/mrp_2_steps_consumed_qty_sync/models/stock_picking.py
+++ b/mrp_2_steps_consumed_qty_sync/models/stock_picking.py
@@ -18,12 +18,14 @@ class StockPicking(models.Model):
                 )
                 # Update the component initial demand in production order and assign
                 # the moves to cover cases like pick more quantities than expected.
-                # In this cases the quantity done is not propagated to linked move
+                # In this cases the quantity done is not propagated to linked move.
+                # Pending origin moves (e.g. backorders) must keep their demand in
+                # the production order, so count them by their initial demand.
                 for move in productions.move_raw_ids:
                     move.product_uom_qty = sum(
-                        move.move_orig_ids.filtered(
-                            lambda sm: sm.state == "done"
-                        ).mapped("quantity_done")
+                        sm.quantity_done if sm.state == "done" else sm.product_uom_qty
+                        for sm in move.move_orig_ids
+                        if sm.state != "cancel"
                     )
                 productions.move_raw_ids._action_assign()
                 productions.move_raw_ids._set_quantities_to_reservation()

--- a/mrp_2_steps_consumed_qty_sync/tests/test_mrp_2_steps_consumed_qty_sync.py
+++ b/mrp_2_steps_consumed_qty_sync/tests/test_mrp_2_steps_consumed_qty_sync.py
@@ -24,7 +24,7 @@ class TestMrp2StepsConsumedQtySync(TestMrpCommon):
         with Form(cls.warehouse) as warehouse:
             warehouse.manufacture_steps = "pbm"
 
-    def _add_product_stock(self, product, qty=50.0):
+    def _add_product_stock(self, product, qty=50.0, location=None):
         return (
             self.env["stock.quant"]
             .with_context(inventory_mode=True)
@@ -32,7 +32,7 @@ class TestMrp2StepsConsumedQtySync(TestMrpCommon):
                 {
                     "product_id": product.id,
                     "quantity": qty,
-                    "location_id": self.warehouse.lot_stock_id.id,
+                    "location_id": (location or self.warehouse.lot_stock_id).id,
                 }
             )
         )
@@ -80,3 +80,41 @@ class TestMrp2StepsConsumedQtySync(TestMrpCommon):
             ).quantity_done,
             15.0,
         )
+
+    def test_pick_backorder_keeps_pending_component_demand(self):
+        with Form(self.warehouse) as warehouse:
+            warehouse.reception_steps = "two_steps"
+        # MO with two components: 50 uds of product_pending and 40 of
+        # product_on_hand, which is the only one available in stock
+        (production, _, _, product_pending, product_on_hand,) = self.generate_mo(
+            qty_final=10,
+            qty_base_1=5,
+            qty_base_2=4,
+            picking_type_id=self.warehouse.manu_type_id,
+        )
+        self._add_product_stock(product_on_hand)
+        # product_pending is received but pending the second reception step,
+        # so its goods are on input location and claimed by the MO
+        self._add_product_stock(
+            product_pending, location=self.warehouse.wh_input_stock_loc_id
+        )
+        self.assertEqual(product_pending.virtual_available, 0.0)
+        # Prepare only the component on hand and validate creating a backorder
+        pick_picking = production.picking_ids
+        pick_picking.action_assign()
+        for line in pick_picking.move_line_ids:
+            line.qty_done = line.product_uom_qty
+        pick_picking._action_done()
+        # The backorder holds the pending component, the MO keeps its demand
+        # and the incoming goods are not exposed to sales
+        backorder = self.env["stock.picking"].search(
+            [("backorder_id", "=", pick_picking.id)]
+        )
+        self.assertEqual(backorder.move_lines.product_id, product_pending)
+        self.assertEqual(
+            production.move_raw_ids.filtered(
+                lambda sm: sm.product_id == product_pending
+            ).product_uom_qty,
+            50.0,
+        )
+        self.assertEqual(product_pending.virtual_available, 0.0)


### PR DESCRIPTION
Validating the pick with a backorder dropped the demand of the not picked components to 0 in the production order because only done origin moves were counted. As a result, the incoming goods were released in the forecast and exposed to sales until the backorder was validated. The fix is to count pending origin moves using their initial demand.

@tecnativa TT63969
@sergio-teruel @CarlosRoca13 