### PR TITLE
[18.0][IMP] mrp_production_date_planned_finished: cover the security lead time with a test

### DIFF
--- a/mrp_production_date_planned_finished/models/mrp_production.py
+++ b/mrp_production_date_planned_finished/models/mrp_production.py
@@ -11,6 +11,14 @@ class MrpProduction(models.Model):
     _inherit = "mrp.production"
 
     def _get_date_start_using_delays(self):
+        # This has to stay the exact inverse of core's `_compute_date_finished`,
+        # which is a stored compute depending on `date_start`: anything else
+        # subtracted here is undone right away by that recompute, and the order
+        # ends up finishing before the date the user asked for. In particular
+        # `company_id.manufacturing_lead` must NOT be subtracted (it was until
+        # v15, when core still added it on the way forward): the security lead
+        # time only applies to procurement now, through
+        # `stock_rule._get_lead_days`, and is not part of the order duration.
         date_start = self.date_finished
         date_start -= relativedelta(days=self.bom_id.produce_delay)
         return date_start

--- a/mrp_production_date_planned_finished/readme/CONTRIBUTORS.md
+++ b/mrp_production_date_planned_finished/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
   - Iván Todorovich \<<ivan.todorovich@camptocamp.com>\>
 - [Tecnativa](https://www.tecnativa.com):
   - Juan Carlos Oñate \<<juancarlos.onate@tecnativa.com>\>
+  - Carlos Dauden

--- a/mrp_production_date_planned_finished/readme/USAGE.md
+++ b/mrp_production_date_planned_finished/readme/USAGE.md
@@ -7,3 +7,9 @@
 4.  The *Scheduled Date* (start) is automatically set to *Scheduled End*
     minus the BoM's *Manuf. Lead Time*, and the dates of the raw
     material moves are updated accordingly.
+
+The company's *Security Lead Time* (*Manufacturing \> Configuration \>
+Settings \> Planning*) is deliberately not taken into account here: it
+is a replenishment setting, applied when a reordering rule schedules a
+manufacturing order, and subtracting it as well would make the order
+finish before the *Scheduled End* you asked for.

--- a/mrp_production_date_planned_finished/tests/test_date_planned_finished.py
+++ b/mrp_production_date_planned_finished/tests/test_date_planned_finished.py
@@ -43,6 +43,37 @@ class TestDateFinished(BaseCommon):
         self.assertEqual(mo.date_start, Datetime.to_datetime("2026-10-08 10:00:00"))
         self.assertEqual(mo.date_finished, Datetime.to_datetime("2026-10-10 10:00:00"))
 
+    def test_mrp_production_date_finished_security_lead_not_applied(self):
+        """The company security lead time must not shift the requested end date.
+
+        Until v15 the module also subtracted ``company_id.manufacturing_lead``,
+        mirroring core, which added it when computing the end date from the
+        start one. Since v16 the end date is instead a stored compute
+        (``_compute_date_finished``) that only adds ``bom_id.produce_delay``,
+        so subtracting the security lead here is immediately undone: core
+        recomputes ``date_finished`` from the new ``date_start`` and the order
+        ends ``manufacturing_lead`` days before the date the user typed. The
+        security lead only applies to procurement now
+        (``stock_rule._get_lead_days``), so it must stay out of this onchange.
+        """
+        self.env.company.manufacturing_lead = 5
+        mo_form = Form(self.env["mrp.production"])
+        mo_form.product_id = self.product
+        mo_form.bom_id = self.bom
+        mo_form.product_qty = 1
+        mo_form.date_finished = Datetime.to_datetime("2026-10-10 10:00:00")
+        mo = mo_form.save()
+        self.assertEqual(
+            mo.date_finished,
+            Datetime.to_datetime("2026-10-10 10:00:00"),
+            "The requested end date must be kept as typed",
+        )
+        self.assertEqual(
+            mo.date_start,
+            Datetime.to_datetime("2026-10-08 10:00:00"),
+            "Only the BoM lead time must be subtracted from the end date",
+        )
+
     def test_mrp_production_date_finished_decoration(self):
         """date_finished decorations must mirror date_start ones.
 


### PR DESCRIPTION
Until v15 the onchange that back-computes the start date from the manually edited end date also subtracted `company_id.manufacturing_lead`, mirroring core, which added that security lead when computing the end date from the start one. Since v16 the end date is a stored compute that only adds the BoM manufacturing lead time, so dropping that subtraction on the way to 18.0 was right: putting it back makes core recompute the end date from the newly shifted start date, and the order ends `manufacturing_lead` days before the date the user asked for, which is precisely what this module exists to avoid. Reproduced on 18.0 with a security lead time of 5 days and a BoM lead time of 2 days: a requested end date of 2026-10-10 10:00 comes back as 2026-10-05 10:00.

No behaviour changes here. This only adds the regression test that was missing, since no existing test configured a non-zero security lead time and the question was therefore untested, plus a comment on the method and a note in the usage documentation explaining why the company security lead time is deliberately left out.

@Tecnativa
ping @sergio-teruel @juancarlosonate-tecnativa @CarlosRoca13 