### PR TITLE
[17.0][FIX] mrp_production_serial_matrix: keep component reservations sane

### DIFF
--- a/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
@@ -432,28 +432,50 @@ class MrpProductionSerialMatrix(models.Model):
         to_remove = lots_current - lots_desired
         if to_remove:
             current_lines.filtered(lambda ml: ml.lot_id in to_remove).unlink()
-        to_add = lots_desired - lots_current
-        for lot in to_add:
-            if move.product_id.tracking == "serial":
-                qty_needed = 1.0
-            else:
-                qty_needed = sum(matrix_lines.mapped("lot_qty"))
-            self._reserve_lot_in_move(move, lot, qty=qty_needed)
-        return True
-
-    def _consume_selected_lots(self, move, matrix_lines):
-        lots_in_matrix = matrix_lines.mapped("component_lot_id")
-        precision = self.env["decimal.precision"].precision_get(
+        precision_digits = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
+        for lot in lots_desired:
+            qty_needed = self._get_lot_qty_needed(move, matrix_lines, lot)
+            qty_on_lines = sum(
+                move.move_line_ids.filtered(
+                    lambda ml, lot=lot: ml.lot_id == lot
+                ).mapped("quantity_product_uom")
+            )
+            missing_qty = qty_needed - qty_on_lines
+            if float_compare(missing_qty, 0.0, precision_digits=precision_digits) > 0:
+                self._reserve_lot_in_move(move, lot, qty=missing_qty)
+        return True
+
+    def _get_lot_qty_needed(self, move, matrix_lines, lot):
+        if move.product_id.tracking == "serial":
+            return 1.0
+        return sum(
+            matrix_lines.filtered(
+                lambda line, lot=lot: line.component_lot_id == lot
+            ).mapped("lot_qty")
+        )
+
+    def _consume_selected_lots(self, move, matrix_lines):
+        """Consume the lots selected in the matrix, and only those.
+
+        ``_amend_reservations`` has already put the quantity the BoM needs on
+        the selected lots, so any other line of the move is a surplus and is
+        dropped. Keeping it consumed more than the BoM asks for, and a surplus
+        line carrying no lot made Odoo consume a tracked component as untracked
+        stock.
+        """
+        lots_in_matrix = matrix_lines.mapped("component_lot_id")
+        if not lots_in_matrix:
+            move.move_line_ids.picked = True
+            return
+        to_drop = self.env["stock.move.line"]
         for ml in move.move_line_ids:
             if ml.lot_id in lots_in_matrix:
                 ml.picked = True
-            elif float_is_zero(ml.quantity, precision_digits=precision):
-                ml.unlink()
             else:
-                ml.lot_id = lots_in_matrix[0] if len(lots_in_matrix) > 1 else False
-                ml.picked = True
+                to_drop |= ml
+        to_drop.unlink()
 
     def _reserve_lot_in_move(self, move, lot, qty):
         precision_digits = self.env["decimal.precision"].precision_get(
@@ -465,15 +487,38 @@ class MrpProductionSerialMatrix(models.Model):
             lot_id=lot,
         )
         if (
-            float_compare(available_quantity, 0.0, precision_digits=precision_digits)
-            <= 0
+            float_compare(available_quantity, qty, precision_digits=precision_digits)
+            < 0
         ):
             raise ValidationError(
-                _("Serial/Lot number '%s' not available at source location.") % lot.name
+                _(
+                    "Serial/Lot number '%(lot)s' is not available at %(location)s in "
+                    "the quantity needed (%(available)s available, %(needed)s needed)."
+                )
+                % {
+                    "lot": lot.name,
+                    "location": move.location_id.complete_name,
+                    "available": available_quantity,
+                    "needed": qty,
+                }
             )
-        move._update_reserved_quantity(
+        taken_quantity = move._update_reserved_quantity(
             qty,
             move.location_id,
             lot_id=lot,
             strict=True,
         )
+        if float_compare(taken_quantity, qty, precision_digits=precision_digits) < 0:
+            raise ValidationError(
+                _(
+                    "Only %(taken)s units of serial/lot number '%(lot)s' could be "
+                    "reserved at %(location)s out of the %(needed)s needed."
+                )
+                % {
+                    "taken": taken_quantity,
+                    "lot": lot.name,
+                    "location": move.location_id.complete_name,
+                    "needed": qty,
+                }
+            )
+        return taken_quantity

--- a/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/models/mrp_production_serial_matrix.py
@@ -355,17 +355,26 @@ class MrpProductionSerialMatrix(models.Model):
             self._set_matrix_done()
             return mos
         try:
-            self._prepare_mo_for_serial(current_mo, fp_lot)
-            self._process_component_moves(current_mo, fp_lot, matrix_map)
-            mos += current_mo
-            current_mo = self._validate_and_get_backorder(current_mo)
-            if current_mo:
-                return self.call_next_process_serial_matrix_lot(
-                    mos, lots_to_process=lots_to_process - fp_lot, current_mo=current_mo
-                )
-            self._set_matrix_done()
+            # One savepoint per finished serial number. The errors raised while
+            # validating an MO reach us from a flush, so catching them without
+            # rolling back leaves the transaction with the stock changes already
+            # applied: writing the exception on the matrix flushes again and
+            # commits them, including the ones a constraint had just rejected.
+            # Recursing outside the savepoint keeps the serial numbers that were
+            # processed successfully.
+            with self.env.cr.savepoint():
+                self._prepare_mo_for_serial(current_mo, fp_lot)
+                self._process_component_moves(current_mo, fp_lot, matrix_map)
+                next_mo = self._validate_and_get_backorder(current_mo)
         except UserError as e:
             self._set_matrix_exception(str(e))
+            return mos
+        mos += current_mo
+        if next_mo:
+            return self.call_next_process_serial_matrix_lot(
+                mos, lots_to_process=lots_to_process - fp_lot, current_mo=next_mo
+            )
+        self._set_matrix_done()
         return mos
 
     def _set_matrix_done(self):

--- a/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
@@ -1,7 +1,7 @@
 # Copyright 2021-24 ForgeFlow S.L. (http://www.forgeflow.com)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -590,3 +590,112 @@ class TestMrpProductionSerialMatrix(TransactionCase):
         production.state = "done"
         with self.assertRaises(UserError):
             matrix.action_reset_to_draft()
+
+    def test_12_reserve_lot_in_move_requires_the_needed_qty(self):
+        """A lot that cannot cover the needed quantity is refused instead of
+        being partially reserved and consumed short."""
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create({"production_id": production.id})
+        short_lot = self._create_serial_number(self.component_3_lot, "3-SHORT", qty=1.0)
+        move = production.move_raw_ids.filtered(
+            lambda m: m.product_id == self.component_3_lot
+        )
+        with self.assertRaises(ValidationError):
+            matrix._reserve_lot_in_move(move, short_lot, qty=4.0)
+        self.assertFalse(move.move_line_ids.filtered(lambda ml: ml.lot_id == short_lot))
+
+    def test_13_no_component_line_is_left_without_a_lot(self):
+        """When a selected lot cannot cover the whole need, the run must stop.
+
+        It used to go on and leave a surplus line with no lot on a lot-tracked
+        component, which Odoo then consumed as untracked stock.
+        """
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp = self._create_serial_number(self.final_product, "FP-SHORT", qty=0)
+        matrix.finished_lot_ids = serial_fp
+        matrix._onchange_finished_lot_ids()
+        # 3-002 holds 8 units, but only 2 of them are free here, while the BoM
+        # needs 4 of the component per finished unit.
+        short_lot = self._create_serial_number(self.component_3_lot, "3-PART", qty=2.0)
+        c3_line = matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_3_lot
+        )
+        c3_line.component_lot_id = short_lot
+        move = production.move_raw_ids.filtered(
+            lambda m: m.product_id == self.component_3_lot
+        )
+        with self.assertRaises(ValidationError):
+            matrix._amend_reservations(move, c3_line)
+        self.assertFalse(
+            move.move_line_ids.filtered(lambda ml: not ml.lot_id),
+            "a lot-tracked component must never carry a line without a lot",
+        )
+
+    def test_14_only_the_selected_lots_are_consumed(self):
+        """Lines on lots the operator did not select are dropped, not consumed:
+        never as untracked stock, and never above what the BoM asks for."""
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp = self._create_serial_number(self.final_product, "FP-LEFT", qty=0)
+        matrix.finished_lot_ids = serial_fp
+        matrix._onchange_finished_lot_ids()
+        c3_line = matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_3_lot
+        )
+        c3_line.component_lot_id = self.lot_3_003
+        move = production.move_raw_ids.filtered(
+            lambda m: m.product_id == self.component_3_lot
+        )
+        self.assertTrue(move.move_line_ids)
+        self.assertNotEqual(move.move_line_ids.lot_id, self.lot_3_003)
+        matrix._amend_reservations(move, c3_line)
+        matrix._consume_selected_lots(move, c3_line)
+        self.assertEqual(move.move_line_ids.mapped("lot_id"), self.lot_3_003)
+        self.assertEqual(sum(move.move_line_ids.mapped("quantity")), 4.0)
+        self.assertTrue(all(move.move_line_ids.mapped("picked")))
+
+    def test_15_reservations_match_the_move_lines(self):
+        """After the matrix has set the lots, every quant it touched must hold
+        exactly what the move lines say is reserved on it."""
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp = self._create_serial_number(self.final_product, "FP-INV", qty=0)
+        matrix.finished_lot_ids = serial_fp
+        matrix._onchange_finished_lot_ids()
+        c3_line = matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_3_lot
+        )
+        c3_line.component_lot_id = self.lot_3_002
+        move = production.move_raw_ids.filtered(
+            lambda m: m.product_id == self.component_3_lot
+        )
+        matrix._amend_reservations(move, c3_line)
+        matrix._consume_selected_lots(move, c3_line)
+        for lot in (self.lot_3_001, self.lot_3_002, self.lot_3_003, False):
+            quants = self.quant_obj.search(
+                [
+                    ("product_id", "=", self.component_3_lot.id),
+                    ("location_id", "=", self.stock_loc.id),
+                    ("lot_id", "=", lot and lot.id),
+                ]
+            )
+            lines = self.move_line_obj.search(
+                [
+                    ("product_id", "=", self.component_3_lot.id),
+                    ("location_id", "=", self.stock_loc.id),
+                    ("lot_id", "=", lot and lot.id),
+                    ("state", "not in", ("done", "cancel")),
+                ]
+            )
+            self.assertAlmostEqual(
+                sum(quants.mapped("reserved_quantity")),
+                sum(lines.mapped("quantity_product_uom")),
+                msg="reservation out of sync for lot %s" % (lot and lot.name or "-"),
+            )

--- a/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
+++ b/mrp_production_serial_matrix/tests/test_mrp_production_serial_matrix.py
@@ -1,6 +1,8 @@
 # Copyright 2021-24 ForgeFlow S.L. (http://www.forgeflow.com)
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from unittest.mock import patch
+
 from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
@@ -155,6 +157,16 @@ class TestMrpProductionSerialMatrix(TransactionCase):
         production_1.action_confirm()
         production_1.action_assign()
         return production_1
+
+    @classmethod
+    def _get_quant(cls, product, lot):
+        return cls.quant_obj.search(
+            [
+                ("product_id", "=", product.id),
+                ("location_id", "=", cls.stock_loc.id),
+                ("lot_id", "=", lot.id),
+            ]
+        )
 
     @classmethod
     def _find_move_lines(cls, mo, component):
@@ -699,3 +711,49 @@ class TestMrpProductionSerialMatrix(TransactionCase):
                 sum(lines.mapped("quantity_product_uom")),
                 msg="reservation out of sync for lot %s" % (lot and lot.name or "-"),
             )
+
+    def test_16_a_failed_serial_rolls_back_its_own_stock_changes(self):
+        """A serial number that fails must leave no stock change behind.
+
+        The errors raised while validating come from a flush. Catching them
+        without rolling back used to leave the transaction with the stock
+        changes already applied, and writing the exception on the matrix
+        committed them - including quantities a constraint had just rejected.
+        """
+        production = self._create_mo(1.0)
+        matrix = self.matrix_obj.create(
+            {"production_id": production.id, "include_lots": True}
+        )
+        serial_fp = self._create_serial_number(self.final_product, "FP-ROLL", qty=0)
+        matrix.finished_lot_ids = serial_fp
+        matrix._onchange_finished_lot_ids()
+        matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_3_lot
+        ).component_lot_id = self.lot_3_002
+        matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_1_serial
+        ).component_lot_id = self.serial_1_001
+        c2_lines = matrix.line_ids.filtered(
+            lambda line: line.component_id == self.component_2_serial
+        )
+        c2_lines[0].component_lot_id = self.serial_2_001
+        c2_lines[1].component_lot_id = self.serial_2_002
+
+        quant = self._get_quant(self.component_3_lot, self.lot_3_002)
+        before = (quant.quantity, quant.reserved_quantity)
+
+        with patch.object(
+            type(matrix),
+            "_validate_and_get_backorder",
+            side_effect=UserError("validation blew up"),
+        ):
+            matrix.state = "in_progress"
+            matrix._process_serial_matrix()
+
+        self.assertEqual(matrix.state, "exception")
+        self.assertEqual(
+            (quant.quantity, quant.reserved_quantity),
+            before,
+            "the failed serial number left stock changes behind",
+        )
+        self.assertGreaterEqual(quant.reserved_quantity, 0.0)


### PR DESCRIPTION
Two fixes for the stock the matrix left behind.

**A failed serial number was committed.** The errors raised while validating an MO reach the matrix from a flush, so `except UserError` caught them with the stock changes already applied and no rollback; writing the exception state and posting it to the chatter flushed again and committed them. `ValidationError` derives from `UserError`, so negative stock constraints were caught this way too: the operation was reported as an error and persisted at the same time, and the next serial number started from the already negative quantity. Each serial number now runs inside its own savepoint, with the recursion outside it so the ones that succeeded are kept.

Seen in the field with `stock_no_negative` installed: a component lot walked down to -4, -6, -8, -10, -12, -14 over six consecutive failed validations, each one recorded in the chatter and committed.

**Surplus component lines were consumed.** `_reserve_lot_in_move` accepted any availability above zero and ignored what it actually managed to reserve; a selected lot already on the move but short of the needed quantity was never topped up; and a leftover line had its lot cleared, which made Odoo consume a lot-tracked component as untracked stock. The needed quantity is now required and verified, the shortfall is reserved per lot, and any line not on a selected lot is dropped instead of consumed.