### PR TITLE
[18.0][FIX] mrp_production_picking_type_from_route: keep op type once confirmed

### DIFF
--- a/mrp_production_picking_type_from_route/models/mrp_production.py
+++ b/mrp_production_picking_type_from_route/models/mrp_production.py
@@ -11,6 +11,11 @@ class MrpProduction(models.Model):
     def _compute_picking_type_id(self):
         res = super()._compute_picking_type_id()
         for mo in self:
+            # Transfers and reservations already exist once the MO is confirmed,
+            # so its operation type must not be repointed. A falsy state is a
+            # record still being created (the field is precomputed).
+            if mo.state and mo.state != "draft":
+                continue
             if mo.product_id:
                 base_domain = [
                     ("action", "=", "manufacture"),

--- a/mrp_production_picking_type_from_route/tests/test_mrp_production_picking_type_from_route.py
+++ b/mrp_production_picking_type_from_route/tests/test_mrp_production_picking_type_from_route.py
@@ -79,3 +79,59 @@ class MrpProductionCase(TransactionCase):
         new_mo.save()
         # Kept after save:
         self.assertEqual(new_mo.picking_type_id, self.standard_manuf_op_type)
+
+    def test_03_confirmed_mo_keeps_its_op_type(self):
+        component = self.product_model.create({"name": "Component"})
+        bom = self.bom_model.create(
+            {
+                "product_tmpl_id": self.product_1.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "bom_line_ids": [
+                    (0, 0, {"product_id": component.id, "product_qty": 1})
+                ],
+            }
+        )
+        mo_form = Form(self.env["mrp.production"])
+        mo_form.product_id = self.product_1
+        mo = mo_form.save()
+        self.assertEqual(mo.picking_type_id, self.standard_manuf_op_type)
+        mo.action_confirm()
+        self.assertEqual(mo.state, "confirmed")
+        # The product is reconfigured to resolve the secondary manufacture rule.
+        self.product_1.route_ids = [(6, 0, self.secondary_manuf_route.ids)]
+        # Updating the BoM rewrites bom_id, which this compute depends on. The
+        # operation type and the component location of a confirmed MO must not
+        # follow the new rule: its transfers and reservations already exist.
+        self.assertEqual(mo.bom_id, bom)
+        mo.action_update_bom()
+        self.assertEqual(mo.picking_type_id, self.standard_manuf_op_type)
+        self.assertEqual(
+            mo.location_src_id, self.standard_manuf_op_type.default_location_src_id
+        )
+        self.assertEqual(
+            mo.move_raw_ids.location_id,
+            self.standard_manuf_op_type.default_location_src_id,
+        )
+
+    def test_04_draft_mo_still_follows_the_route(self):
+        component = self.product_model.create({"name": "Component"})
+        self.bom_model.create(
+            {
+                "product_tmpl_id": self.product_1.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "bom_line_ids": [
+                    (0, 0, {"product_id": component.id, "product_qty": 1})
+                ],
+            }
+        )
+        mo_form = Form(self.env["mrp.production"])
+        mo_form.product_id = self.product_1
+        mo = mo_form.save()
+        self.assertEqual(mo.state, "draft")
+        self.assertEqual(mo.picking_type_id, self.standard_manuf_op_type)
+        # Same trigger as the confirmed case, but the MO is still a draft, so the
+        # operation type is expected to follow the new rule.
+        self.product_1.route_ids = [(6, 0, self.secondary_manuf_route.ids)]
+        mo.action_update_bom()
+        self.assertEqual(mo.picking_type_id, self.op_type_2)
+        self.assertEqual(mo.location_src_id, self.source_loc_2)


### PR DESCRIPTION
The compute reassigned the operation type whenever `bom_id` changed, so Update BoM on a confirmed MO repointed it and its component locations while the transfers and reservations already created stayed on the old ones.